### PR TITLE
fix: require node >=22.13.0 to match pdfjs-dist v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,7 +737,7 @@ CMD ["bun", "node_modules/@sylphx/pdf-reader-mcp/dist/index.js"]
 <br/>
 
 **Prerequisites:**
-- Node.js >= 22.0.0
+- Node.js >= 22.13.0 (required by pdfjs-dist v6)
 - Bun (this repo uses `bun@1.3.1`)
 
 **Setup:**

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.13.0"
   },
   "repository": {
     "type": "git",

--- a/test/integration/mcp-server.test.ts
+++ b/test/integration/mcp-server.test.ts
@@ -21,7 +21,12 @@ const sendMessage = (proc: ChildProcess, message: object): void => {
   proc.stdin?.write(`${json}\n`);
 };
 
-const readResponse = (proc: ChildProcess, timeout = 5000): Promise<unknown> => {
+// Generous per-request timeout: the server spawns a fresh `bun dist/index.js`
+// whose module graph eagerly imports pdfjs-dist (worker + wasm + cmaps). On a
+// cold, loaded CI runner that first import can take several seconds, so 5s was
+// flaky. This is a test-harness tolerance, not a product latency budget — a
+// long-running MCP server pays the import cost once at startup.
+const readResponse = (proc: ChildProcess, timeout = 15000): Promise<unknown> => {
   return new Promise((resolve, reject) => {
     let buffer = '';
     const timer = setTimeout(() => {
@@ -65,8 +70,11 @@ describe('MCP Server Integration', () => {
       env: { ...process.env, NODE_ENV: 'test' },
     });
 
-    // Wait a bit for server to start
-    await new Promise((r) => setTimeout(r, 500));
+    // Wait for the server to boot. The module graph eagerly imports
+    // pdfjs-dist, so cold startup on a loaded CI runner can exceed a few
+    // hundred ms — give it headroom before the first request to avoid a
+    // race where `initialize` is sent before stdin is wired up.
+    await new Promise((r) => setTimeout(r, 2500));
   });
 
   afterAll(() => {


### PR DESCRIPTION
## Summary

pdfjs-dist v6 (merged in #287) declares `engines.node: ">=22.13.0 || >=24"`, but our `package.json` still claimed `">=22.0.0"`. A consumer on node 22.0–22.12 would `npm install` cleanly (npm `engines` is advisory by default) yet hit runtime failures inside pdf.js. This aligns our constraint — and the README prerequisite — with the dependency's real requirement.

Committed as `fix:` so the bump bot cuts a release: the pdfjs-dist v6 upgrade landed as `chore(deps)` in #287, which doesn't trigger a version bump on its own, so it's currently sitting on `main` unpublished. This PR releases it to npm.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun test` — 166 pass / 0 fail
- [ ] CI green → bump bot opens release PR → npm gets pdfjs v6