### PR TITLE
Handle all outstanding issues

### DIFF
--- a/test/benchmark/readPdf.bench.ts
+++ b/test/benchmark/readPdf.bench.ts
@@ -1,5 +1,5 @@
 import { describe, bench, vi as _vi } from 'vitest'; // Prefix unused import
-import { handleReadPdfFunc } from '../../src/handlers/readPdf'; // Adjust path as needed
+import { handleReadPdfFunc } from '../../src/handlers/readPdf.js'; // Adjust path as needed
 import path from 'node:path';
 import fs from 'node:fs/promises';
 


### PR DESCRIPTION
Fix malformed nested test, correct ESM import path, and update error message for URL load failures.

The URL load failure test in `test/handlers/readPdf.test.ts` was incorrectly nested within another `expect.fail` block, preventing it from running. This PR moves it to the top level and updates the expected error message to include the URL for clarity. Additionally, the import path in `test/benchmark/readPdf.bench.ts` was updated to include the `.js` extension for ESM consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-007167f2-3cab-45a3-b4c3-da7bd0895dc7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-007167f2-3cab-45a3-b4c3-da7bd0895dc7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

