### PR TITLE
fix: remove wildcard CORS default in HTTP transport (CWE-942)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -944,12 +944,13 @@ var transportType = process.env["MCP_TRANSPORT"] ?? "stdio";
 var httpPort = Number.parseInt(process.env["MCP_HTTP_PORT"] ?? "8080", 10);
 var httpHost = process.env["MCP_HTTP_HOST"] ?? "0.0.0.0";
 var apiKey = process.env["MCP_API_KEY"];
+var corsOrigin = process.env["MCP_CORS_ORIGIN"];
 function createTransport() {
   if (transportType === "http") {
     return http({
       port: httpPort,
       hostname: httpHost,
-      cors: "*"
+      ...corsOrigin ? { cors: corsOrigin } : {}
     });
   }
   return stdio();
@@ -968,6 +969,9 @@ async function main() {
     console.log(`[PDF Reader MCP] Health check: http://${httpHost}:${httpPort}/mcp/health`);
     if (apiKey) {
       console.log("[PDF Reader MCP] API key authentication enabled (X-API-Key header)");
+    }
+    if (corsOrigin) {
+      console.log(`[PDF Reader MCP] CORS allowed origin: ${corsOrigin}`);
     }
     console.log("[PDF Reader MCP] Project root:", process.cwd());
   } else if (process.env["DEBUG_MCP"]) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,12 @@ import { readPdf } from './handlers/readPdf.js';
 // MCP_HTTP_PORT: HTTP port (default: 8080)
 // MCP_HTTP_HOST: HTTP hostname (default: '0.0.0.0')
 // MCP_API_KEY: Optional API key for authentication (X-API-Key header)
+// MCP_CORS_ORIGIN: CORS allowed origin (e.g. 'https://myapp.example.com'). Not set by default (no cross-origin access).
 const transportType = process.env['MCP_TRANSPORT'] ?? 'stdio';
 const httpPort = Number.parseInt(process.env['MCP_HTTP_PORT'] ?? '8080', 10);
 const httpHost = process.env['MCP_HTTP_HOST'] ?? '0.0.0.0';
 const apiKey = process.env['MCP_API_KEY'];
+const corsOrigin = process.env['MCP_CORS_ORIGIN'];
 
 /**
  * Create the appropriate transport based on configuration
@@ -21,7 +23,7 @@ function createTransport() {
     return http({
       port: httpPort,
       hostname: httpHost,
-      cors: '*', // Allow cross-origin requests for remote access
+      ...(corsOrigin ? { cors: corsOrigin } : {}),
     });
   }
   return stdio();
@@ -45,6 +47,9 @@ async function main(): Promise<void> {
     console.log(`[PDF Reader MCP] Health check: http://${httpHost}:${httpPort}/mcp/health`);
     if (apiKey) {
       console.log('[PDF Reader MCP] API key authentication enabled (X-API-Key header)');
+    }
+    if (corsOrigin) {
+      console.log(`[PDF Reader MCP] CORS allowed origin: ${corsOrigin}`);
     }
     console.log('[PDF Reader MCP] Project root:', process.cwd());
   } else if (process.env['DEBUG_MCP']) {

--- a/test/integration/http-transport.test.ts
+++ b/test/integration/http-transport.test.ts
@@ -150,7 +150,7 @@ describe('MCP Server HTTP Transport Integration', () => {
     }
   });
 
-  it('should handle CORS preflight requests', async () => {
+  it('should not return wildcard CORS headers by default', async () => {
     const response = await fetch(BASE_URL, {
       method: 'OPTIONS',
       headers: {
@@ -159,9 +159,9 @@ describe('MCP Server HTTP Transport Integration', () => {
       },
     });
 
-    // Should allow cross-origin requests
+    // Without MCP_CORS_ORIGIN, no CORS wildcard should be set
     const corsHeader = response.headers.get('Access-Control-Allow-Origin');
-    expect(corsHeader).toBe('*');
+    expect(corsHeader).not.toBe('*');
   });
 
   it('should reject invalid JSON-RPC requests', async () => {


### PR DESCRIPTION
## Summary

The HTTP transport mode in `src/index.ts` configures `cors: '*'` unconditionally, which sets `Access-Control-Allow-Origin: *` on responses. This is a permissive CORS misconfiguration (CWE-942) that allows any website a user visits to make cross-origin requests to the MCP server from the user's browser.

This PR removes the wildcard default and adds an opt-in `MCP_CORS_ORIGIN` environment variable so operators who actually need cross-origin access can specify a concrete allowed origin.

## Vulnerability details

- **File:** `src/index.ts` (and the matching compiled `dist/index.js`)
- **Function:** `createTransport()`
- **CWE:** [CWE-942: Permissive Cross-domain Policy with Untrusted Domains](https://cwe.mitre.org/data/definitions/942.html)
- **Affected mode:** HTTP transport (`MCP_TRANSPORT=http`); stdio mode is unaffected.

The current code:

```typescript
return http({
  port: httpPort,
  hostname: httpHost,
  cors: '*', // Allow cross-origin requests for remote access
});
```

Because the response sets `Access-Control-Allow-Origin: *`, any web origin a user happens to visit can issue `fetch`/`XHR` requests to the MCP server and read the responses. When the server is reachable from the victim's browser (typical scenarios: developer running it on `localhost`, a deployment on a shared/internal network, a containerized dev environment with port forwarding), an attacker-controlled page can:

1. Discover the server via probe requests to common ports/hosts.
2. Invoke MCP tools such as `read_pdf` to exfiltrate file contents from the server's working directory.
3. Read responses thanks to the wildcard CORS header.

This is the classic drive-by browser pivot enabled by `Access-Control-Allow-Origin: *`. The optional `MCP_API_KEY` doesn't change the analysis: many users won't set one (it's optional), and even when it is set, wildcard CORS still broadens the attack surface unnecessarily.

## Fix

- Remove the hardcoded `cors: '*'` default.
- Add an opt-in `MCP_CORS_ORIGIN` env var. When unset, no `cors` option is passed to the HTTP transport, so no `Access-Control-Allow-Origin` header is added by default (browsers will block cross-origin reads — the safe default).
- When set (e.g. `MCP_CORS_ORIGIN=https://myapp.example.com`), the server allows that specific origin and logs the configured value at startup so it's visible in operator logs.

```typescript
const corsOrigin = process.env['MCP_CORS_ORIGIN'];
// ...
return http({
  port: httpPort,
  hostname: httpHost,
  ...(corsOrigin ? { cors: corsOrigin } : {}),
});
```

This is a minimal, default-deny change. Operators who genuinely need browser-based cross-origin access can opt in explicitly to a known origin; everyone else gets a safer default with no code changes required on their side.

## Testing

- `bun test` — full test suite passes (133/133), including the existing HTTP transport integration tests.
- The previous CORS preflight test (which asserted `Access-Control-Allow-Origin: *`) was updated into a regression test that asserts the wildcard header is **not** present by default.
- `tsc --noEmit` and `biome check` pass cleanly.
- `dist/index.js` was rebuilt to match the source change.

## Security analysis

Preconditions for exploitation are minimal and realistic:

1. Operator runs the server in HTTP transport mode (`MCP_TRANSPORT=http`) — a documented, supported mode.
2. The server is reachable from a victim's browser (localhost during development, or any network position the victim's browser shares with the server — common in dev/container/internal-network deployments).

No authentication is required to reach the wildcard CORS surface, and even when `MCP_API_KEY` is configured, wildcard CORS is still broader than necessary. The fix removes the silent foot-gun and forces operators to make an explicit choice when they need cross-origin access. It is fully backward-compatible for operators who want the old behavior (they can set `MCP_CORS_ORIGIN=*` explicitly), but the default is now safe.

### Adversarial review

Before submitting, we tried to disprove this. We considered whether the optional API key, the requirement for HTTP transport to be enabled, or browser same-site protections would make this non-exploitable. They don't: API keys are optional and many users won't set one; HTTP transport is a documented first-class mode (not a hidden flag); and `Access-Control-Allow-Origin: *` is precisely what neutralizes the same-origin policy that would otherwise stop a malicious page from reading the response. The fix is a strict reduction in attack surface with no behavior change for stdio users and a clear opt-in path for HTTP users who need cross-origin access.

cc @lewiswigmore
