### PR TITLE
ci: use release app client id

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,8 @@
 self-hosted-runner:
   labels:
     - sylphx-linux-standard
+paths:
+  .github/workflows/release.yml:
+    ignore:
+      - 'missing input "app-id" which is required by action "actions/create-github-app-token@v3"'
+      - 'input "client-id" is not defined in action "actions/create-github-app-token@v3"'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         id: release-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write


### PR DESCRIPTION
## Summary
- Use the release bot Client ID for actions/create-github-app-token@v3
- Keep actionlint clean while its action metadata still flags client-id as unknown
- Remove the now-unused RELEASE_APP_ID repo variable; RELEASE_APP_CLIENT_ID remains the source of truth

## Validation
- actionlint .github/workflows/release.yml .github/workflows/ci.yml
- bun run check
- git diff --check