### PR TITLE
ci: fix self-hosted runner label + drop unused Vercel config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   validate:
     name: Validate Code Quality
-    runs-on: [self-hosted, sylphx, linux, standard]
+    runs-on: [self-hosted, sylphx-linux-standard]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![License](https://img.shields.io/badge/License-MIT-blue?style=flat-square)](https://opensource.org/licenses/MIT)
 [![CI/CD](https://img.shields.io/github/actions/workflow/status/SylphxAI/pdf-reader-mcp/ci.yml?style=flat-square&label=CI/CD)](https://github.com/SylphxAI/pdf-reader-mcp/actions/workflows/ci.yml)
 [![codecov](https://img.shields.io/codecov/c/github/SylphxAI/pdf-reader-mcp?style=flat-square)](https://codecov.io/gh/SylphxAI/pdf-reader-mcp)
-[![coverage](https://img.shields.io/badge/coverage-94.17%25-brightgreen?style=flat-square)](https://pdf-reader-msu3esos4-sylphx.vercel.app)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.0-blue.svg?style=flat-square)](https://www.typescriptlang.org/)
 [![Downloads](https://img.shields.io/npm/dm/@sylphx/pdf-reader-mcp?style=flat-square)](https://www.npmjs.com/package/@sylphx/pdf-reader-mcp)
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "npx vitepress build docs",
-  "installCommand": "bun install",
-  "outputDirectory": "docs/.vitepress/dist"
-}


### PR DESCRIPTION
## Summary

CI jobs on this repo have been **queueing indefinitely** — no `ci.yml` run has completed since 2026-02-16. Root cause: commit [`e8d3edd`](https://github.com/SylphxAI/pdf-reader-mcp/commit/e8d3edd) ("migrate to flat runner labels") expanded the ARC v2 scale-set name into four separate label tokens:

```yaml
runs-on: [self-hosted, sylphx, linux, standard]   # ❌ no runner has all four
```

ARC v2 scale sets register under a **single** hyphenated label (the scale-set name), so this never matches and every job sits in `queued` forever. Confirmed against working Sylphx repos:

| Repo | `runs-on` | CI |
| --- | --- | --- |
| spiron | `[self-hosted, sylphx-linux-standard]` | ✅ passing |
| sylphx-ai | `sylphx-linux-standard` | ✅ passing |
| **pdf-reader-mcp (before)** | `[self-hosted, sylphx, linux, standard]` | ❌ queued |

This PR restores `runs-on: [self-hosted, sylphx-linux-standard]` to match `spiron`.

## Also: drop unused Vercel config

We no longer use Vercel (docs hosting moved to the Sylphx Platform via `sylphx.toml`). This removes:
- `vercel.json` (vitepress build config for Vercel)
- The stale README coverage badge that linked to a dead `*.vercel.app` URL (the codecov badge already covers coverage)

> ⚠️ **Follow-up not doable from the repo:** the failing **Vercel** commit-status check comes from the Vercel **GitHub App** integration. To stop it entirely, disconnect the Vercel project / Git integration in the Vercel dashboard (or uninstall the Vercel GitHub App for this repo). Removing `vercel.json` alone won't stop the App from posting statuses.

## Test plan

- [x] Label matches the proven-working `spiron` config.
- [ ] This PR's own `Validate Code Quality` check should now get picked up by a JIT runner and run to completion (the real proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)