### PR TITLE
docs: polish release wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- [#300](https://github.com/SylphxAI/pdf-reader-mcp/pull/300) [`8cdb556`](https://github.com/SylphxAI/pdf-reader-mcp/commit/8cdb556c9de1f25bcd24b00acb00cd5d3ad42113) Thanks [@shtse8](https://github.com/shtse8)! - Remove the internal Doctor and Lefthook release gate so the project relies on Changesets, CI, and explicit package scripts for release validation.
+- [#300](https://github.com/SylphxAI/pdf-reader-mcp/pull/300) [`8cdb556`](https://github.com/SylphxAI/pdf-reader-mcp/commit/8cdb556c9de1f25bcd24b00acb00cd5d3ad42113) Thanks [@shtse8](https://github.com/shtse8)! - Streamline release validation around Changesets, CI, and explicit package scripts for a clearer published package workflow.
 
 ## 2.5.0
 


### PR DESCRIPTION
## Summary
- Polish the v2.5.1 changelog entry so public release wording stays product-neutral
- Keep the release validation change described without internal tool names

## Validation
- bun run check
- git diff --check