### PR TITLE
chore: migrate sylphx.json to sylphx.toml

### DIFF
--- a/sylphx.json
+++ b/sylphx.json
@@ -1,4 +1,0 @@
-{
-  "buildDir": "docs",
-  "framework": "static"
-}

--- a/sylphx.toml
+++ b/sylphx.toml
@@ -1,0 +1,16 @@
+version = "1"
+
+[project]
+name = "@sylphx/pdf-reader-mcp"
+slug = "pdf-reader-mcp"
+org = "sylphx"
+
+[build]
+strategy = "auto"
+context = "docs"
+
+[[services]]
+name = "web"
+type = "web"
+port = 80
+watch_paths = ["docs/**"]


### PR DESCRIPTION
## Summary

Switches the Sylphx Platform build config from the legacy \`sylphx.json\` shape (\`buildDir\`, \`framework\`) to the current \`sylphx.toml\` schema with explicit \`[project]\`, \`[build]\`, and \`[[services]]\` sections.

Behavior preserved:
- Build context: \`docs\`
- Web service on port 80
- Watches \`docs/**\`

## Test plan

- [ ] Sylphx Platform redeploys docs successfully after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)