### PR TITLE
fix(security): patch SSS-02/03/07/08 findings (closes #279)

### DIFF
--- a/src/handlers/readPdf.ts
+++ b/src/handlers/readPdf.ts
@@ -18,6 +18,7 @@ import type {
   PdfSource,
   PdfSourceResult,
 } from '../types/pdf.js';
+import { PdfError } from '../utils/errors.js';
 import { createLogger } from '../utils/logger.js';
 
 const logger = createLogger('ReadPdf');
@@ -147,12 +148,20 @@ const processSingleSource = async (
 
     individualResult = { ...individualResult, data: output, success: true };
   } catch (error: unknown) {
-    let errorMessage = `Failed to process PDF from ${sourceDescription}.`;
-
-    if (error instanceof Error) {
-      errorMessage += ` Reason: ${error.message}`;
+    // SSS-02: PdfError messages are curated and safe to surface; anything
+    // else gets logged with full detail but returned as a generic string so
+    // raw PDF.js / Node messages cannot leak filesystem or module paths back
+    // through the response to the LLM.
+    let errorMessage: string;
+    if (error instanceof PdfError) {
+      errorMessage = error.message;
     } else {
-      errorMessage += ` Unknown error: ${JSON.stringify(error)}`;
+      const detail = error instanceof Error ? error.message : String(error);
+      logger.error('Unexpected error processing PDF source', {
+        sourceDescription,
+        error: detail,
+      });
+      errorMessage = `Failed to process PDF from ${sourceDescription}.`;
     }
 
     individualResult.error = errorMessage;

--- a/src/pdf/extractor.ts
+++ b/src/pdf/extractor.ts
@@ -238,6 +238,9 @@ const extractSinglePageText = async (
 
     return { page: pageNum, text: pageText };
   } catch (pageError: unknown) {
+    // SSS-02: do not propagate raw PDF.js error text into page content — it
+    // can carry absolute paths or module internals back to the LLM. The
+    // detailed message is kept in logs for operators.
     const message = pageError instanceof Error ? pageError.message : String(pageError);
     logger.warn('Error getting text content for page', {
       pageNum,
@@ -245,7 +248,7 @@ const extractSinglePageText = async (
       error: message,
     });
 
-    return { page: pageNum, text: `Error processing page: ${message}` };
+    return { page: pageNum, text: `[Error processing page ${String(pageNum)}]` };
   }
 };
 
@@ -443,18 +446,19 @@ export const extractPageContent = async (
       contentItems.push(...validImages);
     }
   } catch (error: unknown) {
+    // SSS-02: log raw error internally but only return a sanitized marker so
+    // the LLM never sees PDF.js / Node internals via page content.
     const message = error instanceof Error ? error.message : String(error);
     logger.warn('Error extracting page content', {
       pageNum,
       sourceDescription,
       error: message,
     });
-    // Return error message as text content
     return [
       {
         type: 'text',
         yPosition: 0,
-        textContent: `Error processing page: ${message}`,
+        textContent: `[Error processing page ${String(pageNum)}]`,
       },
     ];
   }

--- a/src/pdf/loader.ts
+++ b/src/pdf/loader.ts
@@ -4,7 +4,12 @@ import fs from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import type * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.mjs';
 import { getDocument } from 'pdfjs-dist/legacy/build/pdf.mjs';
-import { getSecurityConfig, isUrlAllowed } from '../utils/config.js';
+import {
+  assertUrlNotPrivate,
+  getSecurityConfig,
+  isUrlAllowed,
+  type SecurityConfig,
+} from '../utils/config.js';
 import { ErrorCode, PdfError } from '../utils/errors.js';
 import { createLogger } from '../utils/logger.js';
 import { resolvePath } from '../utils/pathUtils.js';
@@ -39,6 +44,202 @@ const ICC_URL = `${PDFJS_ROOT}iccs/`;
 // Prevents memory exhaustion from loading extremely large files
 const MAX_PDF_SIZE = 100 * 1024 * 1024;
 
+// Per-request timeout for URL fetches. Bounds how long a slow or hostile
+// server can keep the event loop tied up (SSS-08).
+const URL_FETCH_TIMEOUT_MS = 30_000;
+
+// Maximum redirect hops we will follow when fetching a URL. Each hop is
+// re-validated against the SSRF policy.
+const MAX_REDIRECTS = 5;
+
+const formatBytes = (bytes: number): string => `${(bytes / 1024 / 1024).toFixed(0)}MB`;
+
+const sanitizeSourceDescription = (description: string): string =>
+  description.length > 200 ? `${description.slice(0, 197)}...` : description;
+
+/**
+ * Read a local PDF file into memory, refusing oversized files before they are
+ * fully buffered (SSS-08). `fs.stat` runs first so a multi-gigabyte file is
+ * rejected without ever touching the page cache.
+ */
+const loadLocalFile = async (userPath: string): Promise<Uint8Array> => {
+  const safePath = resolvePath(userPath);
+
+  let stats: Awaited<ReturnType<typeof fs.stat>>;
+  try {
+    stats = await fs.stat(safePath);
+  } catch (err: unknown) {
+    if (typeof err === 'object' && err !== null && 'code' in err && err.code === 'ENOENT') {
+      throw new PdfError(ErrorCode.InvalidRequest, `File not found at '${userPath}'.`, {
+        cause: err instanceof Error ? err : undefined,
+      });
+    }
+    throw new PdfError(ErrorCode.InvalidRequest, `Failed to access file at '${userPath}'.`, {
+      cause: err instanceof Error ? err : undefined,
+    });
+  }
+
+  if (!stats.isFile()) {
+    throw new PdfError(ErrorCode.InvalidRequest, `Path '${userPath}' is not a regular file.`);
+  }
+
+  if (stats.size > MAX_PDF_SIZE) {
+    throw new PdfError(
+      ErrorCode.InvalidRequest,
+      `PDF file exceeds maximum size of ${formatBytes(MAX_PDF_SIZE)}. File size: ${formatBytes(stats.size)}.`
+    );
+  }
+
+  const buffer = await fs.readFile(safePath);
+  return new Uint8Array(buffer);
+};
+
+/**
+ * Validate one URL hop against the configured policy plus SSRF guard
+ * (SSS-07). Returns silently when the URL is acceptable; throws PdfError on
+ * any policy/SSRF violation.
+ */
+const validateUrlHop = async (urlString: string, config: SecurityConfig): Promise<void> => {
+  if (!isUrlAllowed(urlString, config)) {
+    const reason = config.allowHttp
+      ? 'host is not in the allowed list or scheme is not http(s)'
+      : 'HTTP access is disabled';
+    throw new PdfError(
+      ErrorCode.InvalidRequest,
+      `Access denied: URL '${urlString}' rejected (${reason}).`
+    );
+  }
+
+  if (!config.allowPrivateIps) {
+    let hostname: string;
+    try {
+      hostname = new URL(urlString).hostname;
+    } catch {
+      throw new PdfError(ErrorCode.InvalidRequest, `Invalid URL: '${urlString}'.`);
+    }
+    try {
+      await assertUrlNotPrivate(hostname);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : 'SSRF check failed';
+      throw new PdfError(ErrorCode.InvalidRequest, `Access denied: ${reason}`);
+    }
+  }
+};
+
+/**
+ * Fetch a PDF from `url` with SSRF protection, redirect re-validation, an
+ * overall timeout, and a streaming size cap (SSS-07 + SSS-08). Returns the
+ * full body as a Uint8Array so we can hand it to PDF.js as `data:` and keep
+ * resource limits enforced at the application layer.
+ */
+const fetchUrlBody = async (url: string, config: SecurityConfig): Promise<Uint8Array> => {
+  let currentUrl = url;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), URL_FETCH_TIMEOUT_MS);
+
+  try {
+    for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+      await validateUrlHop(currentUrl, config);
+
+      const response = await fetch(currentUrl, {
+        redirect: 'manual',
+        signal: controller.signal,
+      });
+
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get('location');
+        if (!location) {
+          throw new PdfError(
+            ErrorCode.InvalidRequest,
+            `URL fetch failed: redirect without Location header.`
+          );
+        }
+        currentUrl = new URL(location, currentUrl).toString();
+        continue;
+      }
+
+      if (!response.ok) {
+        throw new PdfError(
+          ErrorCode.InvalidRequest,
+          `URL fetch failed with HTTP ${String(response.status)}.`
+        );
+      }
+
+      const contentLengthHeader = response.headers.get('content-length');
+      if (contentLengthHeader !== null) {
+        const declared = Number.parseInt(contentLengthHeader, 10);
+        if (Number.isFinite(declared) && declared > MAX_PDF_SIZE) {
+          throw new PdfError(
+            ErrorCode.InvalidRequest,
+            `Remote PDF exceeds maximum size of ${formatBytes(MAX_PDF_SIZE)} (Content-Length: ${formatBytes(declared)}).`
+          );
+        }
+      }
+
+      if (!response.body) {
+        // No streaming body (some implementations); fall back to arrayBuffer
+        // but still apply the size cap.
+        const ab = await response.arrayBuffer();
+        if (ab.byteLength > MAX_PDF_SIZE) {
+          throw new PdfError(
+            ErrorCode.InvalidRequest,
+            `Remote PDF exceeds maximum size of ${formatBytes(MAX_PDF_SIZE)}.`
+          );
+        }
+        return new Uint8Array(ab);
+      }
+
+      const reader = response.body.getReader();
+      const chunks: Uint8Array[] = [];
+      let total = 0;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) {
+          total += value.byteLength;
+          if (total > MAX_PDF_SIZE) {
+            await reader.cancel().catch(() => {});
+            throw new PdfError(
+              ErrorCode.InvalidRequest,
+              `Remote PDF exceeds maximum size of ${formatBytes(MAX_PDF_SIZE)} during streaming.`
+            );
+          }
+          chunks.push(value);
+        }
+      }
+
+      const combined = new Uint8Array(total);
+      let offset = 0;
+      for (const chunk of chunks) {
+        combined.set(chunk, offset);
+        offset += chunk.byteLength;
+      }
+      return combined;
+    }
+
+    throw new PdfError(
+      ErrorCode.InvalidRequest,
+      `URL fetch failed: exceeded redirect limit (${String(MAX_REDIRECTS)}).`
+    );
+  } catch (err: unknown) {
+    if (err instanceof PdfError) throw err;
+    if (err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')) {
+      throw new PdfError(
+        ErrorCode.InvalidRequest,
+        `URL fetch timed out after ${String(URL_FETCH_TIMEOUT_MS / 1000)}s.`,
+        { cause: err }
+      );
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn('URL fetch failed', { url, error: message });
+    throw new PdfError(ErrorCode.InvalidRequest, `URL fetch failed for '${url}'.`, {
+      cause: err instanceof Error ? err : undefined,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
 /**
  * Load a PDF document from a local file path or URL
  * @param source - Object containing either path or url
@@ -49,75 +250,38 @@ export const loadPdfDocument = async (
   source: { path?: string | undefined; url?: string | undefined },
   sourceDescription: string
 ): Promise<pdfjsLib.PDFDocumentProxy> => {
-  let pdfDataSource: Uint8Array | { url: string };
+  const safeSource = sanitizeSourceDescription(sourceDescription);
+  let pdfData: Uint8Array;
 
   try {
     if (source.path) {
-      const safePath = resolvePath(source.path);
-      const buffer = await fs.readFile(safePath);
-
-      // Security: Check file size to prevent memory exhaustion
-      if (buffer.length > MAX_PDF_SIZE) {
-        throw new PdfError(
-          ErrorCode.InvalidRequest,
-          `PDF file exceeds maximum size of ${MAX_PDF_SIZE} bytes (${(MAX_PDF_SIZE / 1024 / 1024).toFixed(0)}MB). File size: ${buffer.length} bytes.`
-        );
-      }
-
-      pdfDataSource = new Uint8Array(buffer);
+      pdfData = await loadLocalFile(source.path);
     } else if (source.url) {
-      // Enforce HTTP access policy (issue #274). The check runs before any
-      // network call so URL fetches are rejected without DNS or socket
-      // activity when the operator has disabled HTTP or restricted hosts.
       const config = getSecurityConfig();
-      if (!isUrlAllowed(source.url, config)) {
-        const reason = config.allowHttp
-          ? `host is not in the allowed list`
-          : `HTTP access is disabled`;
-        throw new PdfError(
-          ErrorCode.InvalidRequest,
-          `Access denied: URL '${source.url}' rejected (${reason}).`
-        );
-      }
-      pdfDataSource = { url: source.url };
+      pdfData = await fetchUrlBody(source.url, config);
     } else {
-      throw new PdfError(
-        ErrorCode.InvalidParams,
-        `Source ${sourceDescription} missing 'path' or 'url'.`
-      );
+      throw new PdfError(ErrorCode.InvalidParams, `Source ${safeSource} missing 'path' or 'url'.`);
     }
   } catch (err: unknown) {
     if (err instanceof PdfError) {
       throw err;
     }
 
+    // Non-PdfError exceptions are logged with full detail but only surface a
+    // generic message to callers — raw filesystem/library messages can leak
+    // internal paths back to the LLM (SSS-02).
     const message = err instanceof Error ? err.message : String(err);
-    const errorCode = ErrorCode.InvalidRequest;
-
-    if (
-      typeof err === 'object' &&
-      err !== null &&
-      'code' in err &&
-      err.code === 'ENOENT' &&
-      source.path
-    ) {
-      throw new PdfError(errorCode, `File not found at '${source.path}'.`, {
-        cause: err instanceof Error ? err : undefined,
-      });
-    }
-
-    throw new PdfError(
-      errorCode,
-      `Failed to prepare PDF source ${sourceDescription}. Reason: ${message}`,
-      { cause: err instanceof Error ? err : undefined }
-    );
+    logger.error('Unexpected error preparing PDF source', {
+      sourceDescription: safeSource,
+      error: message,
+    });
+    throw new PdfError(ErrorCode.InvalidRequest, `Failed to prepare PDF source ${safeSource}.`, {
+      cause: err instanceof Error ? err : undefined,
+    });
   }
 
-  const documentParams =
-    pdfDataSource instanceof Uint8Array ? { data: pdfDataSource } : pdfDataSource;
-
   const loadingTask = getDocument({
-    ...documentParams,
+    data: pdfData,
     cMapUrl: CMAP_URL,
     cMapPacked: true,
     standardFontDataUrl: STANDARD_FONT_DATA_URL,
@@ -129,10 +293,10 @@ export const loadPdfDocument = async (
     return await loadingTask.promise;
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    logger.error('PDF.js loading error', { sourceDescription, error: message });
+    logger.error('PDF.js loading error', { sourceDescription: safeSource, error: message });
     throw new PdfError(
       ErrorCode.InvalidRequest,
-      `Failed to load PDF document from ${sourceDescription}. Reason: ${message || 'Unknown loading error'}`,
+      `Failed to load PDF document from ${safeSource}.`,
       { cause: err instanceof Error ? err : undefined }
     );
   }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -10,25 +10,35 @@
 //   --allow-dir=<path>           (repeatable)   restrict reads to listed dirs
 //   --allow-host=<host>          (repeatable)   restrict URL fetches to hosts
 //   --no-http                                   disable URL sources entirely
+//   --allow-private-ips                         allow URLs that resolve to
+//                                               private/loopback/link-local IPs
 //   MCP_PDF_ALLOWED_DIRS         path1:path2    (':' or ',' separated)
 //   MCP_PDF_ALLOWED_HOSTS        host1,host2    (',' separated)
 //   MCP_PDF_ALLOW_HTTP           "false" | "0"  disable URL sources
+//   MCP_PDF_ALLOW_PRIVATE_IPS    "true" | "1"   allow private/loopback IPs
 //
 // Resolution rules:
 //   - allowedDirs === null  → no filesystem restriction (default)
 //   - allowedDirs === []    → empty list explicitly configured (blocks all)
 //   - allowedHosts === null → no host restriction (default, when http allowed)
 //   - allowHttp === false   → URL sources rejected before any network call
+//   - allowPrivateIps       → false by default; SSRF guard rejects URLs that
+//                             resolve to RFC1918, loopback, link-local, etc.
 
+import dns from 'node:dns';
+import fs from 'node:fs';
+import net from 'node:net';
 import path from 'node:path';
 
 export interface SecurityConfig {
-  /** Allowlisted directories (absolute, normalized). null = unrestricted. */
+  /** Allowlisted directories (absolute, canonicalized). null = unrestricted. */
   allowedDirs: readonly string[] | null;
   /** Allow URL sources at all. */
   allowHttp: boolean;
   /** Allowlisted URL hosts (lowercased). null = any host (when allowHttp). */
   allowedHosts: readonly string[] | null;
+  /** Allow URLs that resolve to private/loopback/link-local IPs. */
+  allowPrivateIps: boolean;
 }
 
 const splitList = (value: string, separators: RegExp): string[] =>
@@ -37,8 +47,31 @@ const splitList = (value: string, separators: RegExp): string[] =>
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
 
+/**
+ * Canonicalize a path so the allowlist comparison sees the real target. Walks
+ * up to the deepest existing ancestor when the path does not exist yet, so a
+ * symlinked ancestor cannot mask the eventual real location.
+ */
+const canonicalizeDir = (p: string): string => {
+  try {
+    return fs.realpathSync(p);
+  } catch (err: unknown) {
+    if (
+      typeof err === 'object' &&
+      err !== null &&
+      'code' in err &&
+      (err.code === 'ENOENT' || err.code === 'ENOTDIR')
+    ) {
+      const parent = path.dirname(p);
+      if (parent === p) return p;
+      return path.join(canonicalizeDir(parent), path.basename(p));
+    }
+    throw err;
+  }
+};
+
 const parseDirs = (values: string[]): string[] =>
-  values.map((dir) => path.resolve(path.normalize(dir)));
+  values.map((dir) => canonicalizeDir(path.resolve(path.normalize(dir))));
 
 const parseBool = (value: string | undefined, fallback: boolean): boolean => {
   if (value === undefined) return fallback;
@@ -52,12 +85,14 @@ interface CliFlags {
   dirs: string[];
   hosts: string[];
   noHttp: boolean;
+  allowPrivateIps: boolean;
 }
 
 const parseCliFlags = (argv: readonly string[]): CliFlags => {
   const dirs: string[] = [];
   const hosts: string[] = [];
   let noHttp = false;
+  let allowPrivateIps = false;
 
   for (const arg of argv) {
     if (arg.startsWith('--allow-dir=')) {
@@ -66,10 +101,12 @@ const parseCliFlags = (argv: readonly string[]): CliFlags => {
       hosts.push(arg.slice('--allow-host='.length).toLowerCase());
     } else if (arg === '--no-http') {
       noHttp = true;
+    } else if (arg === '--allow-private-ips') {
+      allowPrivateIps = true;
     }
   }
 
-  return { dirs, hosts, noHttp };
+  return { dirs, hosts, noHttp, allowPrivateIps };
 };
 
 const envList = (
@@ -97,6 +134,7 @@ export const readSecurityConfig = (
     allowedDirs: mergedDirs.length > 0 ? parseDirs(mergedDirs) : null,
     allowHttp: cli.noHttp ? false : parseBool(env['MCP_PDF_ALLOW_HTTP'], true),
     allowedHosts: mergedHosts.length > 0 ? mergedHosts : null,
+    allowPrivateIps: cli.allowPrivateIps || parseBool(env['MCP_PDF_ALLOW_PRIVATE_IPS'], false),
   };
 };
 
@@ -141,6 +179,9 @@ export const isPathAllowed = (absPath: string, allowedDirs: readonly string[] | 
  * Returns true when `urlString` resolves to a permitted http(s) URL given the
  * configured policy. Non-http(s) URLs (file:, data:, ftp:, etc.) are always
  * rejected — the loader treats `source.url` as a network resource.
+ *
+ * This is the cheap sync gate; SSRF protection against private IPs is layered
+ * on top via {@link assertUrlNotPrivate} which performs DNS resolution.
  */
 export const isUrlAllowed = (urlString: string, config: SecurityConfig): boolean => {
   if (!config.allowHttp) return false;
@@ -156,4 +197,85 @@ export const isUrlAllowed = (urlString: string, config: SecurityConfig): boolean
 
   if (config.allowedHosts === null) return true;
   return config.allowedHosts.includes(parsed.hostname.toLowerCase());
+};
+
+// IPv4 private/loopback/link-local/multicast/reserved ranges that an SSRF
+// guard should refuse to fetch from. Encoded as a table of predicates over
+// `[a, b]` (the first two octets) to keep the dispatch readable.
+const PRIVATE_IPV4_PREDICATES: ReadonlyArray<(a: number, b: number) => boolean> = [
+  (a) => a === 10, // RFC1918 10.0.0.0/8
+  (a, b) => a === 172 && b >= 16 && b <= 31, // RFC1918 172.16.0.0/12
+  (a, b) => a === 192 && b === 168, // RFC1918 192.168.0.0/16
+  (a) => a === 127, // loopback 127.0.0.0/8
+  (a, b) => a === 169 && b === 254, // link-local 169.254.0.0/16
+  (a) => a === 0, // 0.0.0.0/8 "this network"
+  (a, b) => a === 100 && b >= 64 && b <= 127, // CGNAT 100.64.0.0/10
+  (a) => a >= 224, // multicast + reserved 224.0.0.0+
+];
+
+const isPrivateIpv4 = (ip: string): boolean => {
+  const parts = ip.split('.').map((s) => Number.parseInt(s, 10));
+  const a = parts[0];
+  const b = parts[1];
+  if (a === undefined || b === undefined) return true;
+  return PRIVATE_IPV4_PREDICATES.some((pred) => pred(a, b));
+};
+
+const isPrivateIpv6 = (ip: string): boolean => {
+  const lower = ip.toLowerCase();
+  if (lower === '::1' || lower === '::') return true;
+  if (lower.startsWith('fc') || lower.startsWith('fd')) return true; // unique local fc00::/7
+  if (lower.startsWith('fe80')) return true; // link-local fe80::/10
+  if (lower.startsWith('ff')) return true; // multicast
+  if (lower.startsWith('::ffff:')) {
+    // IPv4-mapped IPv6 — extract the embedded v4 and recurse.
+    const tail = lower.slice('::ffff:'.length);
+    if (net.isIPv4(tail)) return isPrivateIpv4(tail);
+  }
+  return false;
+};
+
+/**
+ * Returns true when `ip` is a private, loopback, link-local, multicast, or
+ * otherwise non-public address. Conservative: any address that is not clearly
+ * a routable public IP returns true (denied). Used by the SSRF guard
+ * (SSS-07) to keep URL fetches off the local network and metadata endpoints.
+ */
+export const isPrivateIp = (ip: string): boolean => {
+  if (net.isIPv4(ip)) return isPrivateIpv4(ip);
+  if (net.isIPv6(ip)) return isPrivateIpv6(ip);
+  return true; // unrecognized → deny
+};
+
+/**
+ * Throws if `hostname` resolves to any non-public IP (SSS-07). Caller should
+ * skip this when {@link SecurityConfig.allowPrivateIps} is true. DNS lookups
+ * are made with `{ all: true }` so the check covers every A/AAAA record, not
+ * just the first one the resolver returns.
+ */
+export const assertUrlNotPrivate = async (hostname: string): Promise<void> => {
+  // If the hostname is already a literal IP, check it directly without DNS.
+  if (net.isIP(hostname)) {
+    if (isPrivateIp(hostname)) {
+      throw new Error(`URL host '${hostname}' resolves to a non-public address (SSRF protection).`);
+    }
+    return;
+  }
+
+  let addresses: dns.LookupAddress[];
+  try {
+    addresses = await dns.promises.lookup(hostname, { all: true });
+  } catch {
+    throw new Error(`URL host '${hostname}' could not be resolved.`);
+  }
+
+  if (addresses.length === 0) {
+    throw new Error(`URL host '${hostname}' resolved to no addresses.`);
+  }
+
+  for (const { address } of addresses) {
+    if (isPrivateIp(address)) {
+      throw new Error(`URL host '${hostname}' resolves to a non-public address (SSRF protection).`);
+    }
+  }
 };

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { getSecurityConfig, isPathAllowed } from './config.js';
 import { ErrorCode, PdfError } from './errors.js';
@@ -7,8 +8,37 @@ import { ErrorCode, PdfError } from './errors.js';
 export const PROJECT_ROOT = process.cwd();
 
 /**
+ * Canonicalize symlinks in `p` so the allowlist check sees the real target,
+ * not a link that escapes the sandbox. When `p` does not exist yet, walk up
+ * to the deepest existing ancestor, realpath that, and re-attach the missing
+ * tail — this stops an attacker from hiding the escape behind a symlinked
+ * ancestor directory while still allowing reads of paths that the caller
+ * expects to fail later with ENOENT.
+ */
+const canonicalize = (p: string): string => {
+  try {
+    return fs.realpathSync(p);
+  } catch (err: unknown) {
+    if (
+      typeof err === 'object' &&
+      err !== null &&
+      'code' in err &&
+      (err.code === 'ENOENT' || err.code === 'ENOTDIR')
+    ) {
+      const parent = path.dirname(p);
+      if (parent === p) return p;
+      return path.join(canonicalize(parent), path.basename(p));
+    }
+    throw err;
+  }
+};
+
+/**
  * Resolves a user-provided path, accepting both absolute and relative paths.
  * Relative paths are resolved against the current working directory (PROJECT_ROOT).
+ *
+ * Symlinks are canonicalized via `fs.realpathSync` before the allowlist check
+ * so a link inside an allowed directory cannot point outside it (SSS-03).
  *
  * When the operator has configured filesystem allowlists (via --allow-dir or
  * MCP_PDF_ALLOWED_DIRS), the resolved path must lie inside one of them — this
@@ -16,7 +46,7 @@ export const PROJECT_ROOT = process.cwd();
  * server preserves its historical permissive behavior.
  *
  * @param userPath The path provided by the user (absolute or relative).
- * @returns The resolved absolute path.
+ * @returns The canonical absolute path.
  * @throws {PdfError} If path is invalid or access is denied.
  */
 export const resolvePath = (userPath: string): string => {
@@ -31,13 +61,15 @@ export const resolvePath = (userPath: string): string => {
     ? normalizedUserPath
     : path.resolve(PROJECT_ROOT, normalizedUserPath);
 
+  const canonical = canonicalize(resolved);
+
   const { allowedDirs } = getSecurityConfig();
-  if (!isPathAllowed(resolved, allowedDirs)) {
+  if (!isPathAllowed(canonical, allowedDirs)) {
     throw new PdfError(
       ErrorCode.InvalidRequest,
       `Access denied: path '${userPath}' is outside the allowed directories.`
     );
   }
 
-  return resolved;
+  return canonical;
 };

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,8 +1,31 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { __resetSecurityConfigForTests, isPathAllowed, isUrlAllowed, readSecurityConfig } from '../src/utils/config.js';
+import {
+  __resetSecurityConfigForTests,
+  assertUrlNotPrivate,
+  isPathAllowed,
+  isPrivateIp,
+  isUrlAllowed,
+  readSecurityConfig,
+} from '../src/utils/config.js';
 import { ErrorCode, PdfError } from '../src/utils/errors.js';
 import { resolvePath } from '../src/utils/pathUtils.js';
+
+// On macOS `/tmp` is a symlink to `/private/tmp`; the config parser now
+// realpaths allowlisted dirs so the comparison against canonicalized user
+// paths in resolvePath aligns. Tests compute the expected canonical form
+// the same way so they work on any platform.
+const canonicalize = (p: string): string => {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    const parent = path.dirname(p);
+    if (parent === p) return p;
+    return path.join(canonicalize(parent), path.basename(p));
+  }
+};
+const canonical = (p: string): string => canonicalize(path.resolve(p));
 
 // Snapshot env vars touched by this suite so afterEach can restore them
 // cleanly. Assigning `undefined` to a process.env key actually stringifies
@@ -30,16 +53,27 @@ describe('readSecurityConfig', () => {
     expect(cfg.allowedDirs).toBeNull();
     expect(cfg.allowHttp).toBe(true);
     expect(cfg.allowedHosts).toBeNull();
+    expect(cfg.allowPrivateIps).toBe(false);
   });
 
-  it('parses --allow-dir flags into absolute paths', () => {
+  it('parses --allow-dir flags into canonical absolute paths', () => {
     const cfg = readSecurityConfig(['--allow-dir=/tmp/a', '--allow-dir=/tmp/b'], {});
-    expect(cfg.allowedDirs).toEqual([path.resolve('/tmp/a'), path.resolve('/tmp/b')]);
+    expect(cfg.allowedDirs).toEqual([canonical('/tmp/a'), canonical('/tmp/b')]);
   });
 
   it('parses MCP_PDF_ALLOWED_DIRS with colon and comma separators', () => {
     const cfg = readSecurityConfig([], { MCP_PDF_ALLOWED_DIRS: '/tmp/a:/tmp/b,/tmp/c' });
-    expect(cfg.allowedDirs).toEqual([path.resolve('/tmp/a'), path.resolve('/tmp/b'), path.resolve('/tmp/c')]);
+    expect(cfg.allowedDirs).toEqual([canonical('/tmp/a'), canonical('/tmp/b'), canonical('/tmp/c')]);
+  });
+
+  it('enables private-IP fetches via --allow-private-ips', () => {
+    const cfg = readSecurityConfig(['--allow-private-ips'], {});
+    expect(cfg.allowPrivateIps).toBe(true);
+  });
+
+  it('enables private-IP fetches via MCP_PDF_ALLOW_PRIVATE_IPS', () => {
+    expect(readSecurityConfig([], { MCP_PDF_ALLOW_PRIVATE_IPS: 'true' }).allowPrivateIps).toBe(true);
+    expect(readSecurityConfig([], { MCP_PDF_ALLOW_PRIVATE_IPS: '1' }).allowPrivateIps).toBe(true);
   });
 
   it('disables HTTP via --no-http', () => {
@@ -97,37 +131,92 @@ describe('isPathAllowed', () => {
 });
 
 describe('isUrlAllowed', () => {
+  const baseCfg = {
+    allowHttp: true,
+    allowedDirs: null,
+    allowedHosts: null,
+    allowPrivateIps: false,
+  } as const;
+
   it('rejects all URLs when allowHttp is false', () => {
-    const cfg = { allowHttp: false, allowedDirs: null, allowedHosts: null } as const;
-    expect(isUrlAllowed('https://example.com/file.pdf', cfg)).toBe(false);
+    expect(isUrlAllowed('https://example.com/file.pdf', { ...baseCfg, allowHttp: false })).toBe(false);
   });
 
   it('allows http(s) URLs when allowHttp and no host restriction', () => {
-    const cfg = { allowHttp: true, allowedDirs: null, allowedHosts: null } as const;
-    expect(isUrlAllowed('https://example.com/file.pdf', cfg)).toBe(true);
-    expect(isUrlAllowed('http://example.com/file.pdf', cfg)).toBe(true);
+    expect(isUrlAllowed('https://example.com/file.pdf', baseCfg)).toBe(true);
+    expect(isUrlAllowed('http://example.com/file.pdf', baseCfg)).toBe(true);
   });
 
   it('rejects non-http schemes regardless of policy', () => {
-    const cfg = { allowHttp: true, allowedDirs: null, allowedHosts: null } as const;
-    expect(isUrlAllowed('file:///etc/passwd', cfg)).toBe(false);
-    expect(isUrlAllowed('ftp://example.com/x.pdf', cfg)).toBe(false);
-    expect(isUrlAllowed('data:application/pdf;base64,abc', cfg)).toBe(false);
+    expect(isUrlAllowed('file:///etc/passwd', baseCfg)).toBe(false);
+    expect(isUrlAllowed('ftp://example.com/x.pdf', baseCfg)).toBe(false);
+    expect(isUrlAllowed('data:application/pdf;base64,abc', baseCfg)).toBe(false);
   });
 
   it('enforces allowed hosts list (case-insensitive)', () => {
-    const cfg = {
-      allowHttp: true,
-      allowedDirs: null,
-      allowedHosts: ['cdn.example.com'],
-    } as const;
+    const cfg = { ...baseCfg, allowedHosts: ['cdn.example.com'] } as const;
     expect(isUrlAllowed('https://CDN.example.com/x.pdf', cfg)).toBe(true);
     expect(isUrlAllowed('https://evil.com/x.pdf', cfg)).toBe(false);
   });
 
   it('returns false for malformed URLs', () => {
-    const cfg = { allowHttp: true, allowedDirs: null, allowedHosts: null } as const;
-    expect(isUrlAllowed('not a url', cfg)).toBe(false);
+    expect(isUrlAllowed('not a url', baseCfg)).toBe(false);
+  });
+});
+
+describe('isPrivateIp (SSS-07 SSRF guard)', () => {
+  it('flags RFC1918 IPv4 ranges as private', () => {
+    expect(isPrivateIp('10.0.0.1')).toBe(true);
+    expect(isPrivateIp('172.16.0.5')).toBe(true);
+    expect(isPrivateIp('172.31.255.255')).toBe(true);
+    expect(isPrivateIp('192.168.1.1')).toBe(true);
+  });
+
+  it('flags loopback, link-local, multicast, CGNAT, and reserved as private', () => {
+    expect(isPrivateIp('127.0.0.1')).toBe(true);
+    expect(isPrivateIp('169.254.169.254')).toBe(true); // cloud metadata
+    expect(isPrivateIp('0.0.0.0')).toBe(true);
+    expect(isPrivateIp('100.64.0.1')).toBe(true); // CGNAT
+    expect(isPrivateIp('224.0.0.1')).toBe(true); // multicast
+  });
+
+  it('accepts public IPv4 addresses', () => {
+    expect(isPrivateIp('8.8.8.8')).toBe(false);
+    expect(isPrivateIp('1.1.1.1')).toBe(false);
+    expect(isPrivateIp('203.0.113.5')).toBe(false);
+  });
+
+  it('flags loopback and link-local IPv6 as private', () => {
+    expect(isPrivateIp('::1')).toBe(true);
+    expect(isPrivateIp('fe80::1')).toBe(true);
+    expect(isPrivateIp('fc00::1')).toBe(true); // unique local
+    expect(isPrivateIp('fd12::1')).toBe(true);
+    expect(isPrivateIp('ff02::1')).toBe(true); // multicast
+  });
+
+  it('unwraps IPv4-mapped IPv6 addresses', () => {
+    expect(isPrivateIp('::ffff:127.0.0.1')).toBe(true);
+    expect(isPrivateIp('::ffff:169.254.169.254')).toBe(true);
+    expect(isPrivateIp('::ffff:8.8.8.8')).toBe(false);
+  });
+
+  it('denies addresses that are not recognized as IPv4 or IPv6', () => {
+    expect(isPrivateIp('not-an-ip')).toBe(true);
+  });
+});
+
+describe('assertUrlNotPrivate (SSS-07 SSRF guard)', () => {
+  it('throws for literal private IPv4 hostnames without DNS', async () => {
+    await expect(assertUrlNotPrivate('169.254.169.254')).rejects.toThrow(/non-public/);
+    await expect(assertUrlNotPrivate('127.0.0.1')).rejects.toThrow(/non-public/);
+  });
+
+  it('throws for literal private IPv6 hostnames without DNS', async () => {
+    await expect(assertUrlNotPrivate('::1')).rejects.toThrow(/non-public/);
+  });
+
+  it('resolves successfully for literal public IPs', async () => {
+    await expect(assertUrlNotPrivate('8.8.8.8')).resolves.toBeUndefined();
   });
 });
 
@@ -146,11 +235,31 @@ describe('resolvePath integration with security config', () => {
   });
 
   it('allows paths inside an allowlisted directory', () => {
-    const allowed = path.resolve('/tmp/sandbox-allowed');
+    const allowed = canonical('/tmp/sandbox-allowed');
     process.env['MCP_PDF_ALLOWED_DIRS'] = allowed;
     __resetSecurityConfigForTests();
 
     const target = path.join(allowed, 'doc.pdf');
     expect(resolvePath(target)).toBe(target);
+  });
+
+  it('rejects a symlink inside an allowed dir that points outside (SSS-03)', () => {
+    const sandbox = fs.mkdtempSync(path.join(canonical('/tmp'), 'sandbox-'));
+    const outsideDir = fs.mkdtempSync(path.join(canonical('/tmp'), 'outside-'));
+    const outsideFile = path.join(outsideDir, 'secret.txt');
+    fs.writeFileSync(outsideFile, 'secret');
+    const escapeLink = path.join(sandbox, 'escape');
+    fs.symlinkSync(outsideFile, escapeLink);
+
+    process.env['MCP_PDF_ALLOWED_DIRS'] = sandbox;
+    __resetSecurityConfigForTests();
+
+    try {
+      expect(() => resolvePath(escapeLink)).toThrow(PdfError);
+      expect(() => resolvePath(escapeLink)).toThrow(/Access denied/);
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/handlers/readPdf.test.ts
+++ b/test/handlers/readPdf.test.ts
@@ -1,6 +1,6 @@
 import * as realFsPromises from 'node:fs/promises';
 import { type Schema, safeParse } from '@sylphx/vex';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ErrorCode, PdfError } from '../../src/utils/errors.js';
 import * as pathUtils from '../../src/utils/pathUtils.js'; // Import the module itself for spying
 import { resolvePath } from '../../src/utils/pathUtils.js';
@@ -15,6 +15,14 @@ const mockGetMetadata = vi.fn();
 const mockGetPage = vi.fn();
 const mockGetDocument = vi.fn();
 const mockReadFile = vi.fn();
+const mockStat = vi.fn();
+
+const fakeStats = (size: number) =>
+  ({
+    size,
+    isFile: () => true,
+    isDirectory: () => false,
+  }) as unknown as Awaited<ReturnType<typeof realFsPromises.stat>>;
 
 vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({
   getDocument: mockGetDocument,
@@ -42,8 +50,10 @@ vi.mock('node:fs/promises', () => ({
   default: {
     ...realFsPromises,
     readFile: mockReadFile,
+    stat: mockStat,
   },
   readFile: mockReadFile,
+  stat: mockStat,
 }));
 
 // Dynamically import the handler *once* after mocks are defined
@@ -90,6 +100,8 @@ beforeAll(async () => {
   };
 });
 
+let originalFetch: typeof globalThis.fetch;
+
 // Renamed describe block as it now only tests the handler
 describe('handleReadPdfFunc Integration Tests', () => {
   beforeEach(() => {
@@ -98,6 +110,18 @@ describe('handleReadPdfFunc Integration Tests', () => {
     vi.spyOn(pathUtils, 'resolvePath').mockImplementation((p) => p); // Simple mock for resolvePath
 
     mockReadFile.mockResolvedValue(Buffer.from('mock pdf content'));
+    mockStat.mockResolvedValue(fakeStats(Buffer.from('mock pdf content').length));
+
+    // Default fetch mock returns a small body so URL sources resolve. Tests
+    // that need different behavior override this per-case.
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockImplementation(async () => {
+      const body = new TextEncoder().encode('mock pdf content');
+      return new Response(body, {
+        status: 200,
+        headers: { 'content-length': String(body.byteLength) },
+      });
+    }) as typeof globalThis.fetch;
 
     const mockDocumentAPI = {
       numPages: 3,
@@ -144,6 +168,10 @@ describe('handleReadPdfFunc Integration Tests', () => {
       }
       throw new Error(`Mock getPage error: Invalid page number ${String(pageNum)}`);
     });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
   });
 
   // Removed unit tests for parsePageRanges
@@ -301,14 +329,19 @@ describe('handleReadPdfFunc Integration Tests', () => {
       ],
     };
     expect(mockReadFile).not.toHaveBeenCalled();
-    expect(mockGetDocument).toHaveBeenCalledWith({
-      url: testUrl,
-      cMapUrl: expect.stringContaining('cmaps'),
-      cMapPacked: true,
-      standardFontDataUrl: expect.stringContaining('standard_fonts'),
-      wasmUrl: expect.stringContaining('wasm'),
-      iccUrl: expect.stringContaining('iccs'),
-    });
+    // The loader fetches the URL itself now and hands the body to pdfjs as
+    // `data:` so application-level size and SSRF guards apply (SSS-07/08).
+    expect(mockGetDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.any(Uint8Array),
+        cMapUrl: expect.stringContaining('cmaps'),
+        cMapPacked: true,
+        standardFontDataUrl: expect.stringContaining('standard_fonts'),
+        wasmUrl: expect.stringContaining('wasm'),
+        iccUrl: expect.stringContaining('iccs'),
+      })
+    );
+    expect(globalThis.fetch).toHaveBeenCalledWith(testUrl, expect.objectContaining({ redirect: 'manual' }));
     expect(mockGetMetadata).toHaveBeenCalled();
     expect(mockGetPage).not.toHaveBeenCalled();
     // Add check for content existence and access safely
@@ -364,24 +397,31 @@ describe('handleReadPdfFunc Integration Tests', () => {
     };
     const secondLoadingTaskAPI = { promise: Promise.resolve(secondMockDocumentAPI) };
 
-    // Reset getDocument mock before setting implementation
+    // Tag the URL source by routing fetch responses to a distinct body, then
+    // pick the document API based on that body (since both inputs reach pdfjs
+    // as `data:` now).
+    const URL_BODY_TAG = 'URL_BODY_MARKER';
+    globalThis.fetch = vi.fn().mockImplementation(async () => {
+      const body = new TextEncoder().encode(URL_BODY_TAG);
+      return new Response(body, {
+        status: 200,
+        headers: { 'content-length': String(body.byteLength) },
+      });
+    }) as typeof globalThis.fetch;
+
     mockGetDocument.mockReset();
-    // Mock getDocument based on input source
-    mockGetDocument.mockImplementation(
-      (source: { data?: Uint8Array; url?: string; cMapUrl?: string; cMapPacked?: boolean }) => {
-        // Check if source has the matching url property
-        if (source.url === urlSource) {
-          return secondLoadingTaskAPI;
-        }
-        // Default mock for path-based source (local.pdf)
-        const defaultMockDocumentAPI = {
-          numPages: 3,
-          getMetadata: mockGetMetadata, // Use original metadata mock
-          getPage: mockGetPage, // Use original page mock
-        };
-        return { promise: Promise.resolve(defaultMockDocumentAPI) };
+    mockGetDocument.mockImplementation((source: { data?: Uint8Array }) => {
+      if (source.data) {
+        const text = new TextDecoder().decode(source.data);
+        if (text === URL_BODY_TAG) return secondLoadingTaskAPI;
       }
-    );
+      const defaultMockDocumentAPI = {
+        numPages: 3,
+        getMetadata: mockGetMetadata,
+        getPage: mockGetPage,
+      };
+      return { promise: Promise.resolve(defaultMockDocumentAPI) };
+    });
 
     const result = await handler(args);
     const expectedData = {
@@ -412,22 +452,17 @@ describe('handleReadPdfFunc Integration Tests', () => {
     expect(mockReadFile).toHaveBeenCalledOnce();
     expect(mockReadFile).toHaveBeenCalledWith(resolvePath('local.pdf'));
     expect(mockGetDocument).toHaveBeenCalledTimes(2);
-    expect(mockGetDocument).toHaveBeenCalledWith({
-      data: new Uint8Array(Buffer.from('mock pdf content')),
-      cMapUrl: expect.stringContaining('cmaps'),
-      cMapPacked: true,
-      standardFontDataUrl: expect.stringContaining('standard_fonts'),
-      wasmUrl: expect.stringContaining('wasm'),
-      iccUrl: expect.stringContaining('iccs'),
-    });
-    expect(mockGetDocument).toHaveBeenCalledWith({
-      url: urlSource,
-      cMapUrl: expect.stringContaining('cmaps'),
-      cMapPacked: true,
-      standardFontDataUrl: expect.stringContaining('standard_fonts'),
-      wasmUrl: expect.stringContaining('wasm'),
-      iccUrl: expect.stringContaining('iccs'),
-    });
+    expect(mockGetDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: new Uint8Array(Buffer.from('mock pdf content')),
+        cMapUrl: expect.stringContaining('cmaps'),
+        cMapPacked: true,
+        standardFontDataUrl: expect.stringContaining('standard_fonts'),
+        wasmUrl: expect.stringContaining('wasm'),
+        iccUrl: expect.stringContaining('iccs'),
+      })
+    );
+    expect(globalThis.fetch).toHaveBeenCalledWith(urlSource, expect.objectContaining({ redirect: 'manual' }));
     expect(mockGetPage).toHaveBeenCalledTimes(1); // Should be called once for local.pdf page 1
     expect(secondMockGetPage).toHaveBeenCalledTimes(2);
     // Add check for content existence and access safely
@@ -446,21 +481,22 @@ describe('handleReadPdfFunc Integration Tests', () => {
   it('should throw error if local file not found', async () => {
     const error = new Error('Mock ENOENT') as NodeJS.ErrnoException;
     error.code = 'ENOENT';
-    mockReadFile.mockRejectedValue(error);
+    mockStat.mockRejectedValue(error);
     const args = { sources: [{ path: 'nonexistent.pdf' }] };
     // When all sources fail, handler now throws toolError
     await expect(handler(args)).rejects.toThrow(PdfError);
     await expect(handler(args)).rejects.toThrow("File not found at 'nonexistent.pdf'");
   });
 
-  it('should throw error if pdfjs fails to load document', async () => {
-    const loadError = new Error('Mock PDF loading failed');
+  it('should throw a sanitized error if pdfjs fails to load (SSS-02)', async () => {
+    const loadError = new Error('Mock PDF loading failed /private/etc/leak.bin');
     const failingLoadingTask = { promise: Promise.reject(loadError) };
     mockGetDocument.mockReturnValue(failingLoadingTask);
     const args = { sources: [{ path: 'bad.pdf' }] };
-    // When all sources fail, handler now throws toolError
     await expect(handler(args)).rejects.toThrow(PdfError);
-    await expect(handler(args)).rejects.toThrow('Mock PDF loading failed');
+    await expect(handler(args)).rejects.toThrow(/Failed to load PDF document from bad\.pdf/);
+    // The raw PDF.js message must not surface to the LLM.
+    await expect(handler(args)).rejects.not.toThrow(/private\/etc\/leak/);
   });
 
   it('should throw PdfError for invalid input arguments (Vex error)', async () => {
@@ -497,36 +533,36 @@ describe('handleReadPdfFunc Integration Tests', () => {
     await expect(handler(args)).rejects.toHaveProperty('code', ErrorCode.InvalidParams);
   });
 
-  // Test case for resolvePath failure within the catch block
-  it('should throw error if resolvePath fails', async () => {
-    const resolveError = new Error('Mock resolvePath failed');
+  // Test case for resolvePath failure within the catch block — PdfError
+  // messages from resolvePath are intentionally curated and DO surface.
+  it('should propagate PdfError from resolvePath', async () => {
+    const resolveError = new PdfError(ErrorCode.InvalidRequest, 'Path validation failed');
     vi.spyOn(pathUtils, 'resolvePath').mockImplementation(() => {
       throw resolveError;
     });
     const args = { sources: [{ path: 'some/path' }] };
-    // When all sources fail, handler now throws toolError
     await expect(handler(args)).rejects.toThrow(PdfError);
-    await expect(handler(args)).rejects.toThrow('Mock resolvePath failed');
+    await expect(handler(args)).rejects.toThrow('Path validation failed');
   });
 
-  // Test case for the final catch block with a generic error
-  it('should throw error when generic errors during processing', async () => {
-    const genericError = new Error('Something unexpected happened');
-    mockReadFile.mockRejectedValue(genericError); // Simulate error after path resolution
+  // Test case for the final catch block: generic Errors from libs must NOT
+  // leak their message to the LLM (SSS-02).
+  it('should sanitize generic errors during processing (SSS-02)', async () => {
+    const genericError = new Error('Internal /etc/passwd reference leaks here');
+    mockStat.mockRejectedValue(Object.assign(genericError, { code: 'EACCES' }));
     const args = { sources: [{ path: 'generic/error/path' }] };
-    // When all sources fail, handler now throws toolError
     await expect(handler(args)).rejects.toThrow(PdfError);
-    await expect(handler(args)).rejects.toThrow('Something unexpected happened');
+    await expect(handler(args)).rejects.toThrow(/Failed to access file/);
+    await expect(handler(args)).rejects.not.toThrow(/etc\/passwd/);
   });
 
-  // Test case for the final catch block with a non-Error object
-  it('should throw error with non-Error exceptions during processing', async () => {
+  // Non-Error rejections from fs.stat also surface as sanitized PdfErrors.
+  it('should sanitize non-Error exceptions during processing (SSS-02)', async () => {
     const nonError = { message: 'Just an object', code: 'UNEXPECTED' };
-    mockReadFile.mockRejectedValue(nonError); // Simulate error after path resolution
+    mockStat.mockRejectedValue(nonError);
     const args = { sources: [{ path: 'non/error/path' }] };
-    // When all sources fail, handler now throws toolError
     await expect(handler(args)).rejects.toThrow(PdfError);
-    await expect(handler(args)).rejects.toThrow('non/error/path');
+    await expect(handler(args)).rejects.toThrow(/Failed to access file at 'non\/error\/path'/);
   });
 
   it('should include warnings for requested pages exceeding total pages', async () => {
@@ -600,7 +636,9 @@ describe('handleReadPdfFunc Integration Tests', () => {
             num_pages: 3,
             page_texts: [
               { page: 1, text: 'Mock page text 1' },
-              { page: 2, text: 'Error processing page: Failed to get page 2' },
+              // SSS-02: sanitized marker — raw PDF.js text never reaches the
+              // LLM via page content.
+              { page: 2, text: '[Error processing page 2]' },
               { page: 3, text: 'Mock page text 3' },
             ],
           },
@@ -621,30 +659,17 @@ describe('handleReadPdfFunc Integration Tests', () => {
 
   // --- Additional Coverage Tests ---
 
-  it('should throw error if pdfjs fails to load document from URL', async () => {
+  it('should throw a sanitized error if pdfjs fails to load from URL (SSS-02)', async () => {
     const testUrl = 'http://example.com/bad-url.pdf';
-    const loadError = new Error('Mock URL PDF loading failed');
-    const failingLoadingTask = { promise: Promise.reject(loadError) };
-    // Ensure getDocument is mocked specifically for this URL
     mockGetDocument.mockReset();
-    mockGetDocument.mockImplementation((source: unknown) => {
-      if (
-        typeof source === 'object' &&
-        source !== null &&
-        Object.hasOwn(source, 'url') &&
-        typeof (source as { url?: unknown }).url === 'string' &&
-        (source as { url: string }).url === testUrl
-      ) {
-        return failingLoadingTask;
-      }
-      const mockDocumentAPI = { numPages: 1, getMetadata: vi.fn(), getPage: vi.fn() };
-      return { promise: Promise.resolve(mockDocumentAPI) };
-    });
+    mockGetDocument.mockImplementation(() => ({
+      promise: Promise.reject(new Error('Mock URL PDF loading failed /home/runner/secret')),
+    }));
 
     const args = { sources: [{ url: testUrl }] };
-    // When all sources fail, handler now throws toolError
     await expect(handler(args)).rejects.toThrow(PdfError);
-    await expect(handler(args)).rejects.toThrow('Mock URL PDF loading failed');
+    await expect(handler(args)).rejects.toThrow(`Failed to load PDF document from ${testUrl}.`);
+    await expect(handler(args)).rejects.not.toThrow(/home\/runner\/secret/);
   });
 
   it('should not include page count when include_page_count is false', async () => {
@@ -671,7 +696,7 @@ describe('handleReadPdfFunc Integration Tests', () => {
     expect(mockGetMetadata).not.toHaveBeenCalled(); // Because include_metadata is false
   });
 
-  it('should handle ENOENT error where resolvePath also fails in catch block', async () => {
+  it('should handle ENOENT detected by fs.stat (SSS-08 pre-check)', async () => {
     const enoentError = new Error('Mock ENOENT') as NodeJS.ErrnoException;
     enoentError.code = 'ENOENT';
     const targetPath = 'enoent/and/resolve/fails.pdf';
@@ -679,15 +704,16 @@ describe('handleReadPdfFunc Integration Tests', () => {
     // Mock resolvePath to return path as-is
     vi.spyOn(pathUtils, 'resolvePath').mockImplementation((p) => p);
 
-    mockReadFile.mockRejectedValue(enoentError);
+    mockStat.mockRejectedValue(enoentError);
 
     const args = { sources: [{ path: targetPath }] };
-    // When all sources fail, handler now throws toolError
     await expect(handler(args)).rejects.toThrow(PdfError);
     await expect(handler(args)).rejects.toThrow(`File not found at '${targetPath}'`);
 
-    // Ensure readFile was called with the path that resolvePath returned
-    expect(mockReadFile).toHaveBeenCalledWith(targetPath);
+    // The size pre-check runs first; readFile must not be invoked when stat
+    // fails (the whole point of SSS-08's mitigation).
+    expect(mockStat).toHaveBeenCalledWith(targetPath);
+    expect(mockReadFile).not.toHaveBeenCalled();
   });
 
   // --- Additional Error Coverage Tests ---
@@ -1227,16 +1253,17 @@ describe('handleReadPdfFunc Integration Tests', () => {
     expect(imageParts.length).toBe(1);
   });
 
-  it('should handle Error (not PdfError) during processing', async () => {
-    // Mock getDocument to throw a regular Error (not PdfError)
+  it('should handle Error (not PdfError) during processing with sanitized message (SSS-02)', async () => {
     mockGetDocument.mockReturnValue({
-      promise: Promise.reject(new Error('Regular error message')),
+      promise: Promise.reject(new Error('Regular error message /var/host/leak')),
     });
 
     const args = { sources: [{ path: 'error.pdf' }] };
-    // When all sources fail, handler now throws toolError
     await expect(handler(args)).rejects.toThrow(PdfError);
-    await expect(handler(args)).rejects.toThrow('Regular error message');
+    // The wrapping PdfError mentions the source description (safe — user input)
+    // but NOT the raw error message (could carry filesystem internals).
+    await expect(handler(args)).rejects.toThrow(/Failed to load PDF document from error\.pdf/);
+    await expect(handler(args)).rejects.not.toThrow(/var\/host\/leak/);
   });
 
   // --- Table Extraction Tests ---

--- a/test/pathUtils.test.ts
+++ b/test/pathUtils.test.ts
@@ -1,41 +1,55 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { ErrorCode, PdfError } from '../src/utils/errors.js';
 import { PROJECT_ROOT, resolvePath } from '../src/utils/pathUtils.js';
 
+// resolvePath now canonicalizes symlinks (SSS-03). Tests compute expected
+// canonical paths the same way so they don't drift on macOS where /tmp is a
+// symlink to /private/tmp.
+const canonicalize = (p: string): string => {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    const parent = path.dirname(p);
+    if (parent === p) return p;
+    return path.join(canonicalize(parent), path.basename(p));
+  }
+};
+
 describe('resolvePath Utility', () => {
   it('should resolve a valid relative path correctly', () => {
     const userPath = 'some/file.txt';
-    const expectedPath = path.resolve(PROJECT_ROOT, userPath);
+    const expectedPath = canonicalize(path.resolve(PROJECT_ROOT, userPath));
     expect(resolvePath(userPath)).toBe(expectedPath);
   });
 
   it('should resolve paths with "." correctly', () => {
     const userPath = './some/./other/file.txt';
-    const expectedPath = path.resolve(PROJECT_ROOT, 'some/other/file.txt');
+    const expectedPath = canonicalize(path.resolve(PROJECT_ROOT, 'some/other/file.txt'));
     expect(resolvePath(userPath)).toBe(expectedPath);
   });
 
   it('should resolve paths with ".." correctly', () => {
     const userPath = 'some/folder/../other/file.txt';
-    const expectedPath = path.resolve(PROJECT_ROOT, 'some/other/file.txt');
+    const expectedPath = canonicalize(path.resolve(PROJECT_ROOT, 'some/other/file.txt'));
     expect(resolvePath(userPath)).toBe(expectedPath);
   });
 
   it('should resolve relative paths that go outside PROJECT_ROOT', () => {
     const userPath = '../outside/file.txt';
     const result = resolvePath(userPath);
-    expect(result).toBe(path.resolve(PROJECT_ROOT, userPath));
+    expect(result).toBe(canonicalize(path.resolve(PROJECT_ROOT, userPath)));
   });
 
-  it('should accept absolute paths and return them normalized', () => {
+  it('should accept absolute paths and return them canonicalized', () => {
     const userPath = path.resolve(PROJECT_ROOT, 'absolute/file.txt');
-    expect(resolvePath(userPath)).toBe(path.normalize(userPath));
+    expect(resolvePath(userPath)).toBe(canonicalize(userPath));
   });
 
   it('should accept any absolute path', () => {
     const absolutePath = path.sep === '/' ? '/etc/passwd' : 'C:\\Windows\\System32\\config.txt';
-    expect(resolvePath(absolutePath)).toBe(path.normalize(absolutePath));
+    expect(resolvePath(absolutePath)).toBe(canonicalize(absolutePath));
   });
 
   it('should throw PdfError for non-string input', () => {
@@ -52,7 +66,7 @@ describe('resolvePath Utility', () => {
 
   it('should handle empty string input', () => {
     const userPath = '';
-    const expectedPath = path.resolve(PROJECT_ROOT, '');
+    const expectedPath = canonicalize(path.resolve(PROJECT_ROOT, ''));
     expect(resolvePath(userPath)).toBe(expectedPath);
   });
 });

--- a/test/pdf/extractor.test.ts
+++ b/test/pdf/extractor.test.ts
@@ -153,26 +153,27 @@ describe('extractor', () => {
       ]);
     });
 
-    it('should handle page extraction errors gracefully', async () => {
+    it('should handle page extraction errors gracefully with a sanitized marker (SSS-02)', async () => {
       const mockDocument = {
-        getPage: vi.fn().mockRejectedValue(new Error('Failed to get page')),
+        getPage: vi.fn().mockRejectedValue(new Error('Failed to get page /private/leak')),
       } as unknown as pdfjsLib.PDFDocumentProxy;
 
       const result = await extractPageTexts(mockDocument, [1], 'test.pdf');
 
-      expect(result).toEqual([{ page: 1, text: 'Error processing page: Failed to get page' }]);
-      // Logger outputs message first, then structured JSON
+      // The page-text payload returned to the LLM must carry only the
+      // sanitized marker — the raw error text stays in logs.
+      expect(result).toEqual([{ page: 1, text: '[Error processing page 1]' }]);
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('Error getting text content for page'));
     });
 
-    it('should handle non-Error page exceptions', async () => {
+    it('should handle non-Error page exceptions with a sanitized marker (SSS-02)', async () => {
       const mockDocument = {
         getPage: vi.fn().mockRejectedValue('String error'),
       } as unknown as pdfjsLib.PDFDocumentProxy;
 
       const result = await extractPageTexts(mockDocument, [1], 'test.pdf');
 
-      expect(result).toEqual([{ page: 1, text: 'Error processing page: String error' }]);
+      expect(result).toEqual([{ page: 1, text: '[Error processing page 1]' }]);
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('String error'));
     });
 

--- a/test/pdf/loader.test.ts
+++ b/test/pdf/loader.test.ts
@@ -1,13 +1,15 @@
 import fs from 'node:fs/promises';
 import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.mjs';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { loadPdfDocument } from '../../src/pdf/loader.js';
+import { __resetSecurityConfigForTests } from '../../src/utils/config.js';
 import { ErrorCode, PdfError } from '../../src/utils/errors.js';
 import * as pathUtils from '../../src/utils/pathUtils.js';
 
 vi.mock('node:fs/promises', () => ({
   default: {
     readFile: vi.fn(),
+    stat: vi.fn(),
   },
 }));
 
@@ -19,13 +21,45 @@ vi.mock('../../src/utils/pathUtils.js', () => ({
   resolvePath: vi.fn(),
 }));
 
+const buildStats = (size: number) =>
+  ({
+    size,
+    isFile: () => true,
+    isDirectory: () => false,
+  }) as unknown as Awaited<ReturnType<typeof fs.stat>>;
+
+const buildResponse = (
+  body: Uint8Array,
+  init: { status?: number; headers?: Record<string, string> } = {}
+): Response => {
+  const headers = new Headers(init.headers);
+  if (!headers.has('content-length')) headers.set('content-length', String(body.byteLength));
+  const response = new Response(body, { status: init.status ?? 200, headers });
+  // jsdom's Response sometimes lacks redirect handling under bun; rely on
+  // the global Response which `fetch` returns in Node 22.
+  return response;
+};
+
+let originalFetch: typeof globalThis.fetch;
+
 describe('loader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalFetch = globalThis.fetch;
+    __resetSecurityConfigForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
   describe('loadPdfDocument', () => {
     it('should load PDF from local file path', async () => {
       const mockBuffer = Buffer.from('fake pdf content');
       const mockDocument = { numPages: 5 };
 
       pathUtils.resolvePath.mockReturnValue('/safe/path/test.pdf');
+      fs.stat.mockResolvedValue(buildStats(mockBuffer.length));
       fs.readFile.mockResolvedValue(mockBuffer);
       pdfjsLib.getDocument.mockReturnValue({
         promise: Promise.resolve(mockDocument as unknown as pdfjsLib.PDFDocumentProxy),
@@ -35,11 +69,26 @@ describe('loader', () => {
 
       expect(result).toBe(mockDocument);
       expect(pathUtils.resolvePath).toHaveBeenCalledWith('test.pdf');
+      expect(fs.stat).toHaveBeenCalledWith('/safe/path/test.pdf');
       expect(fs.readFile).toHaveBeenCalledWith('/safe/path/test.pdf');
     });
 
-    it('should load PDF from URL', async () => {
+    it('should reject oversized files via fs.stat before buffering (SSS-08)', async () => {
+      pathUtils.resolvePath.mockReturnValue('/safe/path/huge.pdf');
+      // 200MB > 100MB cap
+      fs.stat.mockResolvedValue(buildStats(200 * 1024 * 1024));
+
+      await expect(loadPdfDocument({ path: 'huge.pdf' }, 'huge.pdf')).rejects.toThrow(/exceeds maximum size/i);
+      // Crucially, fs.readFile must NOT be called — the whole point of the
+      // pre-check is to avoid buffering oversized data.
+      expect(fs.readFile).not.toHaveBeenCalled();
+    });
+
+    it('should load PDF from URL via fetch (not pdfjs URL loader)', async () => {
+      const body = new TextEncoder().encode('mock pdf body');
       const mockDocument = { numPages: 3 };
+      const fetchMock = vi.fn().mockResolvedValue(buildResponse(body));
+      globalThis.fetch = fetchMock as typeof globalThis.fetch;
 
       pdfjsLib.getDocument.mockReturnValue({
         promise: Promise.resolve(mockDocument as unknown as pdfjsLib.PDFDocumentProxy),
@@ -48,14 +97,40 @@ describe('loader', () => {
       const result = await loadPdfDocument({ url: 'https://example.com/test.pdf' }, 'https://example.com/test.pdf');
 
       expect(result).toBe(mockDocument);
-      expect(pdfjsLib.getDocument).toHaveBeenCalledWith({
-        cMapUrl: expect.stringContaining('pdfjs-dist') && expect.stringContaining('cmaps'),
-        cMapPacked: true,
-        standardFontDataUrl: expect.stringContaining('pdfjs-dist') && expect.stringContaining('standard_fonts'),
-        wasmUrl: expect.stringContaining('pdfjs-dist') && expect.stringContaining('wasm'),
-        iccUrl: expect.stringContaining('pdfjs-dist') && expect.stringContaining('iccs'),
-        url: 'https://example.com/test.pdf',
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://example.com/test.pdf',
+        expect.objectContaining({ redirect: 'manual' })
+      );
+      // pdfjs now receives the body as `data`, not a `url`, so we control
+      // size limits and SSRF policy ourselves.
+      const opts = pdfjsLib.getDocument.mock.calls[0]?.[0] as { data: Uint8Array; url?: string };
+      expect(opts.url).toBeUndefined();
+      expect(opts.data).toBeInstanceOf(Uint8Array);
+    });
+
+    it('should reject URLs that resolve to private IPs (SSS-07)', async () => {
+      // 169.254.169.254 is the AWS/GCP metadata endpoint; literal-IP hostname
+      // is checked without DNS so the test stays hermetic.
+      globalThis.fetch = vi.fn() as typeof globalThis.fetch;
+
+      await expect(
+        loadPdfDocument({ url: 'http://169.254.169.254/latest/meta-data/' }, 'http://169.254.169.254/')
+      ).rejects.toThrow(/non-public address|SSRF/);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should reject URL responses whose Content-Length exceeds the cap (SSS-08)', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(new Uint8Array(0), {
+          status: 200,
+          headers: { 'content-length': String(200 * 1024 * 1024) },
+        })
+      );
+      globalThis.fetch = fetchMock as typeof globalThis.fetch;
+
+      await expect(
+        loadPdfDocument({ url: 'https://example.com/huge.pdf' }, 'https://example.com/huge.pdf')
+      ).rejects.toThrow(/exceeds maximum size/i);
     });
 
     // Regression test for https://github.com/SylphxAI/pdf-reader-mcp/issues/271
@@ -70,6 +145,7 @@ describe('loader', () => {
 
       pdfjsLib.getDocument.mockClear();
       pathUtils.resolvePath.mockReturnValue('/safe/path/test.pdf');
+      fs.stat.mockResolvedValue(buildStats(mockBuffer.length));
       fs.readFile.mockResolvedValue(mockBuffer);
       pdfjsLib.getDocument.mockReturnValue({
         promise: Promise.resolve(mockDocument as unknown as pdfjsLib.PDFDocumentProxy),
@@ -121,7 +197,7 @@ describe('loader', () => {
       const enoentError = Object.assign(new Error('File not found'), { code: 'ENOENT' });
 
       pathUtils.resolvePath.mockReturnValue('/safe/path/missing.pdf');
-      fs.readFile.mockRejectedValue(enoentError);
+      fs.stat.mockRejectedValue(enoentError);
 
       await expect(loadPdfDocument({ path: 'missing.pdf' }, 'missing.pdf')).rejects.toThrow(PdfError);
       await expect(loadPdfDocument({ path: 'missing.pdf' }, 'missing.pdf')).rejects.toThrow(
@@ -129,41 +205,50 @@ describe('loader', () => {
       );
     });
 
-    it('should handle generic file read errors', async () => {
+    it('should handle generic file stat errors with a sanitized message (SSS-02)', async () => {
       pathUtils.resolvePath.mockReturnValue('/safe/path/error.pdf');
-      fs.readFile.mockRejectedValue(new Error('Permission denied'));
+      // EACCES (permission denied) should not leak the underlying message
+      // verbatim — the LLM-facing string must not contain "Permission denied".
+      fs.stat.mockRejectedValue(Object.assign(new Error('Permission denied'), { code: 'EACCES' }));
 
       await expect(loadPdfDocument({ path: 'error.pdf' }, 'error.pdf')).rejects.toThrow(PdfError);
-      await expect(loadPdfDocument({ path: 'error.pdf' }, 'error.pdf')).rejects.toThrow(
-        'Failed to prepare PDF source error.pdf. Reason: Permission denied'
-      );
+      await expect(loadPdfDocument({ path: 'error.pdf' }, 'error.pdf')).rejects.toThrow(/Failed to access file/);
+      await expect(loadPdfDocument({ path: 'error.pdf' }, 'error.pdf')).rejects.not.toThrow(/Permission denied/);
     });
 
-    it('should handle non-Error exceptions during file read', async () => {
-      pathUtils.resolvePath.mockReturnValue('/safe/path/test.pdf');
-      fs.readFile.mockRejectedValue('String error');
+    it('should reject non-regular files such as directories', async () => {
+      pathUtils.resolvePath.mockReturnValue('/safe/path/dir');
+      fs.stat.mockResolvedValue({
+        size: 4096,
+        isFile: () => false,
+        isDirectory: () => true,
+      } as unknown as Awaited<ReturnType<typeof fs.stat>>);
 
-      await expect(loadPdfDocument({ path: 'test.pdf' }, 'test.pdf')).rejects.toThrow(
-        'Failed to prepare PDF source test.pdf. Reason: String error'
-      );
+      await expect(loadPdfDocument({ path: 'dir' }, 'dir')).rejects.toThrow(/not a regular file/);
     });
 
-    it('should handle PDF.js loading errors', async () => {
+    it('should handle PDF.js loading errors without leaking the raw message (SSS-02)', async () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       const mockBuffer = Buffer.from('fake pdf');
 
       pathUtils.resolvePath.mockReturnValue('/safe/path/bad.pdf');
+      fs.stat.mockResolvedValue(buildStats(mockBuffer.length));
       fs.readFile.mockResolvedValue(mockBuffer);
-      pdfjsLib.getDocument.mockReturnValue({
-        promise: Promise.reject(new Error('Invalid PDF')),
-      } as pdfjsLib.PDFDocumentLoadingTask);
+      pdfjsLib.getDocument.mockImplementation(
+        () =>
+          ({
+            promise: Promise.reject(new Error('Invalid PDF /private/internal/path.bin')),
+          }) as pdfjsLib.PDFDocumentLoadingTask
+      );
 
       await expect(loadPdfDocument({ path: 'bad.pdf' }, 'bad.pdf')).rejects.toThrow(PdfError);
       await expect(loadPdfDocument({ path: 'bad.pdf' }, 'bad.pdf')).rejects.toThrow(
-        'Failed to load PDF document from bad.pdf. Reason: Invalid PDF'
+        'Failed to load PDF document from bad.pdf.'
       );
+      // The internal path must NOT make it into the surfaced error.
+      await expect(loadPdfDocument({ path: 'bad.pdf' }, 'bad.pdf')).rejects.not.toThrow(/private\/internal/);
 
-      // Logger outputs message first, then structured JSON
+      // Logger still records the raw details for operators.
       expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('PDF.js loading error'));
 
       consoleErrorSpy.mockRestore();
@@ -172,9 +257,15 @@ describe('loader', () => {
     it('should handle non-Error PDF.js loading exceptions', async () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-      pdfjsLib.getDocument.mockReturnValue({
-        promise: Promise.reject('Unknown error'),
-      } as pdfjsLib.PDFDocumentLoadingTask);
+      const body = new TextEncoder().encode('pdf body');
+      globalThis.fetch = vi.fn().mockImplementation(async () => buildResponse(body)) as typeof globalThis.fetch;
+
+      // Build the rejected promise lazily inside mockImplementation so each
+      // call gets a fresh rejection without leaving an unhandled one parked
+      // at test-setup time.
+      pdfjsLib.getDocument.mockImplementation(
+        () => ({ promise: Promise.reject('Unknown error') }) as pdfjsLib.PDFDocumentLoadingTask
+      );
 
       await expect(
         loadPdfDocument({ url: 'https://example.com/bad.pdf' }, 'https://example.com/bad.pdf')
@@ -190,35 +281,6 @@ describe('loader', () => {
       });
 
       await expect(loadPdfDocument({ path: 'test.pdf' }, 'test.pdf')).rejects.toThrow(pdfError);
-    });
-
-    it('should use fallback message when PDF.js error message is empty', async () => {
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-      pdfjsLib.getDocument.mockReturnValue({
-        promise: Promise.reject(new Error('')),
-      } as pdfjsLib.PDFDocumentLoadingTask);
-
-      await expect(
-        loadPdfDocument({ url: 'https://example.com/bad.pdf' }, 'https://example.com/bad.pdf')
-      ).rejects.toThrow('Unknown loading error');
-
-      consoleErrorSpy.mockRestore();
-    });
-
-    it('should handle non-Error exception during file read with cause undefined', async () => {
-      pathUtils.resolvePath.mockReturnValue('/safe/path/test.pdf');
-      const nonErrorObject = { code: 'SOME_ERROR' };
-      fs.readFile.mockRejectedValue(nonErrorObject);
-
-      try {
-        await loadPdfDocument({ path: 'test.pdf' }, 'test.pdf');
-        expect.fail('Should have thrown');
-      } catch (error) {
-        expect(error).toBeInstanceOf(PdfError);
-        // Verify that cause is undefined when error is not an Error instance
-        expect((error as PdfError).cause).toBeUndefined();
-      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #279. Patches all seven findings from the SSS audit:

| Finding | Severity | Fix |
| --- | --- | --- |
| SSS-03 — symlink escape from `--allow-dir` | Critical | `resolvePath()` canonicalizes user paths via `fs.realpathSync` (walking up to the deepest existing ancestor for non-existent files), and allowlisted dirs are canonicalized at config-load time so the comparison aligns even when paths like `/tmp` are themselves symlinks. |
| SSS-07 — SSRF via private/loopback/metadata URLs | High | New `assertUrlNotPrivate()` DNS-resolves URL hosts with `{ all: true }` and blocks any A/AAAA record in RFC1918, loopback, link-local, CGNAT, multicast, or IPv4-mapped-IPv6 ranges. Operators can opt out for local testing via `--allow-private-ips` / `MCP_PDF_ALLOW_PRIVATE_IPS=true`. |
| SSS-08 — file fully buffered before size check | Medium | `loadLocalFile()` now `fs.stat`'s first and rejects oversized files before `readFile`. |
| SSS-08 — URL fetch unbounded | Medium | URLs are fetched through `fetch()` with an `AbortSignal`-backed 30s timeout, `Content-Length` cap, streaming size accumulator, and manual redirect re-validation (each hop is re-checked against the SSRF policy). PDF.js receives `data:` rather than a URL so all resource limits apply at the application layer. |
| SSS-02 — raw `error.message` leak in `readPdf.ts` catch | Medium | Only curated `PdfError` messages surface; non-`PdfError` exceptions are logged with full detail but wrapped in a generic message. |
| SSS-02 — raw error text returned as page text in `extractSinglePageText` | Medium | Returns sanitized `[Error processing page N]`; raw text stays in logs. |
| SSS-02 — raw error text returned as page content in `extractPageContent` | Medium | Same sanitized marker pattern. |

### New config knobs

- `--allow-private-ips` / `MCP_PDF_ALLOW_PRIVATE_IPS=true` — opt back into private-IP URL fetches (off by default).

### Behavior changes worth flagging to consumers

- URL sources are fetched by the server itself now (not delegated to PDF.js's URL loader); responses larger than 100MB or that hang past 30s are rejected at the application layer.
- Returned `path` values from `resolvePath()` are now canonicalized (symlinks resolved). Downstream code that diff'd against the user-provided string would see the real path instead.
- Error messages returned to the LLM no longer include underlying PDF.js / Node text. Operators relying on those messages for debugging should consult the structured logs (`PDF.js loading error`, etc.).

## Test plan

- [x] `bun test` — 166 pass / 7 skip / 0 fail (added ~15 new tests covering symlink escape, private-IP rejection, content-length cap, streaming size cap, error sanitization).
- [x] `bun run typecheck`
- [x] `bun run lint`
- [ ] Manual: run with `--allow-dir=$(pwd)` and a symlink inside that escapes; verify the rejection.
- [ ] Manual: request `http://169.254.169.254/...` against the running server; verify the SSRF guard fires.
- [ ] Manual: request a >100MB URL; verify Content-Length / streaming caps fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)