### PR TITLE
[codex] add agent-native PDF inspection

### DIFF
--- a/.changeset/agent-native-pdf-inspection.md
+++ b/.changeset/agent-native-pdf-inspection.md
@@ -1,0 +1,5 @@
+---
+"@sylphx/pdf-reader-mcp": patch
+---
+
+Add an `inspect_pdf` MCP tool that profiles PDFs before extraction, recommends `read_pdf` arguments, and flags likely OCR needs without adding heavy default dependencies.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg?style=flat-square)](https://www.typescriptlang.org/)
 [![Downloads](https://img.shields.io/npm/dm/@sylphx/pdf-reader-mcp?style=flat-square)](https://www.npmjs.com/package/@sylphx/pdf-reader-mcp)
 
-**5-10x faster parallel processing** • **Structured element output** • **Semantic citation chunks** • **CI-backed quality**
+**PDF inspection** • **Structured element output** • **Semantic citation chunks** • **Local-first MCP**
 
 <a href="https://mseep.ai/app/SylphxAI-pdf-reader-mcp">
 <img src="https://mseep.net/pr/SylphxAI-pdf-reader-mcp-badge.png" alt="Security Validated" width="200"/>
@@ -23,7 +23,7 @@
 
 ## 🚀 Overview
 
-PDF Reader MCP is a **production-ready** Model Context Protocol server that empowers AI agents with **structured, local-first PDF processing capabilities**. Extract text, Markdown, semantic citation chunks, images, tables, annotations, outlines, structure trees, form fields, attachment metadata, and agent-ready document elements with strong performance and reliability.
+PDF Reader MCP is a **production-ready** Model Context Protocol server that empowers AI agents with **structured, local-first PDF processing capabilities**. Inspect PDFs before extraction, then extract text, Markdown, semantic citation chunks, images, tables, annotations, outlines, structure trees, form fields, attachment metadata, and agent-ready document elements with strong performance and reliability.
 
 **The Problem:**
 ```typescript
@@ -37,6 +37,7 @@ PDF Reader MCP is a **production-ready** Model Context Protocol server that empo
 **The Solution:**
 ```typescript
 // PDF Reader MCP
+- Preflight PDF inspection for agent extraction planning 🔎
 - 5-10x faster parallel processing ⚡
 - Structured element output for agent workflows 🧩
 - Markdown rendering for RAG and summarization 📝
@@ -64,6 +65,7 @@ PDF Reader MCP is a **production-ready** Model Context Protocol server that empo
 ### Developer Experience
 
 - 🎯 **Path Flexibility** - Absolute & relative paths, Windows/Unix support (v1.3.0)
+- 🔎 **PDF Inspection** - Profile PDFs before extraction and get recommended `read_pdf` arguments for agent workflows
 - 🧩 **Structured Elements** - Optional page-level elements with stable IDs, provenance, and best-effort bounding boxes
 - 📝 **Markdown Rendering** - Optional page-aware Markdown for RAG, summarization, and agent context
 - 🔗 **Citation Chunks** - Optional page, semantic, size, and table chunks with element IDs and best-effort bounding boxes
@@ -71,7 +73,7 @@ PDF Reader MCP is a **production-ready** Model Context Protocol server that empo
 - 🖼️ **Smart Ordering** - Column-aware content ordering improves natural reading flow
 - 🛡️ **Type Safe** - Full TypeScript with strict mode enabled
 - 📚 **Battle-tested** - Automated tests, strict TypeScript, and CI validation
-- 🎨 **Simple API** - Single tool handles all operations elegantly
+- 🎨 **Simple API** - `inspect_pdf` plans extraction, `read_pdf` performs extraction
 
 ---
 
@@ -201,6 +203,29 @@ npm install -g @sylphx/pdf-reader-mcp
 ---
 
 ## 🎯 Quick Start
+
+### Inspect Before Extraction
+
+Use `inspect_pdf` when an agent needs to decide how to process an unfamiliar
+PDF. It samples a bounded number of pages, detects selectable-text versus
+image-like pages, surfaces document signals, and recommends useful `read_pdf`
+arguments without extracting image bytes.
+
+```json
+{
+  "sources": [{
+    "path": "documents/report.pdf"
+  }],
+  "sample_pages": 5,
+  "include_metadata": true
+}
+```
+
+**Result:**
+- PDF profile such as `digital_text`, `scanned_or_image_only`, or `mixed_text_and_scan`
+- Page-level text density, token estimates, and image paint-operation counts
+- Signals for outlines, page labels, forms, attachments, permissions, and structure trees
+- Recommended `read_pdf` arguments for citation chunks, safety findings, tables, or OCR triage
 
 ### Basic Usage
 
@@ -383,6 +408,7 @@ npm install -g @sylphx/pdf-reader-mcp
 ## ✨ Features
 
 ### Core Capabilities
+- ✅ **PDF Inspection** - Profile PDFs before extraction, detect low-text/scanned pages, and recommend `read_pdf` options
 - ✅ **Text Extraction** - Full document or specific pages with intelligent parsing
 - ✅ **Image Extraction** - Base64-encoded with complete metadata (width, height, format)
 - ✅ **Structured Elements** - Agent-ready elements with stable IDs, provenance, and best-effort bounding boxes
@@ -407,6 +433,18 @@ npm install -g @sylphx/pdf-reader-mcp
 ---
 
 ## 🆕 Latest Improvements
+
+### Agent-Native PDF Inspection
+
+`inspect_pdf` adds a lightweight planning tool for agent workflows. It samples
+up to 20 pages per source, counts selectable text and image paint operations,
+surfaces document-level signals, and returns a recommendation with the next
+best `read_pdf` arguments.
+
+Inspection is intentionally low overhead: it does not decode image bytes and it
+does not perform OCR. When sampled pages look scanned or image-only, the tool
+marks `needs_ocr: true` so agents do not mistake an image-based PDF for a text
+extraction failure.
 
 ### Agent-Ready Structured Output
 
@@ -479,9 +517,34 @@ The extraction pipeline also separates distant same-line text into independent s
 
 ## 📖 API Reference
 
+### `inspect_pdf` Tool
+
+Plan PDF extraction before running a heavier read. This is useful for agents
+that need to choose between metadata review, citation-ready extraction, mixed
+PDF handling, or OCR-capable workflows.
+
+#### Parameters
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `sources` | Array | List of PDF sources to inspect | Required |
+| `sample_pages` | number | Maximum pages to sample per source, capped at 20 | `5` |
+| `include_metadata` | boolean | Include PDF metadata and info objects | `true` |
+
+#### Response Fields
+
+| Field | Description |
+|-------|-------------|
+| `profile` | `digital_text`, `scanned_or_image_only`, `mixed_text_and_scan`, `low_text_or_form`, or `unknown` |
+| `sampled_pages` | Pages used for the bounded inspection sample |
+| `page_signals` | Text chars, text items, token estimate, image paint operations, and scan/low-text flags |
+| `document_signals` | Outline, labels, permissions, forms, attachments, and structure-tree availability |
+| `recommendation` | Suggested workflow, OCR need, reason, and ready-to-use `read_pdf` arguments |
+
 ### `read_pdf` Tool
 
-The single tool that handles all PDF operations.
+The extraction tool that handles PDF content, structure, citations, images,
+tables, and document signals.
 
 #### Parameters
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,10 +1,24 @@
 #!/usr/bin/env node
 
 // src/index.ts
+import { createRequire as createRequire2 } from "node:module";
 import { createServer, http, stdio } from "@sylphx/mcp-server-sdk";
 
-// src/handlers/readPdf.ts
-import { image, text, tool, toolError } from "@sylphx/mcp-server-sdk";
+// src/handlers/inspectPdf.ts
+import { text, tool, toolError } from "@sylphx/mcp-server-sdk";
+
+// src/pdf/inspector.ts
+import { OPS as OPS2 } from "pdfjs-dist/legacy/build/pdf.mjs";
+
+// src/utils/errors.ts
+class PdfError extends Error {
+  code;
+  constructor(code, message, options) {
+    super(message, options?.cause ? { cause: options.cause } : undefined);
+    this.code = code;
+    this.name = "PdfError";
+  }
+}
 
 // src/utils/logger.ts
 class Logger {
@@ -83,14 +97,1476 @@ var createLogger = (component, minLevel) => {
 };
 var logger = new Logger("", 2 /* WARN */);
 
+// src/pdf/extractor.ts
+import { OPS } from "pdfjs-dist/legacy/build/pdf.mjs";
+import { PNG } from "pngjs";
+var logger2 = createLogger("Extractor");
+var TEXT_SEGMENT_GAP_THRESHOLD = 48;
+var COLUMN_CUT_MIN_GAP = 48;
+var COLUMN_CUT_MIN_WIDTH_RATIO = 0.12;
+var SPANNING_WIDTH_RATIO = 0.72;
+var mergeBoundingBoxes = (boxes) => {
+  const validBoxes = boxes.filter((box) => box !== undefined);
+  if (validBoxes.length === 0)
+    return;
+  return {
+    left: Math.min(...validBoxes.map((box) => box.left)),
+    bottom: Math.min(...validBoxes.map((box) => box.bottom)),
+    right: Math.max(...validBoxes.map((box) => box.right)),
+    top: Math.max(...validBoxes.map((box) => box.top))
+  };
+};
+var buildBoundingBox = (x, y, width, height) => {
+  if (x === undefined || y === undefined || width === undefined || height === undefined) {
+    return;
+  }
+  if (![x, y, width, height].every(Number.isFinite)) {
+    return;
+  }
+  return {
+    left: x,
+    bottom: y,
+    right: x + Math.max(0, width),
+    top: y + Math.max(0, height)
+  };
+};
+var buildRectBoundingBox = (rect) => {
+  if (!rect || rect.length < 4)
+    return;
+  const [x1, y1, x2, y2] = rect;
+  if (x1 === undefined || y1 === undefined || x2 === undefined || y2 === undefined || ![x1, y1, x2, y2].every(Number.isFinite)) {
+    return;
+  }
+  return {
+    left: Math.min(x1, x2),
+    bottom: Math.min(y1, y2),
+    right: Math.max(x1, x2),
+    top: Math.max(y1, y2)
+  };
+};
+var finiteNumber = (value) => typeof value === "number" && Number.isFinite(value);
+var textFromAnnotationField = (direct, objectValue) => {
+  const value = direct ?? objectValue?.str;
+  return value && value.trim().length > 0 ? value : undefined;
+};
+var sanitizeOutlineItems = (items) => items.map((item) => {
+  const title = item.title?.trim();
+  if (!title)
+    return;
+  const children = item.items ? sanitizeOutlineItems(item.items) : undefined;
+  return {
+    title,
+    ...item.bold !== undefined ? { bold: item.bold } : {},
+    ...item.italic !== undefined ? { italic: item.italic } : {},
+    ...item.color ? { color: Array.from(item.color) } : {},
+    ...item.url ? { url: item.url } : {},
+    ...item.dest !== undefined ? { dest: item.dest } : {},
+    ...children && children.length > 0 ? { items: children } : {}
+  };
+}).filter((item) => item !== undefined);
+var PDF_PERMISSION_LABELS = new Map([
+  [4, "print"],
+  [8, "modify"],
+  [16, "copy"],
+  [32, "annotate"],
+  [256, "fill_forms"],
+  [512, "copy_for_accessibility"],
+  [1024, "assemble"],
+  [2048, "print_high_quality"]
+]);
+var permissionLabels = (permissions) => permissions.map((permission) => PDF_PERMISSION_LABELS.get(permission) ?? `unknown:${String(permission)}`);
+var attachmentSize = (content) => {
+  if (!content)
+    return;
+  if ("byteLength" in content && typeof content.byteLength === "number") {
+    return content.byteLength;
+  }
+  if ("length" in content && typeof content.length === "number") {
+    return content.length;
+  }
+  return;
+};
+var textSegmentToContentItem = (y, segment) => {
+  const textContent = segment.map((part) => part.text).join("");
+  if (!textContent.trim())
+    return null;
+  const boundingBox = mergeBoundingBoxes(segment.map((part) => part.bounding_box));
+  const xPosition = boundingBox?.left ?? segment[0]?.x;
+  const width = boundingBox !== undefined ? boundingBox.right - boundingBox.left : segment.reduce((sum, part) => sum + part.width, 0);
+  const height = boundingBox !== undefined ? boundingBox.top - boundingBox.bottom : Math.max(...segment.map((part) => part.height), 0);
+  return {
+    type: "text",
+    yPosition: y,
+    xPosition,
+    width,
+    height,
+    bounding_box: boundingBox,
+    textContent
+  };
+};
+var splitTextPartsIntoSegments = (parts) => {
+  const sortedParts = [...parts].sort((a, b) => a.x - b.x);
+  const segments = [];
+  let currentSegment = [];
+  let previousRight;
+  for (const part of sortedParts) {
+    if (previousRight !== undefined && part.x - previousRight > TEXT_SEGMENT_GAP_THRESHOLD) {
+      if (currentSegment.length > 0) {
+        segments.push(currentSegment);
+      }
+      currentSegment = [];
+    }
+    currentSegment.push(part);
+    previousRight = Math.max(previousRight ?? part.x, part.x + part.width);
+  }
+  if (currentSegment.length > 0) {
+    segments.push(currentSegment);
+  }
+  return segments;
+};
+var sortByYThenX = (items) => [...items].sort((a, b) => b.yPosition - a.yPosition || (a.xPosition ?? 0) - (b.xPosition ?? 0));
+var findVerticalColumnCut = (items) => {
+  const boxedItems = items.filter((item) => item.bounding_box !== undefined);
+  if (boxedItems.length < 4)
+    return;
+  const left = Math.min(...boxedItems.map((item) => item.bounding_box?.left ?? 0));
+  const right = Math.max(...boxedItems.map((item) => item.bounding_box?.right ?? 0));
+  const pageWidth = right - left;
+  if (pageWidth <= 0)
+    return;
+  const narrowItems = boxedItems.filter((item) => {
+    const box = item.bounding_box;
+    if (!box)
+      return false;
+    return box.right - box.left < pageWidth * SPANNING_WIDTH_RATIO;
+  });
+  if (narrowItems.length < 4)
+    return;
+  const sorted = [...narrowItems].sort((a, b) => (a.bounding_box?.left ?? 0) - (b.bounding_box?.left ?? 0));
+  let currentRight = sorted[0]?.bounding_box?.right;
+  if (currentRight === undefined)
+    return;
+  let largestGap = 0;
+  let cutPosition;
+  for (let i = 1;i < sorted.length; i++) {
+    const box = sorted[i]?.bounding_box;
+    if (!box)
+      continue;
+    if (box.left > currentRight) {
+      const gap = box.left - currentRight;
+      if (gap > largestGap) {
+        largestGap = gap;
+        cutPosition = (box.left + currentRight) / 2;
+      }
+    }
+    currentRight = Math.max(currentRight, box.right);
+  }
+  if (cutPosition === undefined)
+    return;
+  const minGap = Math.max(COLUMN_CUT_MIN_GAP, pageWidth * COLUMN_CUT_MIN_WIDTH_RATIO);
+  if (largestGap < minGap)
+    return;
+  const leftCount = narrowItems.filter((item) => {
+    const box = item.bounding_box;
+    if (!box)
+      return false;
+    return (box.left + box.right) / 2 < cutPosition;
+  }).length;
+  const rightCount = narrowItems.length - leftCount;
+  return leftCount >= 2 && rightCount >= 2 ? cutPosition : undefined;
+};
+var sortPageContentItems = (items) => {
+  const cutPosition = findVerticalColumnCut(items);
+  if (cutPosition === undefined)
+    return sortByYThenX(items);
+  const leftColumn = [];
+  const rightColumn = [];
+  const spanning = [];
+  for (const item of items) {
+    const box = item.bounding_box;
+    if (!box) {
+      spanning.push(item);
+      continue;
+    }
+    if (box.left < cutPosition && box.right > cutPosition) {
+      spanning.push(item);
+      continue;
+    }
+    const center = (box.left + box.right) / 2;
+    if (center < cutPosition) {
+      leftColumn.push(item);
+    } else {
+      rightColumn.push(item);
+    }
+  }
+  const columnItems = [...leftColumn, ...rightColumn].filter((item) => item.bounding_box);
+  const highestColumnTop = columnItems.length > 0 ? Math.max(...columnItems.map((item) => item.bounding_box?.top ?? item.yPosition)) : Number.POSITIVE_INFINITY;
+  const topSpanning = spanning.filter((item) => (item.bounding_box?.top ?? item.yPosition) >= highestColumnTop);
+  const remainingSpanning = spanning.filter((item) => (item.bounding_box?.top ?? item.yPosition) < highestColumnTop);
+  return [
+    ...sortByYThenX(topSpanning),
+    ...sortByYThenX(leftColumn),
+    ...sortByYThenX(rightColumn),
+    ...sortByYThenX(remainingSpanning)
+  ];
+};
+var encodePixelsToPNG = (pixelData, width, height, channels) => {
+  const png = new PNG({ width, height });
+  if (channels === 4) {
+    png.data = Buffer.from(pixelData);
+  } else if (channels === 3) {
+    for (let i = 0;i < width * height; i++) {
+      const srcIdx = i * 3;
+      const dstIdx = i * 4;
+      png.data[dstIdx] = pixelData[srcIdx] ?? 0;
+      png.data[dstIdx + 1] = pixelData[srcIdx + 1] ?? 0;
+      png.data[dstIdx + 2] = pixelData[srcIdx + 2] ?? 0;
+      png.data[dstIdx + 3] = 255;
+    }
+  } else if (channels === 1) {
+    for (let i = 0;i < width * height; i++) {
+      const gray = pixelData[i] ?? 0;
+      const dstIdx = i * 4;
+      png.data[dstIdx] = gray;
+      png.data[dstIdx + 1] = gray;
+      png.data[dstIdx + 2] = gray;
+      png.data[dstIdx + 3] = 255;
+    }
+  }
+  const pngBuffer = PNG.sync.write(png);
+  return pngBuffer.toString("base64");
+};
+var processImageData = (imageData, pageNum, arrayIndex) => {
+  if (!imageData || typeof imageData !== "object") {
+    return null;
+  }
+  const img = imageData;
+  if (!img.data || !img.width || !img.height) {
+    return null;
+  }
+  const channels = img.kind === 1 ? 1 : img.kind === 3 ? 4 : 3;
+  const format = img.kind === 1 ? "grayscale" : img.kind === 3 ? "rgba" : "rgb";
+  const pngBase64 = encodePixelsToPNG(img.data, img.width, img.height, channels);
+  return {
+    page: pageNum,
+    index: arrayIndex,
+    width: img.width,
+    height: img.height,
+    format,
+    data: pngBase64
+  };
+};
+var retrieveImageData = async (page, imageName, pageNum) => {
+  if (imageName.startsWith("g_")) {
+    try {
+      const imageData = page.commonObjs.get(imageName);
+      if (imageData) {
+        return imageData;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger2.warn("Error getting image from commonObjs", { imageName, error: message });
+    }
+  }
+  try {
+    const imageData = page.objs.get(imageName);
+    if (imageData !== undefined) {
+      return imageData;
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger2.warn("Sync image get failed, trying async", { imageName, error: message });
+  }
+  return new Promise((resolve) => {
+    let resolved = false;
+    let timeoutId = null;
+    const cleanup = () => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+    };
+    timeoutId = setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        cleanup();
+        logger2.warn("Image extraction timeout", { imageName, pageNum });
+        resolve(null);
+      }
+    }, 1e4);
+    try {
+      page.objs.get(imageName, (imageData) => {
+        if (!resolved) {
+          resolved = true;
+          cleanup();
+          resolve(imageData);
+        }
+      });
+    } catch (error) {
+      if (!resolved) {
+        resolved = true;
+        cleanup();
+        const message = error instanceof Error ? error.message : String(error);
+        logger2.warn("Error in async image get", { imageName, error: message });
+        resolve(null);
+      }
+    }
+  });
+};
+var extractMetadataAndPageCount = async (pdfDocument, includeMetadata, includePageCount) => {
+  const output = {};
+  if (includePageCount) {
+    output.num_pages = pdfDocument.numPages;
+  }
+  if (includeMetadata) {
+    try {
+      const pdfMetadata = await pdfDocument.getMetadata();
+      const infoData = pdfMetadata.info;
+      if (infoData !== undefined) {
+        output.info = infoData;
+      }
+      const metadataObj = pdfMetadata.metadata;
+      if (metadataObj && typeof metadataObj.getAll === "function") {
+        output.metadata = metadataObj.getAll();
+      } else if (metadataObj && typeof metadataObj === "object") {
+        const metadataRecord = {};
+        for (const key in metadataObj) {
+          if (Object.hasOwn(metadataObj, key)) {
+            metadataRecord[key] = metadataObj[key];
+          }
+        }
+        output.metadata = metadataRecord;
+      }
+    } catch (metaError) {
+      const message = metaError instanceof Error ? metaError.message : String(metaError);
+      logger2.warn("Error extracting metadata", { error: message });
+    }
+  }
+  return output;
+};
+var extractDocumentStructure = async (pdfDocument, options) => {
+  const documentWithStructure = pdfDocument;
+  const output = {};
+  if (options.includeOutline && typeof documentWithStructure.getOutline === "function") {
+    try {
+      const outline = await documentWithStructure.getOutline();
+      if (outline && outline.length > 0) {
+        output.outline = sanitizeOutlineItems(outline);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger2.warn("Error extracting outline", { error: message });
+    }
+  }
+  if (options.includePageLabels && typeof documentWithStructure.getPageLabels === "function") {
+    try {
+      const pageLabels = await documentWithStructure.getPageLabels();
+      if (pageLabels && pageLabels.length > 0) {
+        output.page_labels = pageLabels;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger2.warn("Error extracting page labels", { error: message });
+    }
+  }
+  if (options.includePermissions && typeof documentWithStructure.getPermissions === "function") {
+    try {
+      const permissions = await documentWithStructure.getPermissions();
+      if (permissions && permissions.length > 0) {
+        output.permissions = permissionLabels(permissions);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger2.warn("Error extracting permissions", { error: message });
+    }
+  }
+  if (options.includePermissions && typeof documentWithStructure.getMarkInfo === "function") {
+    try {
+      const markInfo = await documentWithStructure.getMarkInfo();
+      if (markInfo && Object.keys(markInfo).length > 0) {
+        output.mark_info = markInfo;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger2.warn("Error extracting mark info", { error: message });
+    }
+  }
+  if (options.includeFormFields && typeof documentWithStructure.getFieldObjects === "function") {
+    try {
+      const fieldObjects = await documentWithStructure.getFieldObjects();
+      if (fieldObjects) {
+        const fields = Object.entries(fieldObjects).flatMap(([name, fieldOrFields]) => {
+          const fieldList = Array.isArray(fieldOrFields) ? fieldOrFields : [fieldOrFields];
+          return fieldList.map((field) => normalizeFormField(name, field));
+        }).filter((field) => field !== undefined);
+        if (fields.length > 0) {
+          output.form_fields = fields;
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger2.warn("Error extracting form fields", { error: message });
+    }
+  }
+  if (options.includeAttachments && typeof documentWithStructure.getAttachments === "function") {
+    try {
+      const attachments = await documentWithStructure.getAttachments();
+      if (attachments) {
+        const attachmentSummaries = Object.entries(attachments).map(([name, attachment]) => {
+          const size = attachmentSize(attachment.content);
+          return {
+            name,
+            ...attachment.filename ? { filename: attachment.filename } : {},
+            ...attachment.description ? { description: attachment.description } : {},
+            ...size !== undefined ? { size_bytes: size } : {}
+          };
+        });
+        if (attachmentSummaries.length > 0) {
+          output.attachments = attachmentSummaries;
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger2.warn("Error extracting attachments", { error: message });
+    }
+  }
+  return output;
+};
+var normalizeFormField = (fallbackName, field) => {
+  const name = (field.name ?? field.fieldName ?? fallbackName).trim();
+  if (!name)
+    return;
+  const page = field.page !== undefined ? field.page : field.pageIndex !== undefined ? field.pageIndex + 1 : undefined;
+  const fieldType = field.type ?? field.fieldType;
+  const boundingBox = buildRectBoundingBox(field.rect);
+  return {
+    name,
+    ...fieldType ? { type: fieldType } : {},
+    ...field.value !== undefined ? { value: field.value } : {},
+    ...field.defaultValue !== undefined ? { default_value: field.defaultValue } : {},
+    ...page !== undefined ? { page } : {},
+    ...field.id ? { id: field.id } : {},
+    ...field.editable !== undefined ? { editable: field.editable } : {},
+    ...field.required !== undefined ? { required: field.required } : {},
+    ...boundingBox ? { bounding_box: boundingBox } : {}
+  };
+};
+var normalizeAnnotation = (annotation, pageNum) => {
+  const contents = textFromAnnotationField(annotation.contents, annotation.contentsObj);
+  const title = textFromAnnotationField(annotation.title, annotation.titleObj);
+  const boundingBox = buildRectBoundingBox(annotation.rect);
+  const subtype = annotation.subtype?.trim();
+  const url = annotation.url ?? annotation.unsafeUrl;
+  if (!annotation.id && !subtype && !contents && !title && !url && annotation.dest === undefined) {
+    return;
+  }
+  return {
+    page: pageNum,
+    ...annotation.id ? { id: annotation.id } : {},
+    ...subtype ? { subtype } : {},
+    ...contents ? { contents } : {},
+    ...title ? { title } : {},
+    ...url ? { url } : {},
+    ...annotation.dest !== undefined ? { dest: annotation.dest } : {},
+    ...boundingBox ? { bounding_box: boundingBox } : {}
+  };
+};
+var isRecord = (value) => typeof value === "object" && value !== null;
+var normalizeStructureTreeContent = (rawContent) => {
+  const type = typeof rawContent.type === "string" ? rawContent.type.trim() : "";
+  const id = typeof rawContent.id === "string" ? rawContent.id.trim() : "";
+  if (!type && !id)
+    return;
+  return {
+    type: type || "content",
+    ...id ? { id } : {}
+  };
+};
+var normalizeStructureTreeChild = (rawChild) => {
+  if (!isRecord(rawChild))
+    return;
+  if ("role" in rawChild || "children" in rawChild) {
+    return normalizeStructureTreeNode(rawChild);
+  }
+  return normalizeStructureTreeContent(rawChild);
+};
+var normalizeStructureTreeNode = (rawNode) => {
+  const role = typeof rawNode.role === "string" && rawNode.role.trim() ? rawNode.role.trim() : "Unknown";
+  const children = Array.isArray(rawNode.children) ? rawNode.children.map((child) => normalizeStructureTreeChild(child)).filter((child) => child !== undefined) : [];
+  return {
+    role,
+    ...children.length > 0 ? { children } : {}
+  };
+};
+var extractAnnotations = async (pdfDocument, pagesToProcess) => {
+  const pageAnnotations = [];
+  for (const pageNum of pagesToProcess) {
+    try {
+      const page = await pdfDocument.getPage(pageNum);
+      if (typeof page.getAnnotations !== "function")
+        continue;
+      const annotations = await page.getAnnotations({ intent: "display" });
+      const normalized = annotations.map((annotation) => normalizeAnnotation(annotation, pageNum)).filter((annotation) => annotation !== undefined);
+      if (normalized.length > 0) {
+        pageAnnotations.push({ page: pageNum, annotations: normalized });
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger2.warn("Error extracting annotations from page", { pageNum, error: message });
+    }
+  }
+  return pageAnnotations;
+};
+var extractStructureTrees = async (pdfDocument, pagesToProcess) => {
+  const pageStructureTrees = [];
+  for (const pageNum of pagesToProcess) {
+    try {
+      const page = await pdfDocument.getPage(pageNum);
+      if (typeof page.getStructTree !== "function")
+        continue;
+      const rawTree = await page.getStructTree();
+      if (!rawTree)
+        continue;
+      pageStructureTrees.push({
+        page: pageNum,
+        tree: normalizeStructureTreeNode(rawTree)
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger2.warn("Error extracting structure tree", { pageNum, error: message });
+    }
+  }
+  return pageStructureTrees;
+};
+var extractPageGeometry = async (pdfDocument, pagesToProcess) => {
+  const pageGeometry = [];
+  for (const pageNum of pagesToProcess) {
+    try {
+      const page = await pdfDocument.getPage(pageNum);
+      const viewBox = buildRectBoundingBox(page.view);
+      const viewport = page.getViewport({ scale: 1 });
+      const width = finiteNumber(viewport.width) ? viewport.width : viewBox ? viewBox.right - viewBox.left : undefined;
+      const height = finiteNumber(viewport.height) ? viewport.height : viewBox ? viewBox.top - viewBox.bottom : undefined;
+      if (!finiteNumber(width) || !finiteNumber(height)) {
+        logger2.warn("Skipping page geometry with invalid dimensions", { pageNum });
+        continue;
+      }
+      pageGeometry.push({
+        page: pageNum,
+        width,
+        height,
+        rotation: finiteNumber(page.rotate) ? page.rotate : 0,
+        ...finiteNumber(page.userUnit) ? { user_unit: page.userUnit } : {},
+        ...viewBox ? { view_box: viewBox } : {}
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger2.warn("Error extracting page geometry", { pageNum, error: message });
+    }
+  }
+  return pageGeometry;
+};
+var buildWarnings = (invalidPages, totalPages) => {
+  if (invalidPages.length === 0) {
+    return [];
+  }
+  return [
+    `Requested page numbers ${invalidPages.join(", ")} exceed total pages (${String(totalPages)}).`
+  ];
+};
+var extractPageContent = async (pdfDocument, pageNum, includeImages, sourceDescription) => {
+  const contentItems = [];
+  try {
+    const page = await pdfDocument.getPage(pageNum);
+    const textContent = await page.getTextContent();
+    const textByY = new Map;
+    for (const item of textContent.items) {
+      const textItem = item;
+      const xCoord = textItem.transform?.[4];
+      const yCoord = textItem.transform?.[5];
+      if (yCoord === undefined)
+        continue;
+      const y = Math.round(yCoord);
+      const width = textItem.width ?? textItem.str.length * 6;
+      const height = textItem.height ?? Math.abs(textItem.transform?.[3] ?? 0);
+      const boundingBox = buildBoundingBox(xCoord, yCoord, width, height);
+      if (!textByY.has(y)) {
+        textByY.set(y, []);
+      }
+      textByY.get(y)?.push({
+        text: textItem.str,
+        x: xCoord ?? 0,
+        width,
+        height,
+        bounding_box: boundingBox
+      });
+    }
+    for (const [y, textParts] of textByY.entries()) {
+      for (const segment of splitTextPartsIntoSegments(textParts)) {
+        const contentItem = textSegmentToContentItem(y, segment);
+        if (contentItem) {
+          contentItems.push(contentItem);
+        }
+      }
+    }
+    if (includeImages) {
+      const operatorList = await page.getOperatorList();
+      const imageIndices = [];
+      for (let i = 0;i < operatorList.fnArray.length; i++) {
+        const op = operatorList.fnArray[i];
+        if (op === OPS.paintImageXObject || op === OPS.paintXObject) {
+          imageIndices.push(i);
+        }
+      }
+      const imagePromises = imageIndices.map(async (imgIndex, arrayIndex) => {
+        const argsArray = operatorList.argsArray[imgIndex];
+        if (!argsArray || argsArray.length === 0) {
+          return null;
+        }
+        const imageName = argsArray[0];
+        let xPosition;
+        let yPosition;
+        if (argsArray.length > 1 && Array.isArray(argsArray[1])) {
+          const transform = argsArray[1];
+          const xCoord = transform[4];
+          const yCoord = transform[5];
+          if (xCoord !== undefined) {
+            xPosition = Math.round(xCoord);
+          }
+          if (yCoord !== undefined) {
+            yPosition = Math.round(yCoord);
+          }
+        }
+        const imageData = await retrieveImageData(page, imageName, pageNum);
+        const extractedImage = processImageData(imageData, pageNum, arrayIndex);
+        if (extractedImage) {
+          const imageBox = buildBoundingBox(xPosition, yPosition, extractedImage.width, extractedImage.height);
+          extractedImage.bounding_box = imageBox;
+          return {
+            type: "image",
+            yPosition: imageBox?.top ?? yPosition ?? 0,
+            xPosition,
+            width: extractedImage.width,
+            height: extractedImage.height,
+            bounding_box: imageBox,
+            imageData: extractedImage
+          };
+        }
+        return null;
+      });
+      const resolvedImages = await Promise.all(imagePromises);
+      const validImages = resolvedImages.filter((item) => item !== null);
+      contentItems.push(...validImages);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger2.warn("Error extracting page content", {
+      pageNum,
+      sourceDescription,
+      error: message
+    });
+    return [
+      {
+        type: "text",
+        yPosition: 0,
+        textContent: `[Error processing page ${String(pageNum)}]`
+      }
+    ];
+  }
+  return sortPageContentItems(contentItems);
+};
+
+// src/pdf/loader.ts
+import fs3 from "node:fs/promises";
+import { createRequire } from "node:module";
+import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
+
+// src/utils/config.ts
+import dns from "node:dns";
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+var splitList = (value, separators) => value.split(separators).map((s) => s.trim()).filter((s) => s.length > 0);
+var canonicalizeDir = (p) => {
+  try {
+    return fs.realpathSync(p);
+  } catch (err) {
+    if (typeof err === "object" && err !== null && "code" in err && (err.code === "ENOENT" || err.code === "ENOTDIR")) {
+      const parent = path.dirname(p);
+      if (parent === p)
+        return p;
+      return path.join(canonicalizeDir(parent), path.basename(p));
+    }
+    throw err;
+  }
+};
+var parseDirs = (values) => values.map((dir) => canonicalizeDir(path.resolve(path.normalize(dir))));
+var parseBool = (value, fallback) => {
+  if (value === undefined)
+    return fallback;
+  const v = value.trim().toLowerCase();
+  if (v === "false" || v === "0" || v === "no" || v === "off")
+    return false;
+  if (v === "true" || v === "1" || v === "yes" || v === "on")
+    return true;
+  return fallback;
+};
+var parseCliFlags = (argv) => {
+  const dirs = [];
+  const hosts = [];
+  let noHttp = false;
+  let allowPrivateIps = false;
+  for (const arg of argv) {
+    if (arg.startsWith("--allow-dir=")) {
+      dirs.push(arg.slice("--allow-dir=".length));
+    } else if (arg.startsWith("--allow-host=")) {
+      hosts.push(arg.slice("--allow-host=".length).toLowerCase());
+    } else if (arg === "--no-http") {
+      noHttp = true;
+    } else if (arg === "--allow-private-ips") {
+      allowPrivateIps = true;
+    }
+  }
+  return { dirs, hosts, noHttp, allowPrivateIps };
+};
+var envList = (raw, separators, transform = (v) => v) => raw ? splitList(raw, separators).map(transform) : [];
+var readSecurityConfig = (argv = process.argv.slice(2), env = process.env) => {
+  const cli = parseCliFlags(argv);
+  const envDirs = envList(env["MCP_PDF_ALLOWED_DIRS"], /[:,]/);
+  const envHosts = envList(env["MCP_PDF_ALLOWED_HOSTS"], /,/, (h) => h.toLowerCase());
+  const mergedDirs = [...cli.dirs, ...envDirs];
+  const mergedHosts = [...cli.hosts, ...envHosts];
+  return {
+    allowedDirs: mergedDirs.length > 0 ? parseDirs(mergedDirs) : null,
+    allowHttp: cli.noHttp ? false : parseBool(env["MCP_PDF_ALLOW_HTTP"], true),
+    allowedHosts: mergedHosts.length > 0 ? mergedHosts : null,
+    allowPrivateIps: cli.allowPrivateIps || parseBool(env["MCP_PDF_ALLOW_PRIVATE_IPS"], false)
+  };
+};
+var cached = null;
+var getSecurityConfig = () => {
+  if (cached === null) {
+    cached = readSecurityConfig();
+  }
+  return cached;
+};
+var isPathAllowed = (absPath, allowedDirs) => {
+  if (allowedDirs === null)
+    return true;
+  if (allowedDirs.length === 0)
+    return false;
+  const normalized = path.resolve(absPath);
+  return allowedDirs.some((dir) => {
+    const rel = path.relative(dir, normalized);
+    if (rel === "")
+      return true;
+    if (rel.startsWith(".."))
+      return false;
+    if (path.isAbsolute(rel))
+      return false;
+    return true;
+  });
+};
+var isUrlAllowed = (urlString, config) => {
+  if (!config.allowHttp)
+    return false;
+  let parsed;
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:")
+    return false;
+  if (config.allowedHosts === null)
+    return true;
+  return config.allowedHosts.includes(parsed.hostname.toLowerCase());
+};
+var PRIVATE_IPV4_PREDICATES = [
+  (a) => a === 10,
+  (a, b) => a === 172 && b >= 16 && b <= 31,
+  (a, b) => a === 192 && b === 168,
+  (a) => a === 127,
+  (a, b) => a === 169 && b === 254,
+  (a) => a === 0,
+  (a, b) => a === 100 && b >= 64 && b <= 127,
+  (a) => a >= 224
+];
+var isPrivateIpv4 = (ip) => {
+  const parts = ip.split(".").map((s) => Number.parseInt(s, 10));
+  const a = parts[0];
+  const b = parts[1];
+  if (a === undefined || b === undefined)
+    return true;
+  return PRIVATE_IPV4_PREDICATES.some((pred) => pred(a, b));
+};
+var isPrivateIpv6 = (ip) => {
+  const lower = ip.toLowerCase();
+  if (lower === "::1" || lower === "::")
+    return true;
+  if (lower.startsWith("fc") || lower.startsWith("fd"))
+    return true;
+  if (lower.startsWith("fe80"))
+    return true;
+  if (lower.startsWith("ff"))
+    return true;
+  if (lower.startsWith("::ffff:")) {
+    const tail = lower.slice("::ffff:".length);
+    if (net.isIPv4(tail))
+      return isPrivateIpv4(tail);
+  }
+  return false;
+};
+var isPrivateIp = (ip) => {
+  if (net.isIPv4(ip))
+    return isPrivateIpv4(ip);
+  if (net.isIPv6(ip))
+    return isPrivateIpv6(ip);
+  return true;
+};
+var assertUrlNotPrivate = async (hostname) => {
+  if (net.isIP(hostname)) {
+    if (isPrivateIp(hostname)) {
+      throw new Error(`URL host '${hostname}' resolves to a non-public address (SSRF protection).`);
+    }
+    return;
+  }
+  let addresses;
+  try {
+    addresses = await dns.promises.lookup(hostname, { all: true });
+  } catch {
+    throw new Error(`URL host '${hostname}' could not be resolved.`);
+  }
+  if (addresses.length === 0) {
+    throw new Error(`URL host '${hostname}' resolved to no addresses.`);
+  }
+  for (const { address } of addresses) {
+    if (isPrivateIp(address)) {
+      throw new Error(`URL host '${hostname}' resolves to a non-public address (SSRF protection).`);
+    }
+  }
+};
+
+// src/utils/pathUtils.ts
+import fs2 from "node:fs";
+import path2 from "node:path";
+var PROJECT_ROOT = process.cwd();
+var canonicalize = (p) => {
+  try {
+    return fs2.realpathSync(p);
+  } catch (err) {
+    if (typeof err === "object" && err !== null && "code" in err && (err.code === "ENOENT" || err.code === "ENOTDIR")) {
+      const parent = path2.dirname(p);
+      if (parent === p)
+        return p;
+      return path2.join(canonicalize(parent), path2.basename(p));
+    }
+    throw err;
+  }
+};
+var resolvePath = (userPath) => {
+  if (typeof userPath !== "string") {
+    throw new PdfError(-32602 /* InvalidParams */, "Path must be a string.");
+  }
+  const normalizedUserPath = path2.normalize(userPath);
+  const resolved = path2.isAbsolute(normalizedUserPath) ? normalizedUserPath : path2.resolve(PROJECT_ROOT, normalizedUserPath);
+  const canonical = canonicalize(resolved);
+  const { allowedDirs } = getSecurityConfig();
+  if (!isPathAllowed(canonical, allowedDirs)) {
+    throw new PdfError(-32600 /* InvalidRequest */, `Access denied: path '${userPath}' is outside the allowed directories.`);
+  }
+  return canonical;
+};
+
+// src/pdf/loader.ts
+var logger3 = createLogger("Loader");
+var require2 = createRequire(import.meta.url);
+var PDFJS_ROOT = require2.resolve("pdfjs-dist/package.json").replace("package.json", "");
+var CMAP_URL = `${PDFJS_ROOT}cmaps/`;
+var STANDARD_FONT_DATA_URL = `${PDFJS_ROOT}standard_fonts/`;
+var WASM_URL = `${PDFJS_ROOT}wasm/`;
+var ICC_URL = `${PDFJS_ROOT}iccs/`;
+var MAX_PDF_SIZE = 100 * 1024 * 1024;
+var URL_FETCH_TIMEOUT_MS = 30000;
+var MAX_REDIRECTS = 5;
+var formatBytes = (bytes) => `${(bytes / 1024 / 1024).toFixed(0)}MB`;
+var sanitizeSourceDescription = (description) => description.length > 200 ? `${description.slice(0, 197)}...` : description;
+var loadLocalFile = async (userPath) => {
+  const safePath = resolvePath(userPath);
+  let stats;
+  try {
+    stats = await fs3.stat(safePath);
+  } catch (err) {
+    if (typeof err === "object" && err !== null && "code" in err && err.code === "ENOENT") {
+      throw new PdfError(-32600 /* InvalidRequest */, `File not found at '${userPath}'.`, {
+        cause: err instanceof Error ? err : undefined
+      });
+    }
+    throw new PdfError(-32600 /* InvalidRequest */, `Failed to access file at '${userPath}'.`, {
+      cause: err instanceof Error ? err : undefined
+    });
+  }
+  if (!stats.isFile()) {
+    throw new PdfError(-32600 /* InvalidRequest */, `Path '${userPath}' is not a regular file.`);
+  }
+  if (stats.size > MAX_PDF_SIZE) {
+    throw new PdfError(-32600 /* InvalidRequest */, `PDF file exceeds maximum size of ${formatBytes(MAX_PDF_SIZE)}. File size: ${formatBytes(stats.size)}.`);
+  }
+  const buffer = await fs3.readFile(safePath);
+  return new Uint8Array(buffer);
+};
+var validateUrlHop = async (urlString, config) => {
+  if (!isUrlAllowed(urlString, config)) {
+    const reason = config.allowHttp ? "host is not in the allowed list or scheme is not http(s)" : "HTTP access is disabled";
+    throw new PdfError(-32600 /* InvalidRequest */, `Access denied: URL '${urlString}' rejected (${reason}).`);
+  }
+  if (!config.allowPrivateIps) {
+    let hostname;
+    try {
+      hostname = new URL(urlString).hostname;
+    } catch {
+      throw new PdfError(-32600 /* InvalidRequest */, `Invalid URL: '${urlString}'.`);
+    }
+    try {
+      await assertUrlNotPrivate(hostname);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : "SSRF check failed";
+      throw new PdfError(-32600 /* InvalidRequest */, `Access denied: ${reason}`);
+    }
+  }
+};
+var fetchUrlBody = async (url, config) => {
+  let currentUrl = url;
+  const controller = new AbortController;
+  const timeout = setTimeout(() => controller.abort(), URL_FETCH_TIMEOUT_MS);
+  try {
+    for (let hop = 0;hop <= MAX_REDIRECTS; hop++) {
+      await validateUrlHop(currentUrl, config);
+      const response = await fetch(currentUrl, {
+        redirect: "manual",
+        signal: controller.signal
+      });
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get("location");
+        if (!location) {
+          throw new PdfError(-32600 /* InvalidRequest */, `URL fetch failed: redirect without Location header.`);
+        }
+        currentUrl = new URL(location, currentUrl).toString();
+        continue;
+      }
+      if (!response.ok) {
+        throw new PdfError(-32600 /* InvalidRequest */, `URL fetch failed with HTTP ${String(response.status)}.`);
+      }
+      const contentLengthHeader = response.headers.get("content-length");
+      if (contentLengthHeader !== null) {
+        const declared = Number.parseInt(contentLengthHeader, 10);
+        if (Number.isFinite(declared) && declared > MAX_PDF_SIZE) {
+          throw new PdfError(-32600 /* InvalidRequest */, `Remote PDF exceeds maximum size of ${formatBytes(MAX_PDF_SIZE)} (Content-Length: ${formatBytes(declared)}).`);
+        }
+      }
+      if (!response.body) {
+        const ab = await response.arrayBuffer();
+        if (ab.byteLength > MAX_PDF_SIZE) {
+          throw new PdfError(-32600 /* InvalidRequest */, `Remote PDF exceeds maximum size of ${formatBytes(MAX_PDF_SIZE)}.`);
+        }
+        return new Uint8Array(ab);
+      }
+      const reader = response.body.getReader();
+      const chunks = [];
+      let total = 0;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done)
+          break;
+        if (value) {
+          total += value.byteLength;
+          if (total > MAX_PDF_SIZE) {
+            await reader.cancel().catch(() => {});
+            throw new PdfError(-32600 /* InvalidRequest */, `Remote PDF exceeds maximum size of ${formatBytes(MAX_PDF_SIZE)} during streaming.`);
+          }
+          chunks.push(value);
+        }
+      }
+      const combined = new Uint8Array(total);
+      let offset = 0;
+      for (const chunk of chunks) {
+        combined.set(chunk, offset);
+        offset += chunk.byteLength;
+      }
+      return combined;
+    }
+    throw new PdfError(-32600 /* InvalidRequest */, `URL fetch failed: exceeded redirect limit (${String(MAX_REDIRECTS)}).`);
+  } catch (err) {
+    if (err instanceof PdfError)
+      throw err;
+    if (err instanceof Error && (err.name === "AbortError" || err.name === "TimeoutError")) {
+      throw new PdfError(-32600 /* InvalidRequest */, `URL fetch timed out after ${String(URL_FETCH_TIMEOUT_MS / 1000)}s.`, { cause: err });
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    logger3.warn("URL fetch failed", { url, error: message });
+    throw new PdfError(-32600 /* InvalidRequest */, `URL fetch failed for '${url}'.`, {
+      cause: err instanceof Error ? err : undefined
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+var loadPdfDocument = async (source, sourceDescription) => {
+  const safeSource = sanitizeSourceDescription(sourceDescription);
+  let pdfData;
+  try {
+    if (source.path) {
+      pdfData = await loadLocalFile(source.path);
+    } else if (source.url) {
+      const config = getSecurityConfig();
+      pdfData = await fetchUrlBody(source.url, config);
+    } else {
+      throw new PdfError(-32602 /* InvalidParams */, `Source ${safeSource} missing 'path' or 'url'.`);
+    }
+  } catch (err) {
+    if (err instanceof PdfError) {
+      throw err;
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    logger3.error("Unexpected error preparing PDF source", {
+      sourceDescription: safeSource,
+      error: message
+    });
+    throw new PdfError(-32600 /* InvalidRequest */, `Failed to prepare PDF source ${safeSource}.`, {
+      cause: err instanceof Error ? err : undefined
+    });
+  }
+  const loadingTask = getDocument({
+    data: pdfData,
+    cMapUrl: CMAP_URL,
+    cMapPacked: true,
+    standardFontDataUrl: STANDARD_FONT_DATA_URL,
+    wasmUrl: WASM_URL,
+    iccUrl: ICC_URL
+  });
+  try {
+    return await loadingTask.promise;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger3.error("PDF.js loading error", { sourceDescription: safeSource, error: message });
+    throw new PdfError(-32600 /* InvalidRequest */, `Failed to load PDF document from ${safeSource}.`, { cause: err instanceof Error ? err : undefined });
+  }
+};
+
+// src/pdf/parser.ts
+var logger4 = createLogger("Parser");
+var MAX_RANGE_SIZE = 1e4;
+var parseRangePart = (part, pages) => {
+  const trimmedPart = part.trim();
+  if (trimmedPart.includes("-")) {
+    const splitResult = trimmedPart.split("-");
+    const startStr = splitResult[0] || "";
+    const endStr = splitResult[1];
+    const start = parseInt(startStr, 10);
+    const end = endStr === "" || endStr === undefined ? Infinity : parseInt(endStr, 10);
+    if (Number.isNaN(start) || Number.isNaN(end) || start <= 0 || start > end) {
+      throw new Error(`Invalid page range values: ${trimmedPart}`);
+    }
+    const practicalEnd = Math.min(end, start + MAX_RANGE_SIZE);
+    for (let i = start;i <= practicalEnd; i++) {
+      pages.add(i);
+    }
+    if (end === Infinity && practicalEnd === start + MAX_RANGE_SIZE) {
+      logger4.warn("Open-ended range truncated", { start, practicalEnd });
+    }
+  } else {
+    const page = parseInt(trimmedPart, 10);
+    if (Number.isNaN(page) || page <= 0) {
+      throw new Error(`Invalid page number: ${trimmedPart}`);
+    }
+    pages.add(page);
+  }
+};
+var parsePageRanges = (ranges) => {
+  const pages = new Set;
+  const parts = ranges.split(",");
+  for (const part of parts) {
+    parseRangePart(part, pages);
+  }
+  if (pages.size === 0) {
+    throw new Error("Page range string resulted in zero valid pages.");
+  }
+  return Array.from(pages).sort((a, b) => a - b);
+};
+var getTargetPages = (sourcePages, sourceDescription) => {
+  if (!sourcePages) {
+    return;
+  }
+  try {
+    if (typeof sourcePages === "string") {
+      return parsePageRanges(sourcePages);
+    }
+    if (sourcePages.some((p) => !Number.isInteger(p) || p <= 0)) {
+      throw new Error("Page numbers in array must be positive integers.");
+    }
+    const uniquePages = [...new Set(sourcePages)].sort((a, b) => a - b);
+    if (uniquePages.length === 0) {
+      throw new Error("Page specification resulted in an empty set of pages.");
+    }
+    return uniquePages;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new PdfError(-32602 /* InvalidParams */, `Invalid page specification for source ${sourceDescription}: ${message}`);
+  }
+};
+var determinePagesToProcess = (targetPages, totalPages, includeFullText) => {
+  if (targetPages) {
+    const pagesToProcess = targetPages.filter((p) => p <= totalPages);
+    const invalidPages = targetPages.filter((p) => p > totalPages);
+    return { pagesToProcess, invalidPages };
+  }
+  if (includeFullText) {
+    const pagesToProcess = Array.from({ length: totalPages }, (_, i) => i + 1);
+    return { pagesToProcess, invalidPages: [] };
+  }
+  return { pagesToProcess: [], invalidPages: [] };
+};
+
+// src/pdf/inspector.ts
+var logger5 = createLogger("Inspector");
+var DEFAULT_SAMPLE_PAGES = 5;
+var MAX_SAMPLE_PAGES = 20;
+var LOW_TEXT_CHAR_THRESHOLD = 20;
+var DIGITAL_TEXT_CHAR_THRESHOLD = 80;
+var APPROX_CHARS_PER_TOKEN = 4;
+var clampSamplePageCount = (value) => Math.min(MAX_SAMPLE_PAGES, Math.max(1, Math.floor(value)));
+var publicSource = (source) => ({
+  ...source.path ? { path: source.path } : {},
+  ...source.url ? { url: source.url } : {},
+  ...source.pages ? { pages: source.pages } : {}
+});
+var selectEvenlySpaced = (values, maxItems) => {
+  const uniqueValues = [...new Set(values)].sort((a, b) => a - b);
+  if (uniqueValues.length <= maxItems)
+    return uniqueValues;
+  if (maxItems === 1)
+    return [uniqueValues[0]];
+  const selected = new Set;
+  for (let i = 0;i < maxItems; i++) {
+    const index = Math.round(i * (uniqueValues.length - 1) / (maxItems - 1));
+    const value = uniqueValues[index];
+    if (value !== undefined)
+      selected.add(value);
+  }
+  for (const value of uniqueValues) {
+    if (selected.size >= maxItems)
+      break;
+    selected.add(value);
+  }
+  return [...selected].sort((a, b) => a - b);
+};
+var selectInspectionSamplePages = (totalPages, targetPages, samplePageCount) => {
+  if (totalPages <= 0)
+    return [];
+  const maxSamples = clampSamplePageCount(samplePageCount);
+  if (targetPages !== undefined) {
+    const validTargetPages = targetPages.filter((page) => page >= 1 && page <= totalPages);
+    return selectEvenlySpaced(validTargetPages, maxSamples);
+  }
+  if (totalPages <= maxSamples) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+  const sampled = new Set;
+  for (let i = 0;i < maxSamples; i++) {
+    const page = 1 + Math.round(i * (totalPages - 1) / (maxSamples - 1));
+    sampled.add(page);
+  }
+  return [...sampled].sort((a, b) => a - b);
+};
+var classifyPdfInspectionProfile = (pageSignals) => {
+  if (pageSignals.length === 0)
+    return "unknown";
+  const scannedCount = pageSignals.filter((signal) => signal.likely_scanned).length;
+  const digitalTextCount = pageSignals.filter((signal) => signal.text_chars >= DIGITAL_TEXT_CHAR_THRESHOLD).length;
+  if (scannedCount === pageSignals.length)
+    return "scanned_or_image_only";
+  if (scannedCount > 0 && digitalTextCount > 0)
+    return "mixed_text_and_scan";
+  if (digitalTextCount > 0)
+    return "digital_text";
+  return "low_text_or_form";
+};
+var countImagePaintOperations = async (page) => {
+  try {
+    const operatorList = await page.getOperatorList();
+    return operatorList.fnArray.filter((op) => op === OPS2.paintImageXObject || op === OPS2.paintXObject).length;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger5.warn("Error counting image paint operations", { error: message });
+    return 0;
+  }
+};
+var inspectPageSignal = async (pdfDocument, pageNum) => {
+  const page = await pdfDocument.getPage(pageNum);
+  const textContent = await page.getTextContent();
+  const textValues = textContent.items.map((item) => item.str).filter((value) => typeof value === "string");
+  const textChars = textValues.reduce((sum, value) => sum + value.trim().length, 0);
+  const imagePaintOperations = await countImagePaintOperations(page);
+  const likelyScanned = textChars < LOW_TEXT_CHAR_THRESHOLD && imagePaintOperations > 0;
+  return {
+    page: pageNum,
+    text_chars: textChars,
+    text_items: textValues.filter((value) => value.trim().length > 0).length,
+    estimated_tokens: Math.ceil(textChars / APPROX_CHARS_PER_TOKEN),
+    image_paint_operations: imagePaintOperations,
+    likely_scanned: likelyScanned,
+    low_text_density: textChars < DIGITAL_TEXT_CHAR_THRESHOLD
+  };
+};
+var buildDocumentSignals = (structureOutput, hasStructureTree) => ({
+  has_outline: (structureOutput.outline?.length ?? 0) > 0,
+  has_page_labels: (structureOutput.page_labels?.length ?? 0) > 0,
+  has_permissions: (structureOutput.permissions?.length ?? 0) > 0,
+  has_mark_info: Object.keys(structureOutput.mark_info ?? {}).length > 0,
+  has_form_fields: (structureOutput.form_fields?.length ?? 0) > 0,
+  has_attachments: (structureOutput.attachments?.length ?? 0) > 0,
+  has_structure_tree: hasStructureTree
+});
+var setTrue = (target, key, enabled) => {
+  if (enabled)
+    target[key] = true;
+};
+var buildInspectionRecommendation = (source, profile, documentSignals) => {
+  const readPdfArguments = {
+    sources: [publicSource(source)],
+    include_metadata: true,
+    include_page_count: true,
+    include_page_geometry: true
+  };
+  setTrue(readPdfArguments, "include_outline", documentSignals.has_outline);
+  setTrue(readPdfArguments, "include_page_labels", documentSignals.has_page_labels);
+  setTrue(readPdfArguments, "include_permissions", documentSignals.has_permissions);
+  setTrue(readPdfArguments, "include_form_fields", documentSignals.has_form_fields);
+  setTrue(readPdfArguments, "include_attachments", documentSignals.has_attachments);
+  setTrue(readPdfArguments, "include_structure_tree", documentSignals.has_structure_tree);
+  if (profile === "scanned_or_image_only") {
+    return {
+      workflow: "scanned_pdf_triage",
+      needs_ocr: true,
+      reason: "Sampled pages contain little selectable text and visible image paint operations; OCR or an optional advanced engine is likely required for text extraction.",
+      read_pdf_arguments: readPdfArguments
+    };
+  }
+  if (profile === "mixed_text_and_scan") {
+    Object.assign(readPdfArguments, {
+      include_chunks: true,
+      include_semantic_hints: true,
+      include_safety_findings: true,
+      include_markdown: true,
+      include_tables: true
+    });
+    return {
+      workflow: "mixed_pdf_review",
+      needs_ocr: true,
+      reason: "Some sampled pages look text-based while others look image-only; use read_pdf for selectable-text pages and OCR for scanned pages.",
+      read_pdf_arguments: readPdfArguments
+    };
+  }
+  if (profile === "digital_text") {
+    Object.assign(readPdfArguments, {
+      include_chunks: true,
+      include_semantic_hints: true,
+      include_safety_findings: true,
+      include_markdown: true,
+      include_tables: true
+    });
+    return {
+      workflow: "agentic_rag",
+      needs_ocr: false,
+      reason: "Sampled pages expose selectable text; citation chunks, semantic hints, table extraction, and safety findings are the highest-value next read_pdf options.",
+      read_pdf_arguments: readPdfArguments
+    };
+  }
+  return {
+    workflow: "metadata_review",
+    needs_ocr: false,
+    reason: "Sampled pages expose limited text; inspect metadata, forms, attachments, structure, and selected pages before running a heavier extraction.",
+    read_pdf_arguments: readPdfArguments
+  };
+};
+var inspectPdfSource = async (source, options) => {
+  const sourceDescription = source.path ?? source.url ?? "unknown source";
+  let pdfDocument = null;
+  try {
+    const targetPages = getTargetPages(source.pages, sourceDescription);
+    const { pages: _pages, ...loadArgs } = source;
+    pdfDocument = await loadPdfDocument(loadArgs, sourceDescription);
+    const totalPages = pdfDocument.numPages;
+    const validTargetPages = targetPages?.filter((page) => page <= totalPages);
+    const invalidPages = targetPages?.filter((page) => page > totalPages) ?? [];
+    const sampledPages = selectInspectionSamplePages(totalPages, validTargetPages, options.sample_pages);
+    const metadataOutput = await extractMetadataAndPageCount(pdfDocument, options.include_metadata, true);
+    const structureOutput = await extractDocumentStructure(pdfDocument, {
+      includeOutline: true,
+      includePageLabels: true,
+      includePermissions: true,
+      includeFormFields: true,
+      includeAttachments: true
+    });
+    const structureTrees = sampledPages.length > 0 ? await extractStructureTrees(pdfDocument, sampledPages) : [];
+    const documentSignals = buildDocumentSignals(structureOutput, structureTrees.length > 0);
+    const pageSignals = await Promise.all(sampledPages.map((pageNum) => inspectPageSignal(pdfDocument, pageNum)));
+    const pageGeometry = sampledPages.length > 0 ? await extractPageGeometry(pdfDocument, sampledPages) : [];
+    const profile = classifyPdfInspectionProfile(pageSignals);
+    const recommendation = buildInspectionRecommendation(source, profile, documentSignals);
+    const warnings = buildWarnings(invalidPages, totalPages);
+    if (targetPages !== undefined && sampledPages.length === 0) {
+      warnings.push("No requested pages are inside the document page range.");
+    }
+    if (recommendation.needs_ocr) {
+      warnings.push("Default PDF Reader MCP does not perform OCR; use an optional OCR-capable engine for scanned pages.");
+    }
+    const data = {
+      profile,
+      num_pages: totalPages,
+      sampled_pages: sampledPages,
+      page_signals: pageSignals,
+      document_signals: documentSignals,
+      recommendation,
+      ...metadataOutput.info ? { info: metadataOutput.info } : {},
+      ...metadataOutput.metadata ? { metadata: metadataOutput.metadata } : {},
+      ...pageGeometry.length > 0 ? { page_geometry: pageGeometry } : {},
+      ...warnings.length > 0 ? { warnings } : {}
+    };
+    return {
+      source: sourceDescription,
+      success: true,
+      data
+    };
+  } catch (error) {
+    if (error instanceof PdfError) {
+      return { source: sourceDescription, success: false, error: error.message };
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    logger5.error("Unexpected error inspecting PDF source", {
+      sourceDescription,
+      error: message
+    });
+    return {
+      source: sourceDescription,
+      success: false,
+      error: `Failed to inspect PDF from ${sourceDescription}.`
+    };
+  } finally {
+    const loadingTask = pdfDocument?.loadingTask;
+    if (loadingTask && typeof loadingTask.destroy === "function") {
+      try {
+        await loadingTask.destroy();
+      } catch (destroyError) {
+        const message = destroyError instanceof Error ? destroyError.message : String(destroyError);
+        logger5.warn("Error destroying PDF document after inspection", {
+          sourceDescription,
+          error: message
+        });
+      }
+    }
+  }
+};
+var defaultInspectPdfOptions = () => ({
+  sample_pages: DEFAULT_SAMPLE_PAGES,
+  include_metadata: true
+});
+
+// src/schemas/inspectPdf.ts
+import {
+  array as array2,
+  bool as bool2,
+  description as description2,
+  gte as gte2,
+  int as int2,
+  lte,
+  num as num2,
+  object as object2,
+  optional as optional2
+} from "@sylphx/vex";
+
+// src/schemas/readPdf.ts
+import {
+  array,
+  bool,
+  description,
+  gte,
+  int,
+  min,
+  num,
+  object,
+  optional,
+  str,
+  union
+} from "@sylphx/vex";
+var pageSpecifierSchema = union(array(num(int, gte(1))), str(min(1)));
+var pdfSourceSchema = object({
+  path: optional(str(min(1), description("Path to the local PDF file (absolute or relative to cwd)."))),
+  url: optional(str(min(1), description("URL of the PDF file."))),
+  pages: optional(pageSpecifierSchema)
+});
+var readPdfArgsSchema = object({
+  sources: array(pdfSourceSchema),
+  include_full_text: optional(bool(description("Include the full text content of each PDF (only if 'pages' is not specified for that source)."))),
+  include_metadata: optional(bool(description("Include metadata and info objects for each PDF."))),
+  include_page_count: optional(bool(description("Include the total number of pages for each PDF."))),
+  include_images: optional(bool(description("Extract and include embedded images from the PDF pages as base64-encoded data."))),
+  include_tables: optional(bool(description("Detect and extract tables from PDF pages. Uses spatial clustering of text coordinates to identify tabular structures."))),
+  include_elements: optional(bool(description("Include agent-ready structured document elements with page numbers, stable IDs, provenance, and best-effort bounding boxes."))),
+  include_semantic_hints: optional(bool(description("Include deterministic semantic hints on text elements, such as heading, list item, or paragraph."))),
+  include_markdown: optional(bool(description("Include a Markdown rendering of extracted pages for RAG, summarization, and agent context."))),
+  include_html: optional(bool(description("Include a simple HTML rendering of extracted pages for preview, export, and downstream conversion."))),
+  include_chunks: optional(bool(description("Include page-level citation-ready chunks with text, element IDs, page ranges, and best-effort bounding boxes."))),
+  include_outline: optional(bool(description("Include document outline/bookmark entries when the PDF exposes them."))),
+  include_annotations: optional(bool(description("Include page annotations such as links, notes, and form-related annotations with safe summary fields."))),
+  include_page_labels: optional(bool(description("Include PDF page labels when available, such as roman numerals or section labels."))),
+  include_page_geometry: optional(bool(description("Include page viewport geometry such as width, height, rotation, user unit, and view box."))),
+  include_permissions: optional(bool(description("Include PDF permission and marking signals when exposed by the parser."))),
+  include_form_fields: optional(bool(description("Include PDF form field summaries when AcroForm fields are exposed."))),
+  include_attachments: optional(bool(description("Include embedded attachment metadata such as filename and size. Attachment bytes are not returned."))),
+  include_structure_tree: optional(bool(description("Include best-effort tagged PDF structure trees for selected pages when the PDF exposes them."))),
+  include_safety_findings: optional(bool(description("Include deterministic content safety findings for prompt-injection patterns, tiny text, and off-page text.")))
+});
+
+// src/schemas/inspectPdf.ts
+var inspectPdfArgsSchema = object2({
+  sources: array2(pdfSourceSchema),
+  sample_pages: optional2(num2(int2, gte2(1), lte(20), description2("Maximum number of pages to sample per source for lightweight PDF profiling. Defaults to 5."))),
+  include_metadata: optional2(bool2(description2("Include PDF metadata and info objects in the inspection response.")))
+});
+
+// src/handlers/inspectPdf.ts
+var MAX_CONCURRENT_SOURCES = 3;
+var inspectPdf = tool().description("Inspects one or more PDFs and recommends the best read_pdf options for agentic extraction, citations, safety, and OCR triage.").input(inspectPdfArgsSchema).handler(async ({ input }) => {
+  const options = {
+    ...defaultInspectPdfOptions(),
+    ...input.sample_pages !== undefined ? { sample_pages: input.sample_pages } : {},
+    ...input.include_metadata !== undefined ? { include_metadata: input.include_metadata } : {}
+  };
+  const results = [];
+  for (let i = 0;i < input.sources.length; i += MAX_CONCURRENT_SOURCES) {
+    const batch = input.sources.slice(i, i + MAX_CONCURRENT_SOURCES);
+    const batchResults = await Promise.all(batch.map((source) => inspectPdfSource(source, options)));
+    results.push(...batchResults);
+  }
+  if (results.every((result) => !result.success)) {
+    const errorMessages = results.map((result) => result.error).join("; ");
+    return toolError(`All PDF sources failed inspection: ${errorMessages}`);
+  }
+  return text(JSON.stringify({ results }, null, 2));
+});
+
+// src/handlers/readPdf.ts
+import { image, text as text2, tool as tool2, toolError as toolError2 } from "@sylphx/mcp-server-sdk";
+
 // src/pdf/tableExtractor.ts
-var logger2 = createLogger("TableExtractor");
+var logger6 = createLogger("TableExtractor");
 var Y_TOLERANCE = 5;
 var COLUMN_GAP_THRESHOLD = 15;
 var MIN_ROWS = 2;
 var MIN_COLS = 2;
 var MIN_ROW_ITEMS = 2;
-var buildBoundingBox = (x, y, width, height) => {
+var buildBoundingBox2 = (x, y, width, height) => {
   if (![x, y, width].every(Number.isFinite) || height === undefined || !Number.isFinite(height)) {
     return;
   }
@@ -101,7 +1577,7 @@ var buildBoundingBox = (x, y, width, height) => {
     top: y + Math.max(0, height)
   };
 };
-var mergeBoundingBoxes = (boxes) => {
+var mergeBoundingBoxes2 = (boxes) => {
   if (boxes.length === 0)
     return;
   return {
@@ -132,7 +1608,7 @@ var extractTextItemsWithPositions = async (page) => {
       width: textItem.width ?? textItem.str.length * 6,
       ...height > 0 ? { height } : {},
       ...height > 0 ? {
-        bounding_box: buildBoundingBox(x, y, textItem.width ?? textItem.str.length * 6, height)
+        bounding_box: buildBoundingBox2(x, y, textItem.width ?? textItem.str.length * 6, height)
       } : {}
     });
   }
@@ -215,7 +1691,7 @@ var assignToTableCells = (row, rowIndex, columnBoundaries) => {
     }
   }
   const cells = accumulators.map((accumulator, colIndex) => {
-    const boundingBox = mergeBoundingBoxes(accumulator.boundingBoxes);
+    const boundingBox = mergeBoundingBoxes2(accumulator.boundingBoxes);
     return {
       text: accumulator.textParts.join(" "),
       rowIndex,
@@ -339,7 +1815,7 @@ var extractTablesFromPage = async (page, pageNum) => {
         tableCells.push(...assigned.cells);
       }
       const confidence = calculateConfidence(region.rows, region.columnBoundaries);
-      const tableBoundingBox = mergeBoundingBoxes(tableCells.map((cell) => cell.bounding_box).filter((box) => box !== undefined));
+      const tableBoundingBox = mergeBoundingBoxes2(tableCells.map((cell) => cell.bounding_box).filter((box) => box !== undefined));
       if (confidence >= 0.3) {
         tables.push({
           page: pageNum,
@@ -355,7 +1831,7 @@ var extractTablesFromPage = async (page, pageNum) => {
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    logger2.warn("Error extracting tables from page", { pageNum, error: message });
+    logger6.warn("Error extracting tables from page", { pageNum, error: message });
   }
   return tables;
 };
@@ -368,7 +1844,7 @@ var extractTables = async (pdfDocument, pagesToProcess) => {
       allTables.push(...pageTables);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      logger2.warn("Error getting page for table extraction", { pageNum, error: message });
+      logger6.warn("Error getting page for table extraction", { pageNum, error: message });
     }
   }
   return allTables;
@@ -768,1191 +2244,8 @@ var buildSafetyFindings = (pageContents, pageGeometry) => {
   return findings;
 };
 
-// src/pdf/extractor.ts
-import { OPS } from "pdfjs-dist/legacy/build/pdf.mjs";
-import { PNG } from "pngjs";
-var logger3 = createLogger("Extractor");
-var TEXT_SEGMENT_GAP_THRESHOLD = 48;
-var COLUMN_CUT_MIN_GAP = 48;
-var COLUMN_CUT_MIN_WIDTH_RATIO = 0.12;
-var SPANNING_WIDTH_RATIO = 0.72;
-var mergeBoundingBoxes2 = (boxes) => {
-  const validBoxes = boxes.filter((box) => box !== undefined);
-  if (validBoxes.length === 0)
-    return;
-  return {
-    left: Math.min(...validBoxes.map((box) => box.left)),
-    bottom: Math.min(...validBoxes.map((box) => box.bottom)),
-    right: Math.max(...validBoxes.map((box) => box.right)),
-    top: Math.max(...validBoxes.map((box) => box.top))
-  };
-};
-var buildBoundingBox2 = (x, y, width, height) => {
-  if (x === undefined || y === undefined || width === undefined || height === undefined) {
-    return;
-  }
-  if (![x, y, width, height].every(Number.isFinite)) {
-    return;
-  }
-  return {
-    left: x,
-    bottom: y,
-    right: x + Math.max(0, width),
-    top: y + Math.max(0, height)
-  };
-};
-var buildRectBoundingBox = (rect) => {
-  if (!rect || rect.length < 4)
-    return;
-  const [x1, y1, x2, y2] = rect;
-  if (x1 === undefined || y1 === undefined || x2 === undefined || y2 === undefined || ![x1, y1, x2, y2].every(Number.isFinite)) {
-    return;
-  }
-  return {
-    left: Math.min(x1, x2),
-    bottom: Math.min(y1, y2),
-    right: Math.max(x1, x2),
-    top: Math.max(y1, y2)
-  };
-};
-var finiteNumber = (value) => typeof value === "number" && Number.isFinite(value);
-var textFromAnnotationField = (direct, objectValue) => {
-  const value = direct ?? objectValue?.str;
-  return value && value.trim().length > 0 ? value : undefined;
-};
-var sanitizeOutlineItems = (items) => items.map((item) => {
-  const title = item.title?.trim();
-  if (!title)
-    return;
-  const children = item.items ? sanitizeOutlineItems(item.items) : undefined;
-  return {
-    title,
-    ...item.bold !== undefined ? { bold: item.bold } : {},
-    ...item.italic !== undefined ? { italic: item.italic } : {},
-    ...item.color ? { color: Array.from(item.color) } : {},
-    ...item.url ? { url: item.url } : {},
-    ...item.dest !== undefined ? { dest: item.dest } : {},
-    ...children && children.length > 0 ? { items: children } : {}
-  };
-}).filter((item) => item !== undefined);
-var PDF_PERMISSION_LABELS = new Map([
-  [4, "print"],
-  [8, "modify"],
-  [16, "copy"],
-  [32, "annotate"],
-  [256, "fill_forms"],
-  [512, "copy_for_accessibility"],
-  [1024, "assemble"],
-  [2048, "print_high_quality"]
-]);
-var permissionLabels = (permissions) => permissions.map((permission) => PDF_PERMISSION_LABELS.get(permission) ?? `unknown:${String(permission)}`);
-var attachmentSize = (content) => {
-  if (!content)
-    return;
-  if ("byteLength" in content && typeof content.byteLength === "number") {
-    return content.byteLength;
-  }
-  if ("length" in content && typeof content.length === "number") {
-    return content.length;
-  }
-  return;
-};
-var textSegmentToContentItem = (y, segment) => {
-  const textContent = segment.map((part) => part.text).join("");
-  if (!textContent.trim())
-    return null;
-  const boundingBox = mergeBoundingBoxes2(segment.map((part) => part.bounding_box));
-  const xPosition = boundingBox?.left ?? segment[0]?.x;
-  const width = boundingBox !== undefined ? boundingBox.right - boundingBox.left : segment.reduce((sum, part) => sum + part.width, 0);
-  const height = boundingBox !== undefined ? boundingBox.top - boundingBox.bottom : Math.max(...segment.map((part) => part.height), 0);
-  return {
-    type: "text",
-    yPosition: y,
-    xPosition,
-    width,
-    height,
-    bounding_box: boundingBox,
-    textContent
-  };
-};
-var splitTextPartsIntoSegments = (parts) => {
-  const sortedParts = [...parts].sort((a, b) => a.x - b.x);
-  const segments = [];
-  let currentSegment = [];
-  let previousRight;
-  for (const part of sortedParts) {
-    if (previousRight !== undefined && part.x - previousRight > TEXT_SEGMENT_GAP_THRESHOLD) {
-      if (currentSegment.length > 0) {
-        segments.push(currentSegment);
-      }
-      currentSegment = [];
-    }
-    currentSegment.push(part);
-    previousRight = Math.max(previousRight ?? part.x, part.x + part.width);
-  }
-  if (currentSegment.length > 0) {
-    segments.push(currentSegment);
-  }
-  return segments;
-};
-var sortByYThenX = (items) => [...items].sort((a, b) => b.yPosition - a.yPosition || (a.xPosition ?? 0) - (b.xPosition ?? 0));
-var findVerticalColumnCut = (items) => {
-  const boxedItems = items.filter((item) => item.bounding_box !== undefined);
-  if (boxedItems.length < 4)
-    return;
-  const left = Math.min(...boxedItems.map((item) => item.bounding_box?.left ?? 0));
-  const right = Math.max(...boxedItems.map((item) => item.bounding_box?.right ?? 0));
-  const pageWidth = right - left;
-  if (pageWidth <= 0)
-    return;
-  const narrowItems = boxedItems.filter((item) => {
-    const box = item.bounding_box;
-    if (!box)
-      return false;
-    return box.right - box.left < pageWidth * SPANNING_WIDTH_RATIO;
-  });
-  if (narrowItems.length < 4)
-    return;
-  const sorted = [...narrowItems].sort((a, b) => (a.bounding_box?.left ?? 0) - (b.bounding_box?.left ?? 0));
-  let currentRight = sorted[0]?.bounding_box?.right;
-  if (currentRight === undefined)
-    return;
-  let largestGap = 0;
-  let cutPosition;
-  for (let i = 1;i < sorted.length; i++) {
-    const box = sorted[i]?.bounding_box;
-    if (!box)
-      continue;
-    if (box.left > currentRight) {
-      const gap = box.left - currentRight;
-      if (gap > largestGap) {
-        largestGap = gap;
-        cutPosition = (box.left + currentRight) / 2;
-      }
-    }
-    currentRight = Math.max(currentRight, box.right);
-  }
-  if (cutPosition === undefined)
-    return;
-  const minGap = Math.max(COLUMN_CUT_MIN_GAP, pageWidth * COLUMN_CUT_MIN_WIDTH_RATIO);
-  if (largestGap < minGap)
-    return;
-  const leftCount = narrowItems.filter((item) => {
-    const box = item.bounding_box;
-    if (!box)
-      return false;
-    return (box.left + box.right) / 2 < cutPosition;
-  }).length;
-  const rightCount = narrowItems.length - leftCount;
-  return leftCount >= 2 && rightCount >= 2 ? cutPosition : undefined;
-};
-var sortPageContentItems = (items) => {
-  const cutPosition = findVerticalColumnCut(items);
-  if (cutPosition === undefined)
-    return sortByYThenX(items);
-  const leftColumn = [];
-  const rightColumn = [];
-  const spanning = [];
-  for (const item of items) {
-    const box = item.bounding_box;
-    if (!box) {
-      spanning.push(item);
-      continue;
-    }
-    if (box.left < cutPosition && box.right > cutPosition) {
-      spanning.push(item);
-      continue;
-    }
-    const center = (box.left + box.right) / 2;
-    if (center < cutPosition) {
-      leftColumn.push(item);
-    } else {
-      rightColumn.push(item);
-    }
-  }
-  const columnItems = [...leftColumn, ...rightColumn].filter((item) => item.bounding_box);
-  const highestColumnTop = columnItems.length > 0 ? Math.max(...columnItems.map((item) => item.bounding_box?.top ?? item.yPosition)) : Number.POSITIVE_INFINITY;
-  const topSpanning = spanning.filter((item) => (item.bounding_box?.top ?? item.yPosition) >= highestColumnTop);
-  const remainingSpanning = spanning.filter((item) => (item.bounding_box?.top ?? item.yPosition) < highestColumnTop);
-  return [
-    ...sortByYThenX(topSpanning),
-    ...sortByYThenX(leftColumn),
-    ...sortByYThenX(rightColumn),
-    ...sortByYThenX(remainingSpanning)
-  ];
-};
-var encodePixelsToPNG = (pixelData, width, height, channels) => {
-  const png = new PNG({ width, height });
-  if (channels === 4) {
-    png.data = Buffer.from(pixelData);
-  } else if (channels === 3) {
-    for (let i = 0;i < width * height; i++) {
-      const srcIdx = i * 3;
-      const dstIdx = i * 4;
-      png.data[dstIdx] = pixelData[srcIdx] ?? 0;
-      png.data[dstIdx + 1] = pixelData[srcIdx + 1] ?? 0;
-      png.data[dstIdx + 2] = pixelData[srcIdx + 2] ?? 0;
-      png.data[dstIdx + 3] = 255;
-    }
-  } else if (channels === 1) {
-    for (let i = 0;i < width * height; i++) {
-      const gray = pixelData[i] ?? 0;
-      const dstIdx = i * 4;
-      png.data[dstIdx] = gray;
-      png.data[dstIdx + 1] = gray;
-      png.data[dstIdx + 2] = gray;
-      png.data[dstIdx + 3] = 255;
-    }
-  }
-  const pngBuffer = PNG.sync.write(png);
-  return pngBuffer.toString("base64");
-};
-var processImageData = (imageData, pageNum, arrayIndex) => {
-  if (!imageData || typeof imageData !== "object") {
-    return null;
-  }
-  const img = imageData;
-  if (!img.data || !img.width || !img.height) {
-    return null;
-  }
-  const channels = img.kind === 1 ? 1 : img.kind === 3 ? 4 : 3;
-  const format = img.kind === 1 ? "grayscale" : img.kind === 3 ? "rgba" : "rgb";
-  const pngBase64 = encodePixelsToPNG(img.data, img.width, img.height, channels);
-  return {
-    page: pageNum,
-    index: arrayIndex,
-    width: img.width,
-    height: img.height,
-    format,
-    data: pngBase64
-  };
-};
-var retrieveImageData = async (page, imageName, pageNum) => {
-  if (imageName.startsWith("g_")) {
-    try {
-      const imageData = page.commonObjs.get(imageName);
-      if (imageData) {
-        return imageData;
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger3.warn("Error getting image from commonObjs", { imageName, error: message });
-    }
-  }
-  try {
-    const imageData = page.objs.get(imageName);
-    if (imageData !== undefined) {
-      return imageData;
-    }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    logger3.warn("Sync image get failed, trying async", { imageName, error: message });
-  }
-  return new Promise((resolve) => {
-    let resolved = false;
-    let timeoutId = null;
-    const cleanup = () => {
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-        timeoutId = null;
-      }
-    };
-    timeoutId = setTimeout(() => {
-      if (!resolved) {
-        resolved = true;
-        cleanup();
-        logger3.warn("Image extraction timeout", { imageName, pageNum });
-        resolve(null);
-      }
-    }, 1e4);
-    try {
-      page.objs.get(imageName, (imageData) => {
-        if (!resolved) {
-          resolved = true;
-          cleanup();
-          resolve(imageData);
-        }
-      });
-    } catch (error) {
-      if (!resolved) {
-        resolved = true;
-        cleanup();
-        const message = error instanceof Error ? error.message : String(error);
-        logger3.warn("Error in async image get", { imageName, error: message });
-        resolve(null);
-      }
-    }
-  });
-};
-var extractMetadataAndPageCount = async (pdfDocument, includeMetadata, includePageCount) => {
-  const output = {};
-  if (includePageCount) {
-    output.num_pages = pdfDocument.numPages;
-  }
-  if (includeMetadata) {
-    try {
-      const pdfMetadata = await pdfDocument.getMetadata();
-      const infoData = pdfMetadata.info;
-      if (infoData !== undefined) {
-        output.info = infoData;
-      }
-      const metadataObj = pdfMetadata.metadata;
-      if (metadataObj && typeof metadataObj.getAll === "function") {
-        output.metadata = metadataObj.getAll();
-      } else if (metadataObj && typeof metadataObj === "object") {
-        const metadataRecord = {};
-        for (const key in metadataObj) {
-          if (Object.hasOwn(metadataObj, key)) {
-            metadataRecord[key] = metadataObj[key];
-          }
-        }
-        output.metadata = metadataRecord;
-      }
-    } catch (metaError) {
-      const message = metaError instanceof Error ? metaError.message : String(metaError);
-      logger3.warn("Error extracting metadata", { error: message });
-    }
-  }
-  return output;
-};
-var extractDocumentStructure = async (pdfDocument, options) => {
-  const documentWithStructure = pdfDocument;
-  const output = {};
-  if (options.includeOutline && typeof documentWithStructure.getOutline === "function") {
-    try {
-      const outline = await documentWithStructure.getOutline();
-      if (outline && outline.length > 0) {
-        output.outline = sanitizeOutlineItems(outline);
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger3.warn("Error extracting outline", { error: message });
-    }
-  }
-  if (options.includePageLabels && typeof documentWithStructure.getPageLabels === "function") {
-    try {
-      const pageLabels = await documentWithStructure.getPageLabels();
-      if (pageLabels && pageLabels.length > 0) {
-        output.page_labels = pageLabels;
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger3.warn("Error extracting page labels", { error: message });
-    }
-  }
-  if (options.includePermissions && typeof documentWithStructure.getPermissions === "function") {
-    try {
-      const permissions = await documentWithStructure.getPermissions();
-      if (permissions && permissions.length > 0) {
-        output.permissions = permissionLabels(permissions);
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger3.warn("Error extracting permissions", { error: message });
-    }
-  }
-  if (options.includePermissions && typeof documentWithStructure.getMarkInfo === "function") {
-    try {
-      const markInfo = await documentWithStructure.getMarkInfo();
-      if (markInfo && Object.keys(markInfo).length > 0) {
-        output.mark_info = markInfo;
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger3.warn("Error extracting mark info", { error: message });
-    }
-  }
-  if (options.includeFormFields && typeof documentWithStructure.getFieldObjects === "function") {
-    try {
-      const fieldObjects = await documentWithStructure.getFieldObjects();
-      if (fieldObjects) {
-        const fields = Object.entries(fieldObjects).flatMap(([name, fieldOrFields]) => {
-          const fieldList = Array.isArray(fieldOrFields) ? fieldOrFields : [fieldOrFields];
-          return fieldList.map((field) => normalizeFormField(name, field));
-        }).filter((field) => field !== undefined);
-        if (fields.length > 0) {
-          output.form_fields = fields;
-        }
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger3.warn("Error extracting form fields", { error: message });
-    }
-  }
-  if (options.includeAttachments && typeof documentWithStructure.getAttachments === "function") {
-    try {
-      const attachments = await documentWithStructure.getAttachments();
-      if (attachments) {
-        const attachmentSummaries = Object.entries(attachments).map(([name, attachment]) => {
-          const size = attachmentSize(attachment.content);
-          return {
-            name,
-            ...attachment.filename ? { filename: attachment.filename } : {},
-            ...attachment.description ? { description: attachment.description } : {},
-            ...size !== undefined ? { size_bytes: size } : {}
-          };
-        });
-        if (attachmentSummaries.length > 0) {
-          output.attachments = attachmentSummaries;
-        }
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger3.warn("Error extracting attachments", { error: message });
-    }
-  }
-  return output;
-};
-var normalizeFormField = (fallbackName, field) => {
-  const name = (field.name ?? field.fieldName ?? fallbackName).trim();
-  if (!name)
-    return;
-  const page = field.page !== undefined ? field.page : field.pageIndex !== undefined ? field.pageIndex + 1 : undefined;
-  const fieldType = field.type ?? field.fieldType;
-  const boundingBox = buildRectBoundingBox(field.rect);
-  return {
-    name,
-    ...fieldType ? { type: fieldType } : {},
-    ...field.value !== undefined ? { value: field.value } : {},
-    ...field.defaultValue !== undefined ? { default_value: field.defaultValue } : {},
-    ...page !== undefined ? { page } : {},
-    ...field.id ? { id: field.id } : {},
-    ...field.editable !== undefined ? { editable: field.editable } : {},
-    ...field.required !== undefined ? { required: field.required } : {},
-    ...boundingBox ? { bounding_box: boundingBox } : {}
-  };
-};
-var normalizeAnnotation = (annotation, pageNum) => {
-  const contents = textFromAnnotationField(annotation.contents, annotation.contentsObj);
-  const title = textFromAnnotationField(annotation.title, annotation.titleObj);
-  const boundingBox = buildRectBoundingBox(annotation.rect);
-  const subtype = annotation.subtype?.trim();
-  const url = annotation.url ?? annotation.unsafeUrl;
-  if (!annotation.id && !subtype && !contents && !title && !url && annotation.dest === undefined) {
-    return;
-  }
-  return {
-    page: pageNum,
-    ...annotation.id ? { id: annotation.id } : {},
-    ...subtype ? { subtype } : {},
-    ...contents ? { contents } : {},
-    ...title ? { title } : {},
-    ...url ? { url } : {},
-    ...annotation.dest !== undefined ? { dest: annotation.dest } : {},
-    ...boundingBox ? { bounding_box: boundingBox } : {}
-  };
-};
-var isRecord = (value) => typeof value === "object" && value !== null;
-var normalizeStructureTreeContent = (rawContent) => {
-  const type = typeof rawContent.type === "string" ? rawContent.type.trim() : "";
-  const id = typeof rawContent.id === "string" ? rawContent.id.trim() : "";
-  if (!type && !id)
-    return;
-  return {
-    type: type || "content",
-    ...id ? { id } : {}
-  };
-};
-var normalizeStructureTreeChild = (rawChild) => {
-  if (!isRecord(rawChild))
-    return;
-  if ("role" in rawChild || "children" in rawChild) {
-    return normalizeStructureTreeNode(rawChild);
-  }
-  return normalizeStructureTreeContent(rawChild);
-};
-var normalizeStructureTreeNode = (rawNode) => {
-  const role = typeof rawNode.role === "string" && rawNode.role.trim() ? rawNode.role.trim() : "Unknown";
-  const children = Array.isArray(rawNode.children) ? rawNode.children.map((child) => normalizeStructureTreeChild(child)).filter((child) => child !== undefined) : [];
-  return {
-    role,
-    ...children.length > 0 ? { children } : {}
-  };
-};
-var extractAnnotations = async (pdfDocument, pagesToProcess) => {
-  const pageAnnotations = [];
-  for (const pageNum of pagesToProcess) {
-    try {
-      const page = await pdfDocument.getPage(pageNum);
-      if (typeof page.getAnnotations !== "function")
-        continue;
-      const annotations = await page.getAnnotations({ intent: "display" });
-      const normalized = annotations.map((annotation) => normalizeAnnotation(annotation, pageNum)).filter((annotation) => annotation !== undefined);
-      if (normalized.length > 0) {
-        pageAnnotations.push({ page: pageNum, annotations: normalized });
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger3.warn("Error extracting annotations from page", { pageNum, error: message });
-    }
-  }
-  return pageAnnotations;
-};
-var extractStructureTrees = async (pdfDocument, pagesToProcess) => {
-  const pageStructureTrees = [];
-  for (const pageNum of pagesToProcess) {
-    try {
-      const page = await pdfDocument.getPage(pageNum);
-      if (typeof page.getStructTree !== "function")
-        continue;
-      const rawTree = await page.getStructTree();
-      if (!rawTree)
-        continue;
-      pageStructureTrees.push({
-        page: pageNum,
-        tree: normalizeStructureTreeNode(rawTree)
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger3.warn("Error extracting structure tree", { pageNum, error: message });
-    }
-  }
-  return pageStructureTrees;
-};
-var extractPageGeometry = async (pdfDocument, pagesToProcess) => {
-  const pageGeometry = [];
-  for (const pageNum of pagesToProcess) {
-    try {
-      const page = await pdfDocument.getPage(pageNum);
-      const viewBox = buildRectBoundingBox(page.view);
-      const viewport = page.getViewport({ scale: 1 });
-      const width = finiteNumber(viewport.width) ? viewport.width : viewBox ? viewBox.right - viewBox.left : undefined;
-      const height = finiteNumber(viewport.height) ? viewport.height : viewBox ? viewBox.top - viewBox.bottom : undefined;
-      if (!finiteNumber(width) || !finiteNumber(height)) {
-        logger3.warn("Skipping page geometry with invalid dimensions", { pageNum });
-        continue;
-      }
-      pageGeometry.push({
-        page: pageNum,
-        width,
-        height,
-        rotation: finiteNumber(page.rotate) ? page.rotate : 0,
-        ...finiteNumber(page.userUnit) ? { user_unit: page.userUnit } : {},
-        ...viewBox ? { view_box: viewBox } : {}
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger3.warn("Error extracting page geometry", { pageNum, error: message });
-    }
-  }
-  return pageGeometry;
-};
-var buildWarnings = (invalidPages, totalPages) => {
-  if (invalidPages.length === 0) {
-    return [];
-  }
-  return [
-    `Requested page numbers ${invalidPages.join(", ")} exceed total pages (${String(totalPages)}).`
-  ];
-};
-var extractPageContent = async (pdfDocument, pageNum, includeImages, sourceDescription) => {
-  const contentItems = [];
-  try {
-    const page = await pdfDocument.getPage(pageNum);
-    const textContent = await page.getTextContent();
-    const textByY = new Map;
-    for (const item of textContent.items) {
-      const textItem = item;
-      const xCoord = textItem.transform?.[4];
-      const yCoord = textItem.transform?.[5];
-      if (yCoord === undefined)
-        continue;
-      const y = Math.round(yCoord);
-      const width = textItem.width ?? textItem.str.length * 6;
-      const height = textItem.height ?? Math.abs(textItem.transform?.[3] ?? 0);
-      const boundingBox = buildBoundingBox2(xCoord, yCoord, width, height);
-      if (!textByY.has(y)) {
-        textByY.set(y, []);
-      }
-      textByY.get(y)?.push({
-        text: textItem.str,
-        x: xCoord ?? 0,
-        width,
-        height,
-        bounding_box: boundingBox
-      });
-    }
-    for (const [y, textParts] of textByY.entries()) {
-      for (const segment of splitTextPartsIntoSegments(textParts)) {
-        const contentItem = textSegmentToContentItem(y, segment);
-        if (contentItem) {
-          contentItems.push(contentItem);
-        }
-      }
-    }
-    if (includeImages) {
-      const operatorList = await page.getOperatorList();
-      const imageIndices = [];
-      for (let i = 0;i < operatorList.fnArray.length; i++) {
-        const op = operatorList.fnArray[i];
-        if (op === OPS.paintImageXObject || op === OPS.paintXObject) {
-          imageIndices.push(i);
-        }
-      }
-      const imagePromises = imageIndices.map(async (imgIndex, arrayIndex) => {
-        const argsArray = operatorList.argsArray[imgIndex];
-        if (!argsArray || argsArray.length === 0) {
-          return null;
-        }
-        const imageName = argsArray[0];
-        let xPosition;
-        let yPosition;
-        if (argsArray.length > 1 && Array.isArray(argsArray[1])) {
-          const transform = argsArray[1];
-          const xCoord = transform[4];
-          const yCoord = transform[5];
-          if (xCoord !== undefined) {
-            xPosition = Math.round(xCoord);
-          }
-          if (yCoord !== undefined) {
-            yPosition = Math.round(yCoord);
-          }
-        }
-        const imageData = await retrieveImageData(page, imageName, pageNum);
-        const extractedImage = processImageData(imageData, pageNum, arrayIndex);
-        if (extractedImage) {
-          const imageBox = buildBoundingBox2(xPosition, yPosition, extractedImage.width, extractedImage.height);
-          extractedImage.bounding_box = imageBox;
-          return {
-            type: "image",
-            yPosition: imageBox?.top ?? yPosition ?? 0,
-            xPosition,
-            width: extractedImage.width,
-            height: extractedImage.height,
-            bounding_box: imageBox,
-            imageData: extractedImage
-          };
-        }
-        return null;
-      });
-      const resolvedImages = await Promise.all(imagePromises);
-      const validImages = resolvedImages.filter((item) => item !== null);
-      contentItems.push(...validImages);
-    }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    logger3.warn("Error extracting page content", {
-      pageNum,
-      sourceDescription,
-      error: message
-    });
-    return [
-      {
-        type: "text",
-        yPosition: 0,
-        textContent: `[Error processing page ${String(pageNum)}]`
-      }
-    ];
-  }
-  return sortPageContentItems(contentItems);
-};
-
-// src/pdf/loader.ts
-import fs3 from "node:fs/promises";
-import { createRequire } from "node:module";
-import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
-
-// src/utils/config.ts
-import dns from "node:dns";
-import fs from "node:fs";
-import net from "node:net";
-import path from "node:path";
-var splitList = (value, separators) => value.split(separators).map((s) => s.trim()).filter((s) => s.length > 0);
-var canonicalizeDir = (p) => {
-  try {
-    return fs.realpathSync(p);
-  } catch (err) {
-    if (typeof err === "object" && err !== null && "code" in err && (err.code === "ENOENT" || err.code === "ENOTDIR")) {
-      const parent = path.dirname(p);
-      if (parent === p)
-        return p;
-      return path.join(canonicalizeDir(parent), path.basename(p));
-    }
-    throw err;
-  }
-};
-var parseDirs = (values) => values.map((dir) => canonicalizeDir(path.resolve(path.normalize(dir))));
-var parseBool = (value, fallback) => {
-  if (value === undefined)
-    return fallback;
-  const v = value.trim().toLowerCase();
-  if (v === "false" || v === "0" || v === "no" || v === "off")
-    return false;
-  if (v === "true" || v === "1" || v === "yes" || v === "on")
-    return true;
-  return fallback;
-};
-var parseCliFlags = (argv) => {
-  const dirs = [];
-  const hosts = [];
-  let noHttp = false;
-  let allowPrivateIps = false;
-  for (const arg of argv) {
-    if (arg.startsWith("--allow-dir=")) {
-      dirs.push(arg.slice("--allow-dir=".length));
-    } else if (arg.startsWith("--allow-host=")) {
-      hosts.push(arg.slice("--allow-host=".length).toLowerCase());
-    } else if (arg === "--no-http") {
-      noHttp = true;
-    } else if (arg === "--allow-private-ips") {
-      allowPrivateIps = true;
-    }
-  }
-  return { dirs, hosts, noHttp, allowPrivateIps };
-};
-var envList = (raw, separators, transform = (v) => v) => raw ? splitList(raw, separators).map(transform) : [];
-var readSecurityConfig = (argv = process.argv.slice(2), env = process.env) => {
-  const cli = parseCliFlags(argv);
-  const envDirs = envList(env["MCP_PDF_ALLOWED_DIRS"], /[:,]/);
-  const envHosts = envList(env["MCP_PDF_ALLOWED_HOSTS"], /,/, (h) => h.toLowerCase());
-  const mergedDirs = [...cli.dirs, ...envDirs];
-  const mergedHosts = [...cli.hosts, ...envHosts];
-  return {
-    allowedDirs: mergedDirs.length > 0 ? parseDirs(mergedDirs) : null,
-    allowHttp: cli.noHttp ? false : parseBool(env["MCP_PDF_ALLOW_HTTP"], true),
-    allowedHosts: mergedHosts.length > 0 ? mergedHosts : null,
-    allowPrivateIps: cli.allowPrivateIps || parseBool(env["MCP_PDF_ALLOW_PRIVATE_IPS"], false)
-  };
-};
-var cached = null;
-var getSecurityConfig = () => {
-  if (cached === null) {
-    cached = readSecurityConfig();
-  }
-  return cached;
-};
-var isPathAllowed = (absPath, allowedDirs) => {
-  if (allowedDirs === null)
-    return true;
-  if (allowedDirs.length === 0)
-    return false;
-  const normalized = path.resolve(absPath);
-  return allowedDirs.some((dir) => {
-    const rel = path.relative(dir, normalized);
-    if (rel === "")
-      return true;
-    if (rel.startsWith(".."))
-      return false;
-    if (path.isAbsolute(rel))
-      return false;
-    return true;
-  });
-};
-var isUrlAllowed = (urlString, config) => {
-  if (!config.allowHttp)
-    return false;
-  let parsed;
-  try {
-    parsed = new URL(urlString);
-  } catch {
-    return false;
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:")
-    return false;
-  if (config.allowedHosts === null)
-    return true;
-  return config.allowedHosts.includes(parsed.hostname.toLowerCase());
-};
-var PRIVATE_IPV4_PREDICATES = [
-  (a) => a === 10,
-  (a, b) => a === 172 && b >= 16 && b <= 31,
-  (a, b) => a === 192 && b === 168,
-  (a) => a === 127,
-  (a, b) => a === 169 && b === 254,
-  (a) => a === 0,
-  (a, b) => a === 100 && b >= 64 && b <= 127,
-  (a) => a >= 224
-];
-var isPrivateIpv4 = (ip) => {
-  const parts = ip.split(".").map((s) => Number.parseInt(s, 10));
-  const a = parts[0];
-  const b = parts[1];
-  if (a === undefined || b === undefined)
-    return true;
-  return PRIVATE_IPV4_PREDICATES.some((pred) => pred(a, b));
-};
-var isPrivateIpv6 = (ip) => {
-  const lower = ip.toLowerCase();
-  if (lower === "::1" || lower === "::")
-    return true;
-  if (lower.startsWith("fc") || lower.startsWith("fd"))
-    return true;
-  if (lower.startsWith("fe80"))
-    return true;
-  if (lower.startsWith("ff"))
-    return true;
-  if (lower.startsWith("::ffff:")) {
-    const tail = lower.slice("::ffff:".length);
-    if (net.isIPv4(tail))
-      return isPrivateIpv4(tail);
-  }
-  return false;
-};
-var isPrivateIp = (ip) => {
-  if (net.isIPv4(ip))
-    return isPrivateIpv4(ip);
-  if (net.isIPv6(ip))
-    return isPrivateIpv6(ip);
-  return true;
-};
-var assertUrlNotPrivate = async (hostname) => {
-  if (net.isIP(hostname)) {
-    if (isPrivateIp(hostname)) {
-      throw new Error(`URL host '${hostname}' resolves to a non-public address (SSRF protection).`);
-    }
-    return;
-  }
-  let addresses;
-  try {
-    addresses = await dns.promises.lookup(hostname, { all: true });
-  } catch {
-    throw new Error(`URL host '${hostname}' could not be resolved.`);
-  }
-  if (addresses.length === 0) {
-    throw new Error(`URL host '${hostname}' resolved to no addresses.`);
-  }
-  for (const { address } of addresses) {
-    if (isPrivateIp(address)) {
-      throw new Error(`URL host '${hostname}' resolves to a non-public address (SSRF protection).`);
-    }
-  }
-};
-
-// src/utils/errors.ts
-class PdfError extends Error {
-  code;
-  constructor(code, message, options) {
-    super(message, options?.cause ? { cause: options.cause } : undefined);
-    this.code = code;
-    this.name = "PdfError";
-  }
-}
-
-// src/utils/pathUtils.ts
-import fs2 from "node:fs";
-import path2 from "node:path";
-var PROJECT_ROOT = process.cwd();
-var canonicalize = (p) => {
-  try {
-    return fs2.realpathSync(p);
-  } catch (err) {
-    if (typeof err === "object" && err !== null && "code" in err && (err.code === "ENOENT" || err.code === "ENOTDIR")) {
-      const parent = path2.dirname(p);
-      if (parent === p)
-        return p;
-      return path2.join(canonicalize(parent), path2.basename(p));
-    }
-    throw err;
-  }
-};
-var resolvePath = (userPath) => {
-  if (typeof userPath !== "string") {
-    throw new PdfError(-32602 /* InvalidParams */, "Path must be a string.");
-  }
-  const normalizedUserPath = path2.normalize(userPath);
-  const resolved = path2.isAbsolute(normalizedUserPath) ? normalizedUserPath : path2.resolve(PROJECT_ROOT, normalizedUserPath);
-  const canonical = canonicalize(resolved);
-  const { allowedDirs } = getSecurityConfig();
-  if (!isPathAllowed(canonical, allowedDirs)) {
-    throw new PdfError(-32600 /* InvalidRequest */, `Access denied: path '${userPath}' is outside the allowed directories.`);
-  }
-  return canonical;
-};
-
-// src/pdf/loader.ts
-var logger4 = createLogger("Loader");
-var require2 = createRequire(import.meta.url);
-var PDFJS_ROOT = require2.resolve("pdfjs-dist/package.json").replace("package.json", "");
-var CMAP_URL = `${PDFJS_ROOT}cmaps/`;
-var STANDARD_FONT_DATA_URL = `${PDFJS_ROOT}standard_fonts/`;
-var WASM_URL = `${PDFJS_ROOT}wasm/`;
-var ICC_URL = `${PDFJS_ROOT}iccs/`;
-var MAX_PDF_SIZE = 100 * 1024 * 1024;
-var URL_FETCH_TIMEOUT_MS = 30000;
-var MAX_REDIRECTS = 5;
-var formatBytes = (bytes) => `${(bytes / 1024 / 1024).toFixed(0)}MB`;
-var sanitizeSourceDescription = (description) => description.length > 200 ? `${description.slice(0, 197)}...` : description;
-var loadLocalFile = async (userPath) => {
-  const safePath = resolvePath(userPath);
-  let stats;
-  try {
-    stats = await fs3.stat(safePath);
-  } catch (err) {
-    if (typeof err === "object" && err !== null && "code" in err && err.code === "ENOENT") {
-      throw new PdfError(-32600 /* InvalidRequest */, `File not found at '${userPath}'.`, {
-        cause: err instanceof Error ? err : undefined
-      });
-    }
-    throw new PdfError(-32600 /* InvalidRequest */, `Failed to access file at '${userPath}'.`, {
-      cause: err instanceof Error ? err : undefined
-    });
-  }
-  if (!stats.isFile()) {
-    throw new PdfError(-32600 /* InvalidRequest */, `Path '${userPath}' is not a regular file.`);
-  }
-  if (stats.size > MAX_PDF_SIZE) {
-    throw new PdfError(-32600 /* InvalidRequest */, `PDF file exceeds maximum size of ${formatBytes(MAX_PDF_SIZE)}. File size: ${formatBytes(stats.size)}.`);
-  }
-  const buffer = await fs3.readFile(safePath);
-  return new Uint8Array(buffer);
-};
-var validateUrlHop = async (urlString, config) => {
-  if (!isUrlAllowed(urlString, config)) {
-    const reason = config.allowHttp ? "host is not in the allowed list or scheme is not http(s)" : "HTTP access is disabled";
-    throw new PdfError(-32600 /* InvalidRequest */, `Access denied: URL '${urlString}' rejected (${reason}).`);
-  }
-  if (!config.allowPrivateIps) {
-    let hostname;
-    try {
-      hostname = new URL(urlString).hostname;
-    } catch {
-      throw new PdfError(-32600 /* InvalidRequest */, `Invalid URL: '${urlString}'.`);
-    }
-    try {
-      await assertUrlNotPrivate(hostname);
-    } catch (err) {
-      const reason = err instanceof Error ? err.message : "SSRF check failed";
-      throw new PdfError(-32600 /* InvalidRequest */, `Access denied: ${reason}`);
-    }
-  }
-};
-var fetchUrlBody = async (url, config) => {
-  let currentUrl = url;
-  const controller = new AbortController;
-  const timeout = setTimeout(() => controller.abort(), URL_FETCH_TIMEOUT_MS);
-  try {
-    for (let hop = 0;hop <= MAX_REDIRECTS; hop++) {
-      await validateUrlHop(currentUrl, config);
-      const response = await fetch(currentUrl, {
-        redirect: "manual",
-        signal: controller.signal
-      });
-      if (response.status >= 300 && response.status < 400) {
-        const location = response.headers.get("location");
-        if (!location) {
-          throw new PdfError(-32600 /* InvalidRequest */, `URL fetch failed: redirect without Location header.`);
-        }
-        currentUrl = new URL(location, currentUrl).toString();
-        continue;
-      }
-      if (!response.ok) {
-        throw new PdfError(-32600 /* InvalidRequest */, `URL fetch failed with HTTP ${String(response.status)}.`);
-      }
-      const contentLengthHeader = response.headers.get("content-length");
-      if (contentLengthHeader !== null) {
-        const declared = Number.parseInt(contentLengthHeader, 10);
-        if (Number.isFinite(declared) && declared > MAX_PDF_SIZE) {
-          throw new PdfError(-32600 /* InvalidRequest */, `Remote PDF exceeds maximum size of ${formatBytes(MAX_PDF_SIZE)} (Content-Length: ${formatBytes(declared)}).`);
-        }
-      }
-      if (!response.body) {
-        const ab = await response.arrayBuffer();
-        if (ab.byteLength > MAX_PDF_SIZE) {
-          throw new PdfError(-32600 /* InvalidRequest */, `Remote PDF exceeds maximum size of ${formatBytes(MAX_PDF_SIZE)}.`);
-        }
-        return new Uint8Array(ab);
-      }
-      const reader = response.body.getReader();
-      const chunks = [];
-      let total = 0;
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done)
-          break;
-        if (value) {
-          total += value.byteLength;
-          if (total > MAX_PDF_SIZE) {
-            await reader.cancel().catch(() => {});
-            throw new PdfError(-32600 /* InvalidRequest */, `Remote PDF exceeds maximum size of ${formatBytes(MAX_PDF_SIZE)} during streaming.`);
-          }
-          chunks.push(value);
-        }
-      }
-      const combined = new Uint8Array(total);
-      let offset = 0;
-      for (const chunk of chunks) {
-        combined.set(chunk, offset);
-        offset += chunk.byteLength;
-      }
-      return combined;
-    }
-    throw new PdfError(-32600 /* InvalidRequest */, `URL fetch failed: exceeded redirect limit (${String(MAX_REDIRECTS)}).`);
-  } catch (err) {
-    if (err instanceof PdfError)
-      throw err;
-    if (err instanceof Error && (err.name === "AbortError" || err.name === "TimeoutError")) {
-      throw new PdfError(-32600 /* InvalidRequest */, `URL fetch timed out after ${String(URL_FETCH_TIMEOUT_MS / 1000)}s.`, { cause: err });
-    }
-    const message = err instanceof Error ? err.message : String(err);
-    logger4.warn("URL fetch failed", { url, error: message });
-    throw new PdfError(-32600 /* InvalidRequest */, `URL fetch failed for '${url}'.`, {
-      cause: err instanceof Error ? err : undefined
-    });
-  } finally {
-    clearTimeout(timeout);
-  }
-};
-var loadPdfDocument = async (source, sourceDescription) => {
-  const safeSource = sanitizeSourceDescription(sourceDescription);
-  let pdfData;
-  try {
-    if (source.path) {
-      pdfData = await loadLocalFile(source.path);
-    } else if (source.url) {
-      const config = getSecurityConfig();
-      pdfData = await fetchUrlBody(source.url, config);
-    } else {
-      throw new PdfError(-32602 /* InvalidParams */, `Source ${safeSource} missing 'path' or 'url'.`);
-    }
-  } catch (err) {
-    if (err instanceof PdfError) {
-      throw err;
-    }
-    const message = err instanceof Error ? err.message : String(err);
-    logger4.error("Unexpected error preparing PDF source", {
-      sourceDescription: safeSource,
-      error: message
-    });
-    throw new PdfError(-32600 /* InvalidRequest */, `Failed to prepare PDF source ${safeSource}.`, {
-      cause: err instanceof Error ? err : undefined
-    });
-  }
-  const loadingTask = getDocument({
-    data: pdfData,
-    cMapUrl: CMAP_URL,
-    cMapPacked: true,
-    standardFontDataUrl: STANDARD_FONT_DATA_URL,
-    wasmUrl: WASM_URL,
-    iccUrl: ICC_URL
-  });
-  try {
-    return await loadingTask.promise;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    logger4.error("PDF.js loading error", { sourceDescription: safeSource, error: message });
-    throw new PdfError(-32600 /* InvalidRequest */, `Failed to load PDF document from ${safeSource}.`, { cause: err instanceof Error ? err : undefined });
-  }
-};
-
-// src/pdf/parser.ts
-var logger5 = createLogger("Parser");
-var MAX_RANGE_SIZE = 1e4;
-var parseRangePart = (part, pages) => {
-  const trimmedPart = part.trim();
-  if (trimmedPart.includes("-")) {
-    const splitResult = trimmedPart.split("-");
-    const startStr = splitResult[0] || "";
-    const endStr = splitResult[1];
-    const start = parseInt(startStr, 10);
-    const end = endStr === "" || endStr === undefined ? Infinity : parseInt(endStr, 10);
-    if (Number.isNaN(start) || Number.isNaN(end) || start <= 0 || start > end) {
-      throw new Error(`Invalid page range values: ${trimmedPart}`);
-    }
-    const practicalEnd = Math.min(end, start + MAX_RANGE_SIZE);
-    for (let i = start;i <= practicalEnd; i++) {
-      pages.add(i);
-    }
-    if (end === Infinity && practicalEnd === start + MAX_RANGE_SIZE) {
-      logger5.warn("Open-ended range truncated", { start, practicalEnd });
-    }
-  } else {
-    const page = parseInt(trimmedPart, 10);
-    if (Number.isNaN(page) || page <= 0) {
-      throw new Error(`Invalid page number: ${trimmedPart}`);
-    }
-    pages.add(page);
-  }
-};
-var parsePageRanges = (ranges) => {
-  const pages = new Set;
-  const parts = ranges.split(",");
-  for (const part of parts) {
-    parseRangePart(part, pages);
-  }
-  if (pages.size === 0) {
-    throw new Error("Page range string resulted in zero valid pages.");
-  }
-  return Array.from(pages).sort((a, b) => a - b);
-};
-var getTargetPages = (sourcePages, sourceDescription) => {
-  if (!sourcePages) {
-    return;
-  }
-  try {
-    if (typeof sourcePages === "string") {
-      return parsePageRanges(sourcePages);
-    }
-    if (sourcePages.some((p) => !Number.isInteger(p) || p <= 0)) {
-      throw new Error("Page numbers in array must be positive integers.");
-    }
-    const uniquePages = [...new Set(sourcePages)].sort((a, b) => a - b);
-    if (uniquePages.length === 0) {
-      throw new Error("Page specification resulted in an empty set of pages.");
-    }
-    return uniquePages;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new PdfError(-32602 /* InvalidParams */, `Invalid page specification for source ${sourceDescription}: ${message}`);
-  }
-};
-var determinePagesToProcess = (targetPages, totalPages, includeFullText) => {
-  if (targetPages) {
-    const pagesToProcess = targetPages.filter((p) => p <= totalPages);
-    const invalidPages = targetPages.filter((p) => p > totalPages);
-    return { pagesToProcess, invalidPages };
-  }
-  if (includeFullText) {
-    const pagesToProcess = Array.from({ length: totalPages }, (_, i) => i + 1);
-    return { pagesToProcess, invalidPages: [] };
-  }
-  return { pagesToProcess: [], invalidPages: [] };
-};
-
-// src/schemas/readPdf.ts
-import {
-  array,
-  bool,
-  description,
-  gte,
-  int,
-  min,
-  num,
-  object,
-  optional,
-  str,
-  union
-} from "@sylphx/vex";
-var pageSpecifierSchema = union(array(num(int, gte(1))), str(min(1)));
-var pdfSourceSchema = object({
-  path: optional(str(min(1), description("Path to the local PDF file (absolute or relative to cwd)."))),
-  url: optional(str(min(1), description("URL of the PDF file."))),
-  pages: optional(pageSpecifierSchema)
-});
-var readPdfArgsSchema = object({
-  sources: array(pdfSourceSchema),
-  include_full_text: optional(bool(description("Include the full text content of each PDF (only if 'pages' is not specified for that source)."))),
-  include_metadata: optional(bool(description("Include metadata and info objects for each PDF."))),
-  include_page_count: optional(bool(description("Include the total number of pages for each PDF."))),
-  include_images: optional(bool(description("Extract and include embedded images from the PDF pages as base64-encoded data."))),
-  include_tables: optional(bool(description("Detect and extract tables from PDF pages. Uses spatial clustering of text coordinates to identify tabular structures."))),
-  include_elements: optional(bool(description("Include agent-ready structured document elements with page numbers, stable IDs, provenance, and best-effort bounding boxes."))),
-  include_semantic_hints: optional(bool(description("Include deterministic semantic hints on text elements, such as heading, list item, or paragraph."))),
-  include_markdown: optional(bool(description("Include a Markdown rendering of extracted pages for RAG, summarization, and agent context."))),
-  include_html: optional(bool(description("Include a simple HTML rendering of extracted pages for preview, export, and downstream conversion."))),
-  include_chunks: optional(bool(description("Include page-level citation-ready chunks with text, element IDs, page ranges, and best-effort bounding boxes."))),
-  include_outline: optional(bool(description("Include document outline/bookmark entries when the PDF exposes them."))),
-  include_annotations: optional(bool(description("Include page annotations such as links, notes, and form-related annotations with safe summary fields."))),
-  include_page_labels: optional(bool(description("Include PDF page labels when available, such as roman numerals or section labels."))),
-  include_page_geometry: optional(bool(description("Include page viewport geometry such as width, height, rotation, user unit, and view box."))),
-  include_permissions: optional(bool(description("Include PDF permission and marking signals when exposed by the parser."))),
-  include_form_fields: optional(bool(description("Include PDF form field summaries when AcroForm fields are exposed."))),
-  include_attachments: optional(bool(description("Include embedded attachment metadata such as filename and size. Attachment bytes are not returned."))),
-  include_structure_tree: optional(bool(description("Include best-effort tagged PDF structure trees for selected pages when the PDF exposes them."))),
-  include_safety_findings: optional(bool(description("Include deterministic content safety findings for prompt-injection patterns, tiny text, and off-page text.")))
-});
-
 // src/handlers/readPdf.ts
-var logger6 = createLogger("ReadPdf");
+var logger7 = createLogger("ReadPdf");
 var processSingleSource = async (source, options) => {
   const sourceDescription = source.path ?? source.url ?? "unknown source";
   let individualResult = { source: sourceDescription, success: false };
@@ -2071,7 +2364,7 @@ var processSingleSource = async (source, options) => {
       errorMessage = error.message;
     } else {
       const detail = error instanceof Error ? error.message : String(error);
-      logger6.error("Unexpected error processing PDF source", {
+      logger7.error("Unexpected error processing PDF source", {
         sourceDescription,
         error: detail
       });
@@ -2087,13 +2380,13 @@ var processSingleSource = async (source, options) => {
         await loadingTask.destroy();
       } catch (destroyError) {
         const message = destroyError instanceof Error ? destroyError.message : String(destroyError);
-        logger6.warn("Error destroying PDF document", { sourceDescription, error: message });
+        logger7.warn("Error destroying PDF document", { sourceDescription, error: message });
       }
     }
   }
   return individualResult;
 };
-var readPdf = tool().description("Reads content/metadata/images from one or more PDFs (local/URL). Each source can specify pages to extract.").input(readPdfArgsSchema).handler(async ({ input }) => {
+var readPdf = tool2().description("Reads content/metadata/images from one or more PDFs (local/URL). Each source can specify pages to extract.").input(readPdfArgsSchema).handler(async ({ input }) => {
   const {
     sources,
     include_full_text,
@@ -2116,7 +2409,7 @@ var readPdf = tool().description("Reads content/metadata/images from one or more
     include_structure_tree,
     include_safety_findings
   } = input;
-  const MAX_CONCURRENT_SOURCES = 3;
+  const MAX_CONCURRENT_SOURCES2 = 3;
   const results = [];
   const options = {
     includeFullText: include_full_text ?? false,
@@ -2139,15 +2432,15 @@ var readPdf = tool().description("Reads content/metadata/images from one or more
     includeStructureTree: include_structure_tree ?? false,
     includeSafetyFindings: include_safety_findings ?? false
   };
-  for (let i = 0;i < sources.length; i += MAX_CONCURRENT_SOURCES) {
-    const batch = sources.slice(i, i + MAX_CONCURRENT_SOURCES);
+  for (let i = 0;i < sources.length; i += MAX_CONCURRENT_SOURCES2) {
+    const batch = sources.slice(i, i + MAX_CONCURRENT_SOURCES2);
     const batchResults = await Promise.all(batch.map((source) => processSingleSource(source, options)));
     results.push(...batchResults);
   }
   const allFailed = results.every((r) => !r.success);
   if (allFailed) {
     const errorMessages = results.map((r) => r.error).join("; ");
-    return toolError(`All PDF sources failed to process: ${errorMessages}`);
+    return toolError2(`All PDF sources failed to process: ${errorMessages}`);
   }
   const content = [];
   const resultsForJson = results.map((result) => {
@@ -2178,7 +2471,7 @@ var readPdf = tool().description("Reads content/metadata/images from one or more
     }
     return result;
   });
-  content.push(text(JSON.stringify({ results: resultsForJson }, null, 2)));
+  content.push(text2(JSON.stringify({ results: resultsForJson }, null, 2)));
   for (const result of results) {
     if (!result.success || !result.data?.page_contents)
       continue;
@@ -2193,7 +2486,7 @@ var readPdf = tool().description("Reads content/metadata/images from one or more
         }
       }
       if (pageTextParts.length > 0) {
-        content.push(text(`[Page ${pageContent.page}]
+        content.push(text2(`[Page ${pageContent.page}]
 ${pageTextParts.join(`
 `)}`));
       }
@@ -2211,13 +2504,15 @@ ${pageTextParts.join(`
     }
     if (allTables.length > 0) {
       const markdownTables = tablesToMarkdown(allTables);
-      content.push(text(markdownTables));
+      content.push(text2(markdownTables));
     }
   }
   return content;
 });
 
 // src/index.ts
+var require3 = createRequire2(import.meta.url);
+var packageJson = require3("../package.json");
 var transportType = process.env["MCP_TRANSPORT"] ?? "stdio";
 var httpPort = Number.parseInt(process.env["MCP_HTTP_PORT"] ?? "8080", 10);
 var httpHost = process.env["MCP_HTTP_HOST"] ?? "0.0.0.0";
@@ -2235,9 +2530,9 @@ function createTransport() {
 }
 var server = createServer({
   name: "pdf-reader-mcp",
-  version: "2.1.0",
-  instructions: "MCP Server for reading PDF files and extracting text, metadata, images, and page information.",
-  tools: { read_pdf: readPdf },
+  version: packageJson.version,
+  instructions: "MCP Server for inspecting PDF files and extracting text, metadata, images, citations, safety signals, and agent-ready document structure.",
+  tools: { inspect_pdf: inspectPdf, read_pdf: readPdf },
   transport: createTransport()
 });
 async function main() {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -2,7 +2,8 @@ import { defineConfig } from 'vitepress';
 
 export default defineConfig({
   title: 'PDF Reader MCP',
-  description: 'MCP Server for reading PDF files - extract text, metadata, and images',
+  description:
+    'MCP server for PDF inspection, extraction, citation chunks, and safety signals for AI agents',
 
   appearance: 'dark',
   lastUpdated: true,
@@ -15,26 +16,36 @@ export default defineConfig({
 
   head: [
     ['meta', { property: 'og:type', content: 'website' }],
-    ['meta', { property: 'og:title', content: 'PDF Reader MCP - Extract PDF Content for AI' }],
+    [
+      'meta',
+      { property: 'og:title', content: 'PDF Reader MCP - Inspect and Extract PDFs for AI Agents' },
+    ],
     [
       'meta',
       {
         property: 'og:description',
         content:
-          'A high-performance MCP server for reading text, metadata, and images from PDF files',
+          'A high-performance MCP server for PDF inspection, structured extraction, citation chunks, and safety signals',
       },
     ],
     ['meta', { property: 'og:url', content: 'https://pdf-reader-mcp.sylphx.com' }],
     ['meta', { property: 'og:site_name', content: 'PDF Reader MCP' }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
     ['meta', { name: 'twitter:title', content: 'PDF Reader MCP' }],
-    ['meta', { name: 'twitter:description', content: 'Extract PDF content for AI agents via MCP' }],
+    [
+      'meta',
+      {
+        name: 'twitter:description',
+        content: 'Inspect PDFs and extract agent-ready content via MCP',
+      },
+    ],
     ['meta', { name: 'twitter:site', content: '@sylphxai' }],
     [
       'meta',
       {
         name: 'keywords',
-        content: 'mcp, pdf, reader, ai, claude, model context protocol, typescript',
+        content:
+          'mcp, pdf, reader, ai, claude, model context protocol, typescript, rag, citations, pdf inspection',
       },
     ],
     ['meta', { name: 'author', content: 'Sylphx' }],

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,8 +1,35 @@
 # Getting Started
 
-Once installed, the PDF Reader MCP server provides a single tool: `read_pdf`.
+Once installed, the PDF Reader MCP server provides two tools:
+
+- `inspect_pdf` profiles a PDF and recommends the best extraction options.
+- `read_pdf` extracts PDF content, structure, citations, tables, images, and signals.
 
 ## Basic Usage
+
+### Inspect a PDF First
+
+Use `inspect_pdf` when an agent needs to decide how to process an unfamiliar
+document. It samples a bounded number of pages and returns an extraction plan
+without decoding image bytes.
+
+```json
+{
+  "sources": [{ "path": "/path/to/document.pdf" }],
+  "sample_pages": 5,
+  "include_metadata": true
+}
+```
+
+Typical response fields:
+
+- `profile`: `digital_text`, `scanned_or_image_only`, `mixed_text_and_scan`,
+  `low_text_or_form`, or `unknown`
+- `page_signals`: text density, token estimate, and image paint-operation count
+- `document_signals`: outline, labels, permissions, forms, attachments, and
+  structure-tree availability
+- `recommendation`: workflow, OCR need, reason, and ready-to-use `read_pdf`
+  arguments
 
 ### Get Metadata and Page Count
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,16 +1,19 @@
 # Introduction
 
-PDF Reader MCP is a Model Context Protocol (MCP) server that enables AI agents to read and extract content from PDF files.
+PDF Reader MCP is a Model Context Protocol (MCP) server that enables AI agents to inspect, read, and extract content from PDF files.
 
 ## What It Does
 
-AI agents often need to access information from PDF documents - reports, invoices, research papers, manuals, and more. This server provides tools to extract:
+AI agents often need to access information from PDF documents - reports, invoices, research papers, manuals, and more. This server provides tools to inspect and extract:
 
+- **PDF profiles** - Detect text-rich, low-text, mixed, or scanned/image-like PDFs before extraction
 - **Full text content** - Get all text from a PDF
 - **Page-specific text** - Extract text from specific pages or page ranges
 - **Metadata** - Author, title, creation date, and other document properties
 - **Page count** - Total number of pages
 - **Embedded images** - Extract images as base64-encoded PNG data
+- **Citation chunks** - Return stable source references for retrieval workflows
+- **Safety signals** - Surface deterministic findings before agents trust PDF text
 
 ## Key Features
 
@@ -22,6 +25,9 @@ Send multiple PDF sources in one request. The server processes them concurrently
 
 ### Flexible Extraction
 Choose exactly what data you need - full text, specific pages, metadata only, or everything including images.
+
+### Agent-Native Inspection
+Use `inspect_pdf` to sample a PDF, identify extraction risks, and get recommended `read_pdf` arguments before spending context or runtime on heavier extraction.
 
 ### Image Extraction
 Extract embedded images from PDFs for AI vision analysis. Images are returned as base64-encoded PNG data.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- Node.js >= 22.0.0
+- Node.js >= 22.13.0
 
 ## Claude Code
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: PDF Reader MCP
-  text: Extract PDF Content for AI Agents
-  tagline: A high-performance MCP server for structured, local-first PDF extraction.
+  text: Inspect and Extract PDFs for AI Agents
+  tagline: A high-performance MCP server for local-first PDF inspection, extraction, citations, and safety signals.
   image:
     src: /logo.svg
     alt: PDF Reader MCP Logo
@@ -18,8 +18,8 @@ hero:
 
 features:
   - icon: "\U0001F4C4"
-    title: Structured PDF Extraction
-    details: Extract text, metadata, tables, images, Markdown, HTML, and agent-ready elements from PDF files or URLs.
+    title: Inspect Before Extraction
+    details: Profile unfamiliar PDFs, detect low-text or scanned pages, and get recommended extraction options for agent workflows.
   - icon: "\u26A1"
     title: High Performance
     details: Built with pdfjs-dist and optimized for speed. Supports concurrent processing, batch operations, and column-aware ordering.

--- a/docs/performance/index.md
+++ b/docs/performance/index.md
@@ -15,7 +15,21 @@ Benchmarks run on Node.js 22, measuring operations per second.
 
 ## Optimization Tips
 
-### 1. Request Only What You Need
+### 1. Inspect Before Heavy Extraction
+
+Use `inspect_pdf` first when an agent does not know the document shape. It
+samples a bounded number of pages, counts selectable text and image paint
+operations, and recommends `read_pdf` arguments without decoding image bytes.
+
+```json
+{
+  "sources": [{ "path": "doc.pdf" }],
+  "sample_pages": 5,
+  "include_metadata": true
+}
+```
+
+### 2. Request Only What You Need
 
 ```json
 // Fast - metadata only
@@ -28,7 +42,7 @@ Benchmarks run on Node.js 22, measuring operations per second.
 }
 ```
 
-### 2. Use Page Ranges
+### 3. Use Page Ranges
 
 Instead of full text extraction, request specific pages:
 
@@ -45,7 +59,7 @@ Instead of full text extraction, request specific pages:
 }
 ```
 
-### 3. Batch Sources
+### 4. Batch Sources
 
 Process multiple PDFs in one request for better throughput:
 
@@ -63,7 +77,7 @@ Process multiple PDFs in one request for better throughput:
 }
 ```
 
-### 4. Avoid Images Unless Needed
+### 5. Avoid Images Unless Needed
 
 Image extraction involves encoding to PNG and base64, which adds overhead:
 
@@ -75,7 +89,7 @@ Image extraction involves encoding to PNG and base64, which adds overhead:
 { "include_images": false }
 ```
 
-### 5. Use Structured Elements When You Need References
+### 6. Use Structured Elements When You Need References
 
 `include_elements` adds page-level element metadata for agent workflows. It is
 worth enabling when you need stable IDs, provenance, or best-effort coordinates,
@@ -89,7 +103,7 @@ but plain text remains the leanest response shape.
 }
 ```
 
-### 6. Add Semantic Hints Only When They Help
+### 7. Add Semantic Hints Only When They Help
 
 `include_semantic_hints` adds deterministic heading, list, and paragraph hints
 to text elements. It returns elements even when `include_elements` is omitted.
@@ -102,7 +116,7 @@ to text elements. It returns elements even when `include_elements` is omitted.
 }
 ```
 
-### 7. Use Markdown When You Need Ready-to-Use Context
+### 8. Use Markdown When You Need Ready-to-Use Context
 
 `include_markdown` creates page-aware Markdown in the JSON response. It is
 more convenient than rebuilding sections from `page_texts`, but it still
@@ -116,7 +130,7 @@ requires page extraction.
 }
 ```
 
-### 8. Use Chunks When You Need Source References
+### 9. Use Chunks When You Need Source References
 
 `include_chunks` creates citation-ready chunks with element IDs, strategy
 labels, and best-effort bounding boxes. It can split on semantic heading
@@ -133,7 +147,7 @@ citations, but it does more work than metadata-only or page-count requests.
 }
 ```
 
-### 9. Use HTML Only When Needed
+### 10. Use HTML Only When Needed
 
 `include_html` creates escaped page-aware HTML. It is useful for preview and
 export workflows, but plain text or Markdown are usually leaner for agent-only
@@ -147,7 +161,7 @@ context.
 }
 ```
 
-### 10. Use Document Signals For Lightweight Structure
+### 11. Use Document Signals For Lightweight Structure
 
 Outline, page labels, permissions, structure trees, form fields, attachment
 metadata, and page geometry can be requested without extracting full page text.
@@ -163,7 +177,7 @@ Annotations, structure trees, and page geometry respect selected page ranges.
 }
 ```
 
-### 11. Use Safety Findings When Agents Consume PDF Text
+### 12. Use Safety Findings When Agents Consume PDF Text
 
 `include_safety_findings` scans extracted page text for deterministic risk
 signals. It requires page text extraction, but it does not force `full_text`

--- a/docs/specs/2026-06-14-capability-gap-matrix.md
+++ b/docs/specs/2026-06-14-capability-gap-matrix.md
@@ -18,7 +18,8 @@ neutral capability names and avoids public comparison language.
 
 | Capability | Status | Notes |
 |---|---:|---|
-| MCP-native PDF tool | Shipped | Single `read_pdf` tool with stdio/http transport. |
+| MCP-native PDF tools | Shipped | `inspect_pdf` and `read_pdf` with stdio/http transport. |
+| Agent-native PDF inspection | Shipped | `inspect_pdf` profiles PDFs, samples pages, flags OCR needs, and recommends `read_pdf` options. |
 | Local path and URL sources | Shipped | Includes filesystem and HTTP restrictions. |
 | Metadata and page count | Shipped | Existing `include_metadata`, `include_page_count`. |
 | Text extraction | Shipped | Full text and selected pages. |

--- a/docs/specs/2026-06-14-pdf-intelligence-vnext.md
+++ b/docs/specs/2026-06-14-pdf-intelligence-vnext.md
@@ -124,6 +124,8 @@ Candidate engines:
 ## Phased Roadmap
 
 1. Structured foundation
+   - Add `inspect_pdf` for bounded preflight profiling, OCR triage, and
+     recommended `read_pdf` arguments.
    - Add `include_elements`.
    - Add `include_semantic_hints`.
    - Add `include_markdown`.

--- a/docs/specs/2026-06-15-agent-native-pdf-inspection.md
+++ b/docs/specs/2026-06-15-agent-native-pdf-inspection.md
@@ -1,0 +1,105 @@
+# Agent-Native PDF Inspection
+
+Date: 2026-06-15
+Status: active
+
+## Goal
+
+Add a lightweight MCP tool that lets an agent inspect a PDF before extracting it.
+The tool should answer: what kind of PDF is this, which pages should be sampled,
+what risks are visible, and which `read_pdf` options are most useful next.
+
+This improves time-to-value without adding OCR models, Java, Python, cloud
+services, or any large default dependency.
+
+## Non-goals
+
+- Do not perform OCR in the default package.
+- Do not claim high-accuracy parsing from a short inspection sample.
+- Do not extract image bytes during inspection.
+- Do not replace `read_pdf`; inspection is an additive planning step.
+
+## Contract
+
+Expose a second MCP tool named `inspect_pdf`.
+
+Input:
+
+```json
+{
+  "sources": [{ "path": "report.pdf", "pages": "1-5" }],
+  "sample_pages": 5,
+  "include_metadata": true
+}
+```
+
+Output is a JSON text part:
+
+```json
+{
+  "results": [
+    {
+      "source": "report.pdf",
+      "success": true,
+      "data": {
+        "profile": "digital_text",
+        "num_pages": 12,
+        "sampled_pages": [1, 4, 7, 9, 12],
+        "page_signals": [
+          {
+            "page": 1,
+            "text_chars": 2400,
+            "text_items": 82,
+            "estimated_tokens": 600,
+            "image_paint_operations": 2,
+            "likely_scanned": false,
+            "low_text_density": false
+          }
+        ],
+        "document_signals": {
+          "has_outline": true,
+          "has_page_labels": false,
+          "has_permissions": false,
+          "has_mark_info": false,
+          "has_form_fields": false,
+          "has_attachments": false,
+          "has_structure_tree": false
+        },
+        "recommendation": {
+          "workflow": "agentic_rag",
+          "needs_ocr": false,
+          "reason": "Sampled pages expose selectable text; citation chunks, semantic hints, table extraction, and safety findings are the highest-value next read_pdf options.",
+          "read_pdf_arguments": {
+            "sources": [{ "path": "report.pdf" }],
+            "include_metadata": true,
+            "include_page_count": true,
+            "include_page_geometry": true,
+            "include_outline": true,
+            "include_chunks": true,
+            "include_semantic_hints": true,
+            "include_safety_findings": true,
+            "include_markdown": true,
+            "include_tables": true
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+## Invariants
+
+- Inspection returns per-source success or failure independently.
+- Sampling is bounded and defaults to a small number of pages.
+- `read_pdf_arguments` must never imply OCR support from the default package.
+- The first JSON part must not include binary image data.
+- Existing `read_pdf` callers remain unchanged.
+
+## Validation
+
+- Unit tests cover page sampling and profile classification.
+- Handler tests cover successful digital and scanned/image-like PDFs.
+- Integration tests confirm the MCP server lists `inspect_pdf`.
+- Full validation: `bun run check`, `bun run build`, `bun test`, and
+  `bun run docs:build`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sylphx/pdf-reader-mcp",
   "version": "2.5.3",
-  "description": "An MCP server providing tools to read PDF files.",
+  "description": "Agent-native MCP server for PDF inspection, extraction, citation chunks, and safety signals.",
   "type": "module",
   "bin": {
     "pdf-reader-mcp": "./dist/index.js"
@@ -40,7 +40,12 @@
     "node",
     "ai",
     "agent",
-    "tool"
+    "tool",
+    "rag",
+    "citations",
+    "pdf-inspection",
+    "pdf-to-markdown",
+    "document-processing"
   ],
   "scripts": {
     "build": "bunup --no-dts",

--- a/src/handlers/inspectPdf.ts
+++ b/src/handlers/inspectPdf.ts
@@ -1,0 +1,35 @@
+import { text, tool, toolError } from '@sylphx/mcp-server-sdk';
+import { defaultInspectPdfOptions, inspectPdfSource } from '../pdf/inspector.js';
+import { inspectPdfArgsSchema } from '../schemas/inspectPdf.js';
+import type { PdfInspectionSourceResult } from '../types/pdf.js';
+
+const MAX_CONCURRENT_SOURCES = 3;
+
+export const inspectPdf = tool()
+  .description(
+    'Inspects one or more PDFs and recommends the best read_pdf options for agentic extraction, citations, safety, and OCR triage.'
+  )
+  .input(inspectPdfArgsSchema)
+  .handler(async ({ input }) => {
+    const options = {
+      ...defaultInspectPdfOptions(),
+      ...(input.sample_pages !== undefined ? { sample_pages: input.sample_pages } : {}),
+      ...(input.include_metadata !== undefined ? { include_metadata: input.include_metadata } : {}),
+    };
+    const results: PdfInspectionSourceResult[] = [];
+
+    for (let i = 0; i < input.sources.length; i += MAX_CONCURRENT_SOURCES) {
+      const batch = input.sources.slice(i, i + MAX_CONCURRENT_SOURCES);
+      const batchResults = await Promise.all(
+        batch.map((source) => inspectPdfSource(source, options))
+      );
+      results.push(...batchResults);
+    }
+
+    if (results.every((result) => !result.success)) {
+      const errorMessages = results.map((result) => result.error).join('; ');
+      return toolError(`All PDF sources failed inspection: ${errorMessages}`);
+    }
+
+    return text(JSON.stringify({ results }, null, 2));
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
 
+import { createRequire } from 'node:module';
 import { createServer, http, stdio } from '@sylphx/mcp-server-sdk';
+import { inspectPdf } from './handlers/inspectPdf.js';
 import { readPdf } from './handlers/readPdf.js';
+
+const require = createRequire(import.meta.url);
+const packageJson = require('../package.json') as { version: string };
 
 // Transport configuration via environment variables
 // MCP_TRANSPORT: 'stdio' (default) | 'http'
@@ -31,10 +36,10 @@ function createTransport() {
 
 const server = createServer({
   name: 'pdf-reader-mcp',
-  version: '2.1.0',
+  version: packageJson.version,
   instructions:
-    'MCP Server for reading PDF files and extracting text, metadata, images, and page information.',
-  tools: { read_pdf: readPdf },
+    'MCP Server for inspecting PDF files and extracting text, metadata, images, citations, safety signals, and agent-ready document structure.',
+  tools: { inspect_pdf: inspectPdf, read_pdf: readPdf },
   transport: createTransport(),
 });
 

--- a/src/pdf/inspector.ts
+++ b/src/pdf/inspector.ts
@@ -1,0 +1,337 @@
+import type * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.mjs';
+import { OPS } from 'pdfjs-dist/legacy/build/pdf.mjs';
+import type {
+  InspectPdfOptions,
+  PdfInspectionData,
+  PdfInspectionDocumentSignals,
+  PdfInspectionPageSignal,
+  PdfInspectionProfile,
+  PdfInspectionRecommendation,
+  PdfInspectionSourceResult,
+  PdfSource,
+} from '../types/pdf.js';
+import { PdfError } from '../utils/errors.js';
+import { createLogger } from '../utils/logger.js';
+import {
+  buildWarnings,
+  extractDocumentStructure,
+  extractMetadataAndPageCount,
+  extractPageGeometry,
+  extractStructureTrees,
+} from './extractor.js';
+import { loadPdfDocument } from './loader.js';
+import { getTargetPages } from './parser.js';
+
+const logger = createLogger('Inspector');
+
+const DEFAULT_SAMPLE_PAGES = 5;
+const MAX_SAMPLE_PAGES = 20;
+const LOW_TEXT_CHAR_THRESHOLD = 20;
+const DIGITAL_TEXT_CHAR_THRESHOLD = 80;
+const APPROX_CHARS_PER_TOKEN = 4;
+
+const clampSamplePageCount = (value: number): number =>
+  Math.min(MAX_SAMPLE_PAGES, Math.max(1, Math.floor(value)));
+
+const publicSource = (source: PdfSource): PdfSource => ({
+  ...(source.path ? { path: source.path } : {}),
+  ...(source.url ? { url: source.url } : {}),
+  ...(source.pages ? { pages: source.pages } : {}),
+});
+
+const selectEvenlySpaced = (values: number[], maxItems: number): number[] => {
+  const uniqueValues = [...new Set(values)].sort((a, b) => a - b);
+  if (uniqueValues.length <= maxItems) return uniqueValues;
+  if (maxItems === 1) return [uniqueValues[0] as number];
+
+  const selected = new Set<number>();
+  for (let i = 0; i < maxItems; i++) {
+    const index = Math.round((i * (uniqueValues.length - 1)) / (maxItems - 1));
+    const value = uniqueValues[index];
+    if (value !== undefined) selected.add(value);
+  }
+
+  for (const value of uniqueValues) {
+    if (selected.size >= maxItems) break;
+    selected.add(value);
+  }
+
+  return [...selected].sort((a, b) => a - b);
+};
+
+export const selectInspectionSamplePages = (
+  totalPages: number,
+  targetPages: number[] | undefined,
+  samplePageCount: number
+): number[] => {
+  if (totalPages <= 0) return [];
+
+  const maxSamples = clampSamplePageCount(samplePageCount);
+  if (targetPages !== undefined) {
+    const validTargetPages = targetPages.filter((page) => page >= 1 && page <= totalPages);
+    return selectEvenlySpaced(validTargetPages, maxSamples);
+  }
+
+  if (totalPages <= maxSamples) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+
+  const sampled = new Set<number>();
+  for (let i = 0; i < maxSamples; i++) {
+    const page = 1 + Math.round((i * (totalPages - 1)) / (maxSamples - 1));
+    sampled.add(page);
+  }
+
+  return [...sampled].sort((a, b) => a - b);
+};
+
+export const classifyPdfInspectionProfile = (
+  pageSignals: PdfInspectionPageSignal[]
+): PdfInspectionProfile => {
+  if (pageSignals.length === 0) return 'unknown';
+
+  const scannedCount = pageSignals.filter((signal) => signal.likely_scanned).length;
+  const digitalTextCount = pageSignals.filter(
+    (signal) => signal.text_chars >= DIGITAL_TEXT_CHAR_THRESHOLD
+  ).length;
+
+  if (scannedCount === pageSignals.length) return 'scanned_or_image_only';
+  if (scannedCount > 0 && digitalTextCount > 0) return 'mixed_text_and_scan';
+  if (digitalTextCount > 0) return 'digital_text';
+  return 'low_text_or_form';
+};
+
+const countImagePaintOperations = async (page: pdfjsLib.PDFPageProxy): Promise<number> => {
+  try {
+    const operatorList = await page.getOperatorList();
+    return operatorList.fnArray.filter(
+      (op) => op === OPS.paintImageXObject || op === OPS.paintXObject
+    ).length;
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn('Error counting image paint operations', { error: message });
+    return 0;
+  }
+};
+
+const inspectPageSignal = async (
+  pdfDocument: pdfjsLib.PDFDocumentProxy,
+  pageNum: number
+): Promise<PdfInspectionPageSignal> => {
+  const page = await pdfDocument.getPage(pageNum);
+  const textContent = await page.getTextContent();
+  const textValues = textContent.items
+    .map((item: unknown) => (item as { str?: unknown }).str)
+    .filter((value): value is string => typeof value === 'string');
+  const textChars = textValues.reduce((sum, value) => sum + value.trim().length, 0);
+  const imagePaintOperations = await countImagePaintOperations(page);
+  const likelyScanned = textChars < LOW_TEXT_CHAR_THRESHOLD && imagePaintOperations > 0;
+
+  return {
+    page: pageNum,
+    text_chars: textChars,
+    text_items: textValues.filter((value) => value.trim().length > 0).length,
+    estimated_tokens: Math.ceil(textChars / APPROX_CHARS_PER_TOKEN),
+    image_paint_operations: imagePaintOperations,
+    likely_scanned: likelyScanned,
+    low_text_density: textChars < DIGITAL_TEXT_CHAR_THRESHOLD,
+  };
+};
+
+const buildDocumentSignals = (
+  structureOutput: Awaited<ReturnType<typeof extractDocumentStructure>>,
+  hasStructureTree: boolean
+): PdfInspectionDocumentSignals => ({
+  has_outline: (structureOutput.outline?.length ?? 0) > 0,
+  has_page_labels: (structureOutput.page_labels?.length ?? 0) > 0,
+  has_permissions: (structureOutput.permissions?.length ?? 0) > 0,
+  has_mark_info: Object.keys(structureOutput.mark_info ?? {}).length > 0,
+  has_form_fields: (structureOutput.form_fields?.length ?? 0) > 0,
+  has_attachments: (structureOutput.attachments?.length ?? 0) > 0,
+  has_structure_tree: hasStructureTree,
+});
+
+const setTrue = (target: Record<string, unknown>, key: string, enabled: boolean) => {
+  if (enabled) target[key] = true;
+};
+
+export const buildInspectionRecommendation = (
+  source: PdfSource,
+  profile: PdfInspectionProfile,
+  documentSignals: PdfInspectionDocumentSignals
+): PdfInspectionRecommendation => {
+  const readPdfArguments: Record<string, unknown> = {
+    sources: [publicSource(source)],
+    include_metadata: true,
+    include_page_count: true,
+    include_page_geometry: true,
+  };
+
+  setTrue(readPdfArguments, 'include_outline', documentSignals.has_outline);
+  setTrue(readPdfArguments, 'include_page_labels', documentSignals.has_page_labels);
+  setTrue(readPdfArguments, 'include_permissions', documentSignals.has_permissions);
+  setTrue(readPdfArguments, 'include_form_fields', documentSignals.has_form_fields);
+  setTrue(readPdfArguments, 'include_attachments', documentSignals.has_attachments);
+  setTrue(readPdfArguments, 'include_structure_tree', documentSignals.has_structure_tree);
+
+  if (profile === 'scanned_or_image_only') {
+    return {
+      workflow: 'scanned_pdf_triage',
+      needs_ocr: true,
+      reason:
+        'Sampled pages contain little selectable text and visible image paint operations; OCR or an optional advanced engine is likely required for text extraction.',
+      read_pdf_arguments: readPdfArguments,
+    };
+  }
+
+  if (profile === 'mixed_text_and_scan') {
+    Object.assign(readPdfArguments, {
+      include_chunks: true,
+      include_semantic_hints: true,
+      include_safety_findings: true,
+      include_markdown: true,
+      include_tables: true,
+    });
+    return {
+      workflow: 'mixed_pdf_review',
+      needs_ocr: true,
+      reason:
+        'Some sampled pages look text-based while others look image-only; use read_pdf for selectable-text pages and OCR for scanned pages.',
+      read_pdf_arguments: readPdfArguments,
+    };
+  }
+
+  if (profile === 'digital_text') {
+    Object.assign(readPdfArguments, {
+      include_chunks: true,
+      include_semantic_hints: true,
+      include_safety_findings: true,
+      include_markdown: true,
+      include_tables: true,
+    });
+    return {
+      workflow: 'agentic_rag',
+      needs_ocr: false,
+      reason:
+        'Sampled pages expose selectable text; citation chunks, semantic hints, table extraction, and safety findings are the highest-value next read_pdf options.',
+      read_pdf_arguments: readPdfArguments,
+    };
+  }
+
+  return {
+    workflow: 'metadata_review',
+    needs_ocr: false,
+    reason:
+      'Sampled pages expose limited text; inspect metadata, forms, attachments, structure, and selected pages before running a heavier extraction.',
+    read_pdf_arguments: readPdfArguments,
+  };
+};
+
+export const inspectPdfSource = async (
+  source: PdfSource,
+  options: InspectPdfOptions
+): Promise<PdfInspectionSourceResult> => {
+  const sourceDescription = source.path ?? source.url ?? 'unknown source';
+  let pdfDocument: pdfjsLib.PDFDocumentProxy | null = null;
+
+  try {
+    const targetPages = getTargetPages(source.pages, sourceDescription);
+    const { pages: _pages, ...loadArgs } = source;
+    pdfDocument = await loadPdfDocument(loadArgs, sourceDescription);
+    const totalPages = pdfDocument.numPages;
+    const validTargetPages = targetPages?.filter((page) => page <= totalPages);
+    const invalidPages = targetPages?.filter((page) => page > totalPages) ?? [];
+    const sampledPages = selectInspectionSamplePages(
+      totalPages,
+      validTargetPages,
+      options.sample_pages
+    );
+
+    const metadataOutput = await extractMetadataAndPageCount(
+      pdfDocument,
+      options.include_metadata,
+      true
+    );
+    const structureOutput = await extractDocumentStructure(pdfDocument, {
+      includeOutline: true,
+      includePageLabels: true,
+      includePermissions: true,
+      includeFormFields: true,
+      includeAttachments: true,
+    });
+    const structureTrees =
+      sampledPages.length > 0 ? await extractStructureTrees(pdfDocument, sampledPages) : [];
+    const documentSignals = buildDocumentSignals(structureOutput, structureTrees.length > 0);
+    const pageSignals = await Promise.all(
+      sampledPages.map((pageNum) =>
+        inspectPageSignal(pdfDocument as pdfjsLib.PDFDocumentProxy, pageNum)
+      )
+    );
+    const pageGeometry =
+      sampledPages.length > 0 ? await extractPageGeometry(pdfDocument, sampledPages) : [];
+    const profile = classifyPdfInspectionProfile(pageSignals);
+    const recommendation = buildInspectionRecommendation(source, profile, documentSignals);
+    const warnings = buildWarnings(invalidPages, totalPages);
+
+    if (targetPages !== undefined && sampledPages.length === 0) {
+      warnings.push('No requested pages are inside the document page range.');
+    }
+    if (recommendation.needs_ocr) {
+      warnings.push(
+        'Default PDF Reader MCP does not perform OCR; use an optional OCR-capable engine for scanned pages.'
+      );
+    }
+
+    const data: PdfInspectionData = {
+      profile,
+      num_pages: totalPages,
+      sampled_pages: sampledPages,
+      page_signals: pageSignals,
+      document_signals: documentSignals,
+      recommendation,
+      ...(metadataOutput.info ? { info: metadataOutput.info } : {}),
+      ...(metadataOutput.metadata ? { metadata: metadataOutput.metadata } : {}),
+      ...(pageGeometry.length > 0 ? { page_geometry: pageGeometry } : {}),
+      ...(warnings.length > 0 ? { warnings } : {}),
+    };
+
+    return {
+      source: sourceDescription,
+      success: true,
+      data,
+    };
+  } catch (error: unknown) {
+    if (error instanceof PdfError) {
+      return { source: sourceDescription, success: false, error: error.message };
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error('Unexpected error inspecting PDF source', {
+      sourceDescription,
+      error: message,
+    });
+    return {
+      source: sourceDescription,
+      success: false,
+      error: `Failed to inspect PDF from ${sourceDescription}.`,
+    };
+  } finally {
+    const loadingTask = pdfDocument?.loadingTask;
+    if (loadingTask && typeof loadingTask.destroy === 'function') {
+      try {
+        await loadingTask.destroy();
+      } catch (destroyError: unknown) {
+        const message = destroyError instanceof Error ? destroyError.message : String(destroyError);
+        logger.warn('Error destroying PDF document after inspection', {
+          sourceDescription,
+          error: message,
+        });
+      }
+    }
+  }
+};
+
+export const defaultInspectPdfOptions = (): InspectPdfOptions => ({
+  sample_pages: DEFAULT_SAMPLE_PAGES,
+  include_metadata: true,
+});

--- a/src/schemas/inspectPdf.ts
+++ b/src/schemas/inspectPdf.ts
@@ -1,0 +1,32 @@
+import {
+  array,
+  bool,
+  description,
+  gte,
+  type InferOutput,
+  int,
+  lte,
+  num,
+  object,
+  optional,
+} from '@sylphx/vex';
+import { pdfSourceSchema } from './readPdf.js';
+
+export const inspectPdfArgsSchema = object({
+  sources: array(pdfSourceSchema),
+  sample_pages: optional(
+    num(
+      int,
+      gte(1),
+      lte(20),
+      description(
+        'Maximum number of pages to sample per source for lightweight PDF profiling. Defaults to 5.'
+      )
+    )
+  ),
+  include_metadata: optional(
+    bool(description('Include PDF metadata and info objects in the inspection response.'))
+  ),
+});
+
+export type InspectPdfArgs = InferOutput<typeof inspectPdfArgsSchema>;

--- a/src/types/pdf.ts
+++ b/src/types/pdf.ts
@@ -232,6 +232,66 @@ export interface PdfSourceResult {
   error?: string;
 }
 
+export type PdfInspectionProfile =
+  | 'digital_text'
+  | 'scanned_or_image_only'
+  | 'mixed_text_and_scan'
+  | 'low_text_or_form'
+  | 'unknown';
+
+export type PdfInspectionWorkflow =
+  | 'agentic_rag'
+  | 'metadata_review'
+  | 'scanned_pdf_triage'
+  | 'mixed_pdf_review';
+
+export interface PdfInspectionPageSignal {
+  page: number;
+  text_chars: number;
+  text_items: number;
+  estimated_tokens: number;
+  image_paint_operations: number;
+  likely_scanned: boolean;
+  low_text_density: boolean;
+}
+
+export interface PdfInspectionDocumentSignals {
+  has_outline: boolean;
+  has_page_labels: boolean;
+  has_permissions: boolean;
+  has_mark_info: boolean;
+  has_form_fields: boolean;
+  has_attachments: boolean;
+  has_structure_tree: boolean;
+}
+
+export interface PdfInspectionRecommendation {
+  workflow: PdfInspectionWorkflow;
+  needs_ocr: boolean;
+  reason: string;
+  read_pdf_arguments: Record<string, unknown>;
+}
+
+export interface PdfInspectionData {
+  profile: PdfInspectionProfile;
+  num_pages: number;
+  sampled_pages: number[];
+  page_signals: PdfInspectionPageSignal[];
+  document_signals: PdfInspectionDocumentSignals;
+  recommendation: PdfInspectionRecommendation;
+  info?: PdfInfo | undefined;
+  metadata?: PdfMetadata | undefined;
+  page_geometry?: PdfPageGeometry[] | undefined;
+  warnings?: string[] | undefined;
+}
+
+export interface PdfInspectionSourceResult {
+  source: string;
+  success: boolean;
+  data?: PdfInspectionData | undefined;
+  error?: string;
+}
+
 export interface PdfSource {
   path?: string | undefined;
   url?: string | undefined;
@@ -258,4 +318,9 @@ export interface ReadPdfOptions {
   include_attachments: boolean;
   include_structure_tree: boolean;
   include_safety_findings: boolean;
+}
+
+export interface InspectPdfOptions {
+  sample_pages: number;
+  include_metadata: boolean;
 }

--- a/test/integration/http-transport.test.ts
+++ b/test/integration/http-transport.test.ts
@@ -4,11 +4,15 @@
  */
 
 import { type ChildProcess, spawn } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const TEST_PORT = 18080; // Use a high port to avoid conflicts
 const BASE_URL = `http://localhost:${TEST_PORT}/mcp`;
+const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../package.json'), 'utf8')) as {
+  version: string;
+};
 
 // JSON-RPC request helper
 const sendRequest = async (method: string, params?: unknown, id = 1) => {
@@ -102,7 +106,7 @@ describe('MCP Server HTTP Transport Integration', () => {
 
     expect(response.id).toBe(1);
     expect(response.result?.serverInfo?.name).toBe('pdf-reader-mcp');
-    expect(response.result?.serverInfo?.version).toBe('2.1.0');
+    expect(response.result?.serverInfo?.version).toBe(packageJson.version);
   });
 
   it('should list available tools over HTTP', async () => {
@@ -119,6 +123,7 @@ describe('MCP Server HTTP Transport Integration', () => {
     expect(response.result?.tools?.length).toBeGreaterThan(0);
 
     const toolNames = response.result?.tools?.map((t: { name: string }) => t.name);
+    expect(toolNames).toContain('inspect_pdf');
     expect(toolNames).toContain('read_pdf');
   });
 

--- a/test/integration/mcp-server.test.ts
+++ b/test/integration/mcp-server.test.ts
@@ -118,13 +118,45 @@ describe('MCP Server Integration', () => {
     expect(response.result?.tools?.length).toBeGreaterThan(0);
 
     const toolNames = response.result?.tools?.map((t) => t.name);
+    expect(toolNames).toContain('inspect_pdf');
     expect(toolNames).toContain('read_pdf');
+  });
+
+  it('should call inspect_pdf tool with a test PDF', async () => {
+    const testPdfPath = path.resolve(__dirname, '../fixtures/sample.pdf');
+
+    const callRequest = createRequest(3, 'tools/call', {
+      name: 'inspect_pdf',
+      arguments: {
+        sources: [{ path: testPdfPath }],
+        sample_pages: 2,
+        include_metadata: true,
+      },
+    });
+
+    sendMessage(serverProc, callRequest);
+    const response = (await readResponse(serverProc, 10000)) as {
+      id: number;
+      result?: { content?: Array<{ type: string; text?: string }>; isError?: boolean };
+      error?: { message: string };
+    };
+
+    expect(response.id).toBe(3);
+
+    if (response.error || response.result?.isError) {
+      expect(response.error?.message || response.result?.content?.[0]?.text).toContain('PDF');
+    } else {
+      const textContent = response.result?.content?.[0]?.text ?? '';
+      expect(response.result?.content?.[0]?.type).toBe('text');
+      expect(textContent).toContain('"profile"');
+      expect(textContent).toContain('"recommendation"');
+    }
   });
 
   it('should call read_pdf tool with a test PDF', async () => {
     const testPdfPath = path.resolve(__dirname, '../fixtures/sample.pdf');
 
-    const callRequest = createRequest(3, 'tools/call', {
+    const callRequest = createRequest(4, 'tools/call', {
       name: 'read_pdf',
       arguments: {
         sources: [{ path: testPdfPath }],
@@ -141,7 +173,7 @@ describe('MCP Server Integration', () => {
       error?: { message: string };
     };
 
-    expect(response.id).toBe(3);
+    expect(response.id).toBe(4);
 
     // If test PDF doesn't exist, expect error
     if (response.error || response.result?.isError) {
@@ -155,7 +187,7 @@ describe('MCP Server Integration', () => {
   });
 
   it('should handle invalid tool arguments', async () => {
-    const callRequest = createRequest(4, 'tools/call', {
+    const callRequest = createRequest(5, 'tools/call', {
       name: 'read_pdf',
       arguments: {
         // Missing required 'sources' field
@@ -170,7 +202,7 @@ describe('MCP Server Integration', () => {
       error?: { code: number; message: string };
     };
 
-    expect(response.id).toBe(4);
+    expect(response.id).toBe(5);
     // SDK returns validation error as result.isError, not JSON-RPC error
     expect(response.result?.isError).toBe(true);
     expect(response.result?.content?.[0]?.text).toMatch(/sources/i);

--- a/test/pdf/inspector.test.ts
+++ b/test/pdf/inspector.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildInspectionRecommendation,
+  classifyPdfInspectionProfile,
+  selectInspectionSamplePages,
+} from '../../src/pdf/inspector.js';
+import type { PdfInspectionDocumentSignals, PdfInspectionPageSignal } from '../../src/types/pdf.js';
+
+const signal = (page: number, textChars: number, imagePaintOperations = 0): PdfInspectionPageSignal => ({
+  page,
+  text_chars: textChars,
+  text_items: textChars > 0 ? 4 : 0,
+  estimated_tokens: Math.ceil(textChars / 4),
+  image_paint_operations: imagePaintOperations,
+  likely_scanned: textChars < 20 && imagePaintOperations > 0,
+  low_text_density: textChars < 80,
+});
+
+const documentSignals = (overrides: Partial<PdfInspectionDocumentSignals> = {}): PdfInspectionDocumentSignals => ({
+  has_outline: false,
+  has_page_labels: false,
+  has_permissions: false,
+  has_mark_info: false,
+  has_form_fields: false,
+  has_attachments: false,
+  has_structure_tree: false,
+  ...overrides,
+});
+
+describe('inspector', () => {
+  describe('selectInspectionSamplePages', () => {
+    it('samples the first, middle, and last pages without exceeding the limit', () => {
+      expect(selectInspectionSamplePages(100, undefined, 5)).toEqual([1, 26, 51, 75, 100]);
+    });
+
+    it('samples inside explicit target pages only', () => {
+      expect(selectInspectionSamplePages(20, [2, 4, 6, 8, 10, 12], 3)).toEqual([2, 8, 12]);
+    });
+
+    it('ignores target pages outside the document range', () => {
+      expect(selectInspectionSamplePages(3, [10, 11], 5)).toEqual([]);
+    });
+  });
+
+  describe('classifyPdfInspectionProfile', () => {
+    it('classifies text-rich samples as digital text', () => {
+      expect(classifyPdfInspectionProfile([signal(1, 500), signal(2, 300)])).toBe('digital_text');
+    });
+
+    it('classifies image-only samples as scanned or image-only', () => {
+      expect(classifyPdfInspectionProfile([signal(1, 0, 2), signal(2, 3, 1)])).toBe('scanned_or_image_only');
+    });
+
+    it('classifies mixed selectable text and scanned pages', () => {
+      expect(classifyPdfInspectionProfile([signal(1, 420), signal(2, 0, 1)])).toBe('mixed_text_and_scan');
+    });
+  });
+
+  describe('buildInspectionRecommendation', () => {
+    it('does not imply OCR support for scanned PDFs', () => {
+      const recommendation = buildInspectionRecommendation(
+        { path: 'scan.pdf' },
+        'scanned_or_image_only',
+        documentSignals()
+      );
+
+      expect(recommendation).toMatchObject({
+        workflow: 'scanned_pdf_triage',
+        needs_ocr: true,
+      });
+      expect(recommendation.read_pdf_arguments).not.toHaveProperty('include_full_text');
+      expect(recommendation.read_pdf_arguments).not.toHaveProperty('include_chunks');
+    });
+
+    it('recommends citation-ready extraction for digital text PDFs', () => {
+      const recommendation = buildInspectionRecommendation(
+        { path: 'report.pdf' },
+        'digital_text',
+        documentSignals({ has_outline: true, has_structure_tree: true })
+      );
+
+      expect(recommendation).toMatchObject({
+        workflow: 'agentic_rag',
+        needs_ocr: false,
+        read_pdf_arguments: {
+          include_chunks: true,
+          include_semantic_hints: true,
+          include_safety_findings: true,
+          include_tables: true,
+          include_outline: true,
+          include_structure_tree: true,
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add an `inspect_pdf` MCP tool that profiles PDFs before heavier extraction
- return page-level text/image signals, document signals, OCR triage, and ready-to-use `read_pdf` recommendations
- update public README, docs, specs, package metadata, tests, and bundled dist output

## Validation

- `bun run check`
- `bun run typecheck`
- `bun run build`
- `bun test --reporter=dot`
- `bun run docs:build`
- `bun changeset status`
- `git diff --check`
- live HTTP MCP smoke for `/mcp/health`, `initialize`, `tools/list`, and `inspect_pdf` on `test/fixtures/sample.pdf`

## Release

- includes a patch Changeset for `@sylphx/pdf-reader-mcp`
- after merge, the Changesets release workflow should create/update the release PR and publish the package after the release PR lands
