### PR TITLE
chore(release): version package

### DIFF
--- a/.changeset/clear-rules.md
+++ b/.changeset/clear-rules.md
@@ -1,5 +1,0 @@
----
-"@sylphx/pdf-reader-mcp": patch
----
-
-Remove the internal Doctor and Lefthook release gate so the project relies on Changesets, CI, and explicit package scripts for release validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.5.1
+
+### Patch Changes
+
+- [#300](https://github.com/SylphxAI/pdf-reader-mcp/pull/300) [`8cdb556`](https://github.com/SylphxAI/pdf-reader-mcp/commit/8cdb556c9de1f25bcd24b00acb00cd5d3ad42113) Thanks [@shtse8](https://github.com/shtse8)! - Remove the internal Doctor and Lefthook release gate so the project relies on Changesets, CI, and explicit package scripts for release validation.
+
 ## 2.5.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "An MCP server providing tools to read PDF files.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Version `@sylphx/pdf-reader-mcp` to `2.5.1`
- Move the Doctor/Lefthook removal note into the changelog
- Remove the consumed Changeset file

## Validation
- `bun audit`
- `bun run build`
- `bun run typecheck`
- `bun run check`
- `bun run validate`
- `bun run docs:build`
- `bun run prepublishOnly`
- `bun run test:cov`

## Notes
This is the manual Changesets version PR because the repository Actions setting still prevents GitHub Actions from creating pull requests.