### PR TITLE
ci: use release bot app token

### DIFF
--- a/.changeset/release-bot-token.md
+++ b/.changeset/release-bot-token.md
@@ -1,0 +1,5 @@
+---
+"@sylphx/pdf-reader-mcp": patch
+---
+
+Use a scoped release bot token for automated Changesets release pull requests and publishing.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,19 +8,27 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
     steps:
+      - name: Create release bot token
+        id: release-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Checkout repository
         uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ steps.release-token.outputs.token }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -43,6 +51,7 @@ jobs:
           commit: 'chore(release): version packages'
           createGithubReleases: true
           commitMode: github-api
+          github-token: ${{ steps.release-token.outputs.token }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.release-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Store release automation intent in a patch changeset
- Generate a scoped GitHub App installation token for the Release workflow
- Use that token for checkout and Changesets PR/release operations
- Reduce the workflow GITHUB_TOKEN to read-only contents access

## Validation
- actionlint .github/workflows/release.yml .github/workflows/ci.yml
- bun changeset status
- bun run check
- bun run build
- git diff --check

## Secret handling
- RELEASE_APP_ID repo variable set
- RELEASE_APP_PRIVATE_KEY repo secret set from local PEM without printing the secret
- Installation token checked locally against SylphxAI/pdf-reader-mcp with contents/pull_requests write request