### PR TITLE
ci: use supported Bun version for release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.1'
+          bun-version: '1.3.12'
 
       - name: Install dependencies
         run: |
@@ -34,6 +34,9 @@ jobs:
 
       - name: Check Code Quality (Biome)
         run: bun run check
+
+      - name: Build package
+        run: bun run build
 
       - name: Run Tests and Check Coverage
         run: bun run test:cov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.1'
+          bun-version: '1.3.12'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -97,5 +97,5 @@
     "typescript": "^6.0.3",
     "vitepress": "^1.6.4"
   },
-  "packageManager": "bun@1.3.1"
+  "packageManager": "bun@1.3.12"
 }


### PR DESCRIPTION
## Summary

Fixes the first real failure after moving Release from startup failure to executable Changesets workflow.

- Updates CI and Release from Bun 1.3.1 to Bun 1.3.12.
- Aligns `packageManager` with the Bun version used locally and in workflows.
- Adds `bun run build` to CI so build-tool/runtime version regressions fail before release.

## Root cause

The Changesets Release workflow reached the `Build package` step but failed because `bunup@0.16.31` requires Bun `>=1.3.6`, while the workflow pinned Bun `1.3.1`.

## Validation

- `git diff --check`
- `bun run build`
- `bun run typecheck`
- `bun changeset status --since=HEAD~1` — pending minor release still detected for `@sylphx/pdf-reader-mcp`
- `bun run validate` — 183 pass / 7 skip / 0 fail
