### PR TITLE
ci: clean optional coverage uploads

### DIFF
--- a/.changeset/ci-coverage-upload.md
+++ b/.changeset/ci-coverage-upload.md
@@ -1,0 +1,5 @@
+---
+"@sylphx/pdf-reader-mcp": patch
+---
+
+Refresh CI coverage upload handling so release validation skips missing optional reports cleanly and uses the supported Codecov action path for test-result uploads.

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - sylphx-linux-standard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,30 @@ jobs:
       - name: Run Tests and Check Coverage
         run: bun run test:cov
 
+      - name: Detect coverage reports
+        id: coverage
+        shell: bash
+        run: |
+          if [[ -d coverage ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [[ -f coverage/lcov.info ]]; then
+            echo "lcov=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "lcov=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if compgen -G "coverage/*.xml" > /dev/null; then
+            echo "test_results=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "test_results=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload coverage to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.coverage.outputs.lcov == 'true' }}
         continue-on-error: true
         uses: codecov/codecov-action@v6.0.1
         with:
@@ -51,13 +73,17 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.coverage.outputs.test_results == 'true' }}
         continue-on-error: true
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/*.xml
+          report_type: test_results
+          fail_ci_if_error: false
 
       - name: Upload coverage reports
+        if: ${{ !cancelled() && steps.coverage.outputs.available == 'true' }}
         uses: actions/upload-artifact@v7.0.1
         with:
           name: coverage-report


### PR DESCRIPTION
## Summary
- Skip optional Codecov uploads when Bun does not emit coverage files
- Replace deprecated Codecov test-results action with the supported Codecov action path
- Add actionlint config for the repository self-hosted runner label
- Add a patch changeset so the Release workflow can verify automatic Changesets PR creation

## Validation
- actionlint .github/workflows/ci.yml .github/workflows/release.yml
- bun run check
- bun run build
- bun run typecheck
- bun run test:cov
- bun changeset status
- git diff --check