### PR TITLE
[codex] add layout diagnostics

### DIFF
--- a/.changeset/layout-diagnostics.md
+++ b/.changeset/layout-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@sylphx/pdf-reader-mcp": patch
+---
+
+Add optional `include_layout_diagnostics` output with page layout profiles, reading-order confidence, column signals, and warnings for agent routing.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg?style=flat-square)](https://www.typescriptlang.org/)
 [![Downloads](https://img.shields.io/npm/dm/@sylphx/pdf-reader-mcp?style=flat-square)](https://www.npmjs.com/package/@sylphx/pdf-reader-mcp)
 
-**PDF inspection** • **Structured element output** • **Semantic citation chunks** • **Local-first MCP**
+**PDF inspection** • **Layout confidence** • **Semantic citation chunks** • **Local-first MCP**
 
 <a href="https://mseep.ai/app/SylphxAI-pdf-reader-mcp">
 <img src="https://mseep.net/pr/SylphxAI-pdf-reader-mcp-badge.png" alt="Security Validated" width="200"/>
@@ -42,6 +42,7 @@ PDF Reader MCP is a **production-ready** Model Context Protocol server that empo
 - Structured element output for agent workflows 🧩
 - Markdown rendering for RAG and summarization 📝
 - Citation-ready semantic/table/page chunks 🔗
+- Layout diagnostics with reading-order confidence 📐
 - Outlines, annotations, structure trees, forms, attachments, labels, and permission signals 🗂️
 - Column-aware reading order 📐
 - Flexible path support (absolute/relative) 🎯
@@ -67,6 +68,7 @@ PDF Reader MCP is a **production-ready** Model Context Protocol server that empo
 - 🎯 **Path Flexibility** - Absolute & relative paths, Windows/Unix support (v1.3.0)
 - 🔎 **PDF Inspection** - Profile PDFs before extraction and get recommended `read_pdf` arguments for agent workflows
 - 🧩 **Structured Elements** - Optional page-level elements with stable IDs, provenance, and best-effort bounding boxes
+- 📐 **Layout Diagnostics** - Optional page profiles, column signals, and reading-order confidence for agent routing
 - 📝 **Markdown Rendering** - Optional page-aware Markdown for RAG, summarization, and agent context
 - 🔗 **Citation Chunks** - Optional page, semantic, size, and table chunks with element IDs and best-effort bounding boxes
 - 🗂️ **Document Signals** - Optional outlines, page labels, annotations, structure trees, forms, attachments, permissions, and mark info
@@ -446,6 +448,14 @@ does not perform OCR. When sampled pages look scanned or image-only, the tool
 marks `needs_ocr: true` so agents do not mistake an image-based PDF for a text
 extraction failure.
 
+### Layout Confidence for Agent Routing
+
+`include_layout_diagnostics` adds deterministic page-level signals for layout
+profile, reading-order model, confidence, column count, positioned item ratio,
+and warnings. This helps agents decide when local extraction is safe for RAG and
+when a page should be routed to a heavier parser, OCR/vision workflow, or human
+review.
+
 ### Agent-Ready Structured Output
 
 `include_elements` adds structured document elements to the JSON response while keeping the existing text, metadata, image, and table outputs backward compatible.
@@ -561,6 +571,7 @@ tables, and document signals.
 | `include_markdown` | boolean | Include page-aware Markdown for RAG and summarization | `false` |
 | `include_html` | boolean | Include escaped page-aware HTML for preview/export workflows | `false` |
 | `include_chunks` | boolean | Include page, semantic, size, and table chunks with source references | `false` |
+| `include_layout_diagnostics` | boolean | Include page layout profiles, reading-order confidence, column signals, and warnings | `false` |
 | `include_outline` | boolean | Include PDF outline/bookmarks when available | `false` |
 | `include_annotations` | boolean | Include safe annotation summaries for selected pages | `false` |
 | `include_page_labels` | boolean | Include PDF page labels when available | `false` |
@@ -1036,6 +1047,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md)
 - [x] Citation-ready page, semantic, size, and table chunks
 - [x] Outlines, annotations, structure trees, form fields, attachment metadata, page labels, and permission signals
 - [x] Column-aware ordering for common multi-column PDFs
+- [x] Layout diagnostics with reading-order confidence
 - [x] Quality evals for semantic chunks, table ordering, renderers, and safety findings
 - [x] Filesystem and HTTP access restrictions
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1357,6 +1357,7 @@ var buildInspectionRecommendation = (source, profile, documentSignals) => {
       include_chunks: true,
       include_semantic_hints: true,
       include_safety_findings: true,
+      include_layout_diagnostics: true,
       include_markdown: true,
       include_tables: true
     });
@@ -1372,6 +1373,7 @@ var buildInspectionRecommendation = (source, profile, documentSignals) => {
       include_chunks: true,
       include_semantic_hints: true,
       include_safety_findings: true,
+      include_layout_diagnostics: true,
       include_markdown: true,
       include_tables: true
     });
@@ -1525,7 +1527,8 @@ var readPdfArgsSchema = object({
   include_form_fields: optional(bool(description("Include PDF form field summaries when AcroForm fields are exposed."))),
   include_attachments: optional(bool(description("Include embedded attachment metadata such as filename and size. Attachment bytes are not returned."))),
   include_structure_tree: optional(bool(description("Include best-effort tagged PDF structure trees for selected pages when the PDF exposes them."))),
-  include_safety_findings: optional(bool(description("Include deterministic content safety findings for prompt-injection patterns, tiny text, and off-page text.")))
+  include_safety_findings: optional(bool(description("Include deterministic content safety findings for prompt-injection patterns, tiny text, and off-page text."))),
+  include_layout_diagnostics: optional(bool(description("Include deterministic page layout profiles, reading-order confidence, column signals, and warnings for agent routing.")))
 });
 
 // src/schemas/inspectPdf.ts
@@ -1888,6 +1891,10 @@ var tablesToMarkdown = (tables) => {
 
 // src/pdf/documentModel.ts
 var DEFAULT_CHUNK_MAX_CHARS = 1800;
+var LAYOUT_COLUMN_MIN_GAP = 48;
+var LAYOUT_COLUMN_MIN_GAP_RATIO = 0.14;
+var LAYOUT_SPANNING_WIDTH_RATIO = 0.72;
+var LAYOUT_POSITIONED_RATIO_WARNING = 0.8;
 var buildElementId = (page, type, index) => `p${String(page)}-${type}-${String(index)}`;
 var imageElementMetadata = (imageData) => {
   const { data: _data, ...metadata } = imageData;
@@ -2173,6 +2180,149 @@ var buildCitationChunks = (elements, options) => {
   pushCurrent();
   return chunks;
 };
+var roundRatio = (value) => Math.round(value * 100) / 100;
+var clampConfidence = (value) => Math.max(0.2, Math.min(0.98, roundRatio(value)));
+var boxWidth = (box) => box ? Math.max(0, box.right - box.left) : 0;
+var boxArea = (box) => {
+  if (!box)
+    return 0;
+  return Math.max(0, box.right - box.left) * Math.max(0, box.top - box.bottom);
+};
+var boxCenterX = (box) => box ? (box.left + box.right) / 2 : 0;
+var toLayoutColumn = (items, index) => {
+  const boxes = items.map((item) => item.bounding_box).filter((box) => box !== undefined);
+  return {
+    index,
+    left: Math.min(...boxes.map((box) => box.left)),
+    right: Math.max(...boxes.map((box) => box.right)),
+    item_count: items.length
+  };
+};
+var detectLayoutColumns = (positionedItems) => {
+  if (positionedItems.length < 4)
+    return [];
+  const left = Math.min(...positionedItems.map((item) => item.bounding_box?.left ?? 0));
+  const right = Math.max(...positionedItems.map((item) => item.bounding_box?.right ?? 0));
+  const pageWidth = right - left;
+  if (pageWidth <= 0)
+    return [];
+  const candidates = positionedItems.filter((item) => boxWidth(item.bounding_box) < pageWidth * LAYOUT_SPANNING_WIDTH_RATIO);
+  if (candidates.length < 4)
+    return [];
+  const sorted = [...candidates].sort((a, b) => (a.bounding_box?.left ?? 0) - (b.bounding_box?.left ?? 0));
+  let currentRight = sorted[0]?.bounding_box?.right;
+  if (currentRight === undefined)
+    return [];
+  let largestGap = 0;
+  let cutPosition;
+  for (let i = 1;i < sorted.length; i++) {
+    const box = sorted[i]?.bounding_box;
+    if (!box)
+      continue;
+    if (box.left > currentRight) {
+      const gap = box.left - currentRight;
+      if (gap > largestGap) {
+        largestGap = gap;
+        cutPosition = (box.left + currentRight) / 2;
+      }
+    }
+    currentRight = Math.max(currentRight, box.right);
+  }
+  const minGap = Math.max(LAYOUT_COLUMN_MIN_GAP, pageWidth * LAYOUT_COLUMN_MIN_GAP_RATIO);
+  if (cutPosition === undefined || largestGap < minGap)
+    return [];
+  const leftColumn = candidates.filter((item) => boxCenterX(item.bounding_box) < cutPosition);
+  const rightColumn = candidates.filter((item) => boxCenterX(item.bounding_box) >= cutPosition);
+  if (leftColumn.length < 2 || rightColumn.length < 2)
+    return [];
+  return [toLayoutColumn(leftColumn, 1), toLayoutColumn(rightColumn, 2)];
+};
+var overlapArea = (first, second) => {
+  if (!first || !second)
+    return 0;
+  const width = Math.max(0, Math.min(first.right, second.right) - Math.max(first.left, second.left));
+  const height = Math.max(0, Math.min(first.top, second.top) - Math.max(first.bottom, second.bottom));
+  return width * height;
+};
+var countSignificantOverlaps = (items) => {
+  const positionedItems = items.filter((item) => item.bounding_box !== undefined).slice(0, 200);
+  let overlaps = 0;
+  for (let i = 0;i < positionedItems.length; i++) {
+    for (let j = i + 1;j < positionedItems.length; j++) {
+      const first = positionedItems[i];
+      const second = positionedItems[j];
+      if (!first?.bounding_box || !second?.bounding_box)
+        continue;
+      const smallerArea = Math.min(boxArea(first.bounding_box), boxArea(second.bounding_box));
+      if (smallerArea <= 0)
+        continue;
+      if (overlapArea(first.bounding_box, second.bounding_box) / smallerArea > 0.45) {
+        overlaps++;
+      }
+    }
+  }
+  return overlaps;
+};
+var buildLayoutDiagnostics = (pageContents) => pageContents.map((pageContent) => {
+  const itemCount = pageContent.items.length;
+  const textItemCount = pageContent.items.filter((item) => item.type === "text").length;
+  const imageItemCount = pageContent.items.filter((item) => item.type === "image").length;
+  const positionedItems = pageContent.items.filter((item) => item.bounding_box !== undefined);
+  const positionedItemRatio = itemCount === 0 ? 0 : roundRatio(positionedItems.length / itemCount);
+  const columns = detectLayoutColumns(positionedItems);
+  const left = positionedItems.length ? Math.min(...positionedItems.map((item) => item.bounding_box?.left ?? 0)) : 0;
+  const right = positionedItems.length ? Math.max(...positionedItems.map((item) => item.bounding_box?.right ?? 0)) : 0;
+  const pageWidth = right - left;
+  const spanningItemCount = pageWidth > 0 ? positionedItems.filter((item) => boxWidth(item.bounding_box) >= pageWidth * LAYOUT_SPANNING_WIDTH_RATIO).length : 0;
+  const overlapCount = countSignificantOverlaps(pageContent.items);
+  const signals = new Set;
+  const warnings = [];
+  if (itemCount === 0)
+    signals.add("empty-page-content");
+  if (textItemCount > 0)
+    signals.add("text-items");
+  if (imageItemCount > 0)
+    signals.add("image-items");
+  if (positionedItems.length > 0)
+    signals.add("positioned-items");
+  if (positionedItemRatio < 1 && itemCount > 0)
+    signals.add("unpositioned-items");
+  if (columns.length >= 2)
+    signals.add("two-column-layout");
+  if (spanningItemCount > 0)
+    signals.add("spanning-items");
+  if (itemCount > 0 && itemCount < 3)
+    signals.add("sparse-page");
+  if (overlapCount > 0)
+    signals.add("overlap-risk");
+  if (positionedItemRatio < LAYOUT_POSITIONED_RATIO_WARNING && itemCount > 0) {
+    warnings.push("Some content items are missing coordinates; reading-order confidence is reduced.");
+  }
+  if (overlapCount > 0) {
+    warnings.push("Some positioned items overlap significantly; verify reading order before citation-critical use.");
+  }
+  const profile = itemCount === 0 ? "unknown" : textItemCount === 0 ? "image_or_sparse" : columns.length >= 2 && spanningItemCount > 0 ? "mixed_layout" : columns.length >= 2 ? "multi_column" : positionedItems.length > 0 ? "single_column" : "unknown";
+  const readingOrder = profile === "multi_column" ? "columnar" : profile === "mixed_layout" ? "mixed" : profile === "single_column" ? "natural" : "uncertain";
+  const baseConfidence = profile === "single_column" ? 0.92 : profile === "multi_column" ? 0.86 : profile === "mixed_layout" ? 0.78 : profile === "image_or_sparse" ? 0.42 : 0.3;
+  const confidence = clampConfidence(baseConfidence - (1 - positionedItemRatio) * 0.35 - (overlapCount > 0 ? 0.12 : 0) - (itemCount > 0 && itemCount < 3 ? 0.12 : 0));
+  if (confidence < 0.7 && itemCount > 0) {
+    warnings.push("Layout confidence is below the recommended threshold for unattended RAG chunking.");
+  }
+  return {
+    page: pageContent.page,
+    profile,
+    reading_order: readingOrder,
+    confidence,
+    item_count: itemCount,
+    text_item_count: textItemCount,
+    image_item_count: imageItemCount,
+    positioned_item_ratio: positionedItemRatio,
+    column_count: columns.length > 0 ? columns.length : positionedItems.length > 0 ? 1 : 0,
+    ...columns.length > 0 ? { columns } : {},
+    signals: [...signals],
+    ...warnings.length > 0 ? { warnings } : {}
+  };
+});
 var PROMPT_INJECTION_PATTERNS = [
   /\bignore (all )?(previous|prior|above) instructions\b/i,
   /\bdisregard (previous|prior|above) instructions\b/i,
@@ -2265,7 +2415,7 @@ var processSingleSource = async (source, options) => {
       includeAttachments: options.includeAttachments
     });
     Object.assign(output, structureOutput);
-    const explicitPageContent = options.includeFullText || options.includeElements || options.includeSemanticHints || options.includeMarkdown || options.includeHtml || options.includeChunks || options.includeImages || options.includeSafetyFindings;
+    const explicitPageContent = options.includeFullText || options.includeElements || options.includeSemanticHints || options.includeMarkdown || options.includeHtml || options.includeChunks || options.includeImages || options.includeSafetyFindings || options.includeLayoutDiagnostics;
     const pageScopedMetadata = options.includeTables || options.includeAnnotations || options.includePageGeometry || options.includeStructureTree;
     const includeSelectedPageText = targetPages !== undefined && !explicitPageContent && !pageScopedMetadata;
     const shouldSelectPages = explicitPageContent || includeSelectedPageText || pageScopedMetadata;
@@ -2344,6 +2494,9 @@ var processSingleSource = async (source, options) => {
           output.safety_findings = safetyFindings;
         }
       }
+      if (options.includeLayoutDiagnostics && output.page_contents) {
+        output.layout_diagnostics = buildLayoutDiagnostics(output.page_contents);
+      }
       if (options.includeAnnotations) {
         const annotations = await extractAnnotations(pdfDocument, pagesToProcess);
         if (annotations.length > 0) {
@@ -2407,7 +2560,8 @@ var readPdf = tool2().description("Reads content/metadata/images from one or mor
     include_form_fields,
     include_attachments,
     include_structure_tree,
-    include_safety_findings
+    include_safety_findings,
+    include_layout_diagnostics
   } = input;
   const MAX_CONCURRENT_SOURCES2 = 3;
   const results = [];
@@ -2430,7 +2584,8 @@ var readPdf = tool2().description("Reads content/metadata/images from one or mor
     includeFormFields: include_form_fields ?? false,
     includeAttachments: include_attachments ?? false,
     includeStructureTree: include_structure_tree ?? false,
-    includeSafetyFindings: include_safety_findings ?? false
+    includeSafetyFindings: include_safety_findings ?? false,
+    includeLayoutDiagnostics: include_layout_diagnostics ?? false
   };
   for (let i = 0;i < sources.length; i += MAX_CONCURRENT_SOURCES2) {
     const batch = sources.slice(i, i + MAX_CONCURRENT_SOURCES2);

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitepress';
 export default defineConfig({
   title: 'PDF Reader MCP',
   description:
-    'MCP server for PDF inspection, extraction, citation chunks, and safety signals for AI agents',
+    'MCP server for PDF inspection, layout confidence, citation chunks, and safety signals for AI agents',
 
   appearance: 'dark',
   lastUpdated: true,
@@ -25,7 +25,7 @@ export default defineConfig({
       {
         property: 'og:description',
         content:
-          'A high-performance MCP server for PDF inspection, structured extraction, citation chunks, and safety signals',
+          'A high-performance MCP server for PDF inspection, layout confidence, citation chunks, and safety signals',
       },
     ],
     ['meta', { property: 'og:url', content: 'https://pdf-reader-mcp.sylphx.com' }],
@@ -36,7 +36,7 @@ export default defineConfig({
       'meta',
       {
         name: 'twitter:description',
-        content: 'Inspect PDFs and extract agent-ready content via MCP',
+        content: 'Inspect PDFs and extract layout-aware agent-ready content via MCP',
       },
     ],
     ['meta', { name: 'twitter:site', content: '@sylphxai' }],
@@ -45,7 +45,7 @@ export default defineConfig({
       {
         name: 'keywords',
         content:
-          'mcp, pdf, reader, ai, claude, model context protocol, typescript, rag, citations, pdf inspection',
+          'mcp, pdf, reader, ai, claude, model context protocol, typescript, rag, citations, pdf inspection, layout analysis, reading order',
       },
     ],
     ['meta', { name: 'author', content: 'Sylphx' }],

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -3,7 +3,8 @@
 Once installed, the PDF Reader MCP server provides two tools:
 
 - `inspect_pdf` profiles a PDF and recommends the best extraction options.
-- `read_pdf` extracts PDF content, structure, citations, tables, images, and signals.
+- `read_pdf` extracts PDF content, structure, citations, tables, images, layout
+  confidence, and signals.
 
 ## Basic Usage
 
@@ -175,6 +176,29 @@ available.
   "include_page_count": true
 }
 ```
+
+### Get Layout Diagnostics
+
+Use `include_layout_diagnostics` when an agent needs to know whether local
+reading order is likely reliable before indexing, citing, or summarizing a
+page. Diagnostics are deterministic and use existing extracted item geometry;
+they do not add OCR, vision, or a heavy parser dependency.
+
+```json
+{
+  "sources": [{
+    "path": "/path/to/document.pdf",
+    "pages": "1-5"
+  }],
+  "include_layout_diagnostics": true,
+  "include_chunks": true,
+  "include_semantic_hints": true,
+  "include_full_text": false
+}
+```
+
+Response fields include `profile`, `reading_order`, `confidence`,
+`column_count`, `positioned_item_ratio`, `signals`, and optional `warnings`.
 
 ### Get Document Signals
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: PDF Reader MCP
   text: Inspect and Extract PDFs for AI Agents
-  tagline: A high-performance MCP server for local-first PDF inspection, extraction, citations, and safety signals.
+  tagline: A high-performance MCP server for local-first PDF inspection, layout confidence, citations, and safety signals.
   image:
     src: /logo.svg
     alt: PDF Reader MCP Logo
@@ -28,7 +28,10 @@ features:
     details: Works with Claude Desktop, Claude Code, Cursor, and any MCP-compatible client. One command to install.
   - icon: "\U0001F5BC\uFE0F"
     title: Agent-Ready Context
-    details: Return stable element IDs, semantic hints, citation-ready semantic/table chunks, structure trees, page geometry, provenance, and best-effort coordinates.
+    details: Return stable element IDs, semantic hints, citation-ready semantic/table chunks, layout confidence, structure trees, page geometry, provenance, and best-effort coordinates.
+  - icon: "\U0001F9ED"
+    title: Layout Confidence
+    details: Surface page layout profiles, reading-order confidence, column signals, and warnings so agents can route uncertain pages safely.
   - icon: "\U0001F6E1\uFE0F"
     title: Content Safety Signals
     details: Surface deterministic findings for prompt-injection patterns, tiny text, and off-page text before agents use PDF content.

--- a/docs/performance/index.md
+++ b/docs/performance/index.md
@@ -161,7 +161,23 @@ context.
 }
 ```
 
-### 11. Use Document Signals For Lightweight Structure
+### 11. Use Layout Diagnostics For Routing
+
+`include_layout_diagnostics` returns page layout profiles, reading-order
+confidence, column signals, and warnings. It uses already extracted content
+geometry and does not add OCR, vision, or parser dependencies. It is useful
+before unattended RAG indexing or citation-critical summarization.
+
+```json
+{
+  "sources": [{ "path": "doc.pdf", "pages": "1-5" }],
+  "include_layout_diagnostics": true,
+  "include_chunks": true,
+  "include_full_text": false
+}
+```
+
+### 12. Use Document Signals For Lightweight Structure
 
 Outline, page labels, permissions, structure trees, form fields, attachment
 metadata, and page geometry can be requested without extracting full page text.
@@ -177,7 +193,7 @@ Annotations, structure trees, and page geometry respect selected page ranges.
 }
 ```
 
-### 12. Use Safety Findings When Agents Consume PDF Text
+### 13. Use Safety Findings When Agents Consume PDF Text
 
 `include_safety_findings` scans extracted page text for deterministic risk
 signals. It requires page text extraction, but it does not force `full_text`

--- a/docs/specs/2026-06-14-capability-gap-matrix.md
+++ b/docs/specs/2026-06-14-capability-gap-matrix.md
@@ -31,6 +31,7 @@ neutral capability names and avoids public comparison language.
 | HTML rendering | Shipped | `include_html`; escaped page-aware HTML. |
 | Citation-ready chunks | Shipped | `include_chunks`; page, semantic, size, and table strategies with stable element references. |
 | Column-aware reading order | Shipped | Handles common two-column text segmentation. Needs broader fixtures. |
+| Layout diagnostics and confidence | Shipped | `include_layout_diagnostics`; page profile, reading-order model, confidence, column signals, and warnings. |
 | Outline/bookmark extraction | Shipped | `include_outline`; best-effort when exposed by PDF.js. |
 | Annotation extraction | Shipped | `include_annotations`; safe summary fields. |
 | Page labels | Shipped | `include_page_labels`. |
@@ -57,7 +58,7 @@ neutral capability names and avoids public comparison language.
    outline, annotations, page labels, permissions, form fields, attachment
    metadata, page geometry, structure trees, semantic hints, and safety
    findings.
-2. Expand extraction quality evals: multi-column, tables,
+2. Expand extraction quality evals: multi-column, layout diagnostics, tables,
    annotations, forms, hidden/off-page text, scanned PDFs.
 3. Add deterministic semantic model: headings, paragraphs, lists, captions,
    richer tables.

--- a/docs/specs/2026-06-14-pdf-intelligence-vnext.md
+++ b/docs/specs/2026-06-14-pdf-intelligence-vnext.md
@@ -137,6 +137,7 @@ Candidate engines:
    - Add best-effort text and image element metadata.
    - Add best-effort table and table-cell geometry.
    - Add semantic, size, and table-aware chunk strategies.
+   - Add layout diagnostics with reading-order confidence for agent routing.
    - Keep legacy outputs stable.
    - Add tests for schema, JSON response shape, and no binary data in JSON.
 
@@ -145,6 +146,7 @@ Candidate engines:
    - Add layout-aware reading order beyond simple Y sorting.
    - Split distant same-line text into independent segments for common
      multi-column PDFs.
+   - Add page-level layout profiles, confidence scores, and warnings.
    - Add fixtures for multi-column pages, sidebars, headers, and footers.
 
 3. Semantic extraction

--- a/docs/specs/2026-06-15-layout-diagnostics.md
+++ b/docs/specs/2026-06-15-layout-diagnostics.md
@@ -1,0 +1,79 @@
+# Layout Diagnostics
+
+Date: 2026-06-15
+Status: active
+
+## Goal
+
+Expose lightweight, deterministic layout confidence signals so agents can
+decide whether local PDF extraction is safe for indexing, summarization, and
+citation-critical workflows.
+
+The feature should improve routing quality without adding OCR, vision models,
+Java, Python, or external parser dependencies.
+
+## Contract
+
+`read_pdf` accepts:
+
+```json
+{
+  "sources": [{ "path": "report.pdf", "pages": "1-5" }],
+  "include_layout_diagnostics": true
+}
+```
+
+When enabled, each successful source may include `layout_diagnostics`:
+
+```json
+{
+  "layout_diagnostics": [
+    {
+      "page": 1,
+      "profile": "multi_column",
+      "reading_order": "columnar",
+      "confidence": 0.86,
+      "item_count": 12,
+      "text_item_count": 12,
+      "image_item_count": 0,
+      "positioned_item_ratio": 1,
+      "column_count": 2,
+      "columns": [
+        { "index": 1, "left": 40, "right": 210, "item_count": 6 },
+        { "index": 2, "left": 330, "right": 500, "item_count": 6 }
+      ],
+      "signals": ["text-items", "positioned-items", "two-column-layout"]
+    }
+  ]
+}
+```
+
+Profiles:
+
+- `single_column`
+- `multi_column`
+- `mixed_layout`
+- `image_or_sparse`
+- `unknown`
+
+Reading-order models:
+
+- `natural`
+- `columnar`
+- `mixed`
+- `uncertain`
+
+## Invariants
+
+- Disabled by default for backward compatibility.
+- Uses existing page content geometry; no second parser pass.
+- Does not decode image bytes unless `include_images` is also requested.
+- Does not claim OCR, vision, or accessibility remediation.
+- Emits warnings when confidence is low, coordinates are sparse, or positioned
+  items overlap.
+
+## Validation
+
+- Unit/eval coverage verifies layout confidence signals.
+- Handler coverage verifies the public `read_pdf` flag and JSON shape.
+- Full validation includes typecheck, Biome, build, tests, and docs build.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "rag",
     "citations",
     "pdf-inspection",
+    "layout-analysis",
+    "reading-order",
     "pdf-to-markdown",
     "document-processing"
   ],

--- a/src/handlers/readPdf.ts
+++ b/src/handlers/readPdf.ts
@@ -4,6 +4,7 @@ import { image, text, tool, toolError } from '@sylphx/mcp-server-sdk';
 import type * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.mjs';
 import {
   buildCitationChunks,
+  buildLayoutDiagnostics,
   buildSafetyFindings,
   buildStructuredElements,
   renderHtmlFromPageContents,
@@ -60,6 +61,7 @@ const processSingleSource = async (
     includeAttachments: boolean;
     includeStructureTree: boolean;
     includeSafetyFindings: boolean;
+    includeLayoutDiagnostics: boolean;
   }
 ): Promise<PdfSourceResult> => {
   const sourceDescription = source.path ?? source.url ?? 'unknown source';
@@ -102,7 +104,8 @@ const processSingleSource = async (
       options.includeHtml ||
       options.includeChunks ||
       options.includeImages ||
-      options.includeSafetyFindings;
+      options.includeSafetyFindings ||
+      options.includeLayoutDiagnostics;
     const pageScopedMetadata =
       options.includeTables ||
       options.includeAnnotations ||
@@ -245,6 +248,10 @@ const processSingleSource = async (
         }
       }
 
+      if (options.includeLayoutDiagnostics && output.page_contents) {
+        output.layout_diagnostics = buildLayoutDiagnostics(output.page_contents);
+      }
+
       if (options.includeAnnotations) {
         const annotations = await extractAnnotations(
           pdfDocument as pdfjsLib.PDFDocumentProxy,
@@ -335,6 +342,7 @@ export const readPdf = tool()
       include_attachments,
       include_structure_tree,
       include_safety_findings,
+      include_layout_diagnostics,
     } = input;
 
     // Process sources with concurrency limit to prevent memory exhaustion
@@ -361,6 +369,7 @@ export const readPdf = tool()
       includeAttachments: include_attachments ?? false,
       includeStructureTree: include_structure_tree ?? false,
       includeSafetyFindings: include_safety_findings ?? false,
+      includeLayoutDiagnostics: include_layout_diagnostics ?? false,
     };
 
     for (let i = 0; i < sources.length; i += MAX_CONCURRENT_SOURCES) {

--- a/src/pdf/documentModel.ts
+++ b/src/pdf/documentModel.ts
@@ -4,7 +4,9 @@ import type {
   PageContentItem,
   PdfChunk,
   PdfDocumentElement,
+  PdfLayoutColumn,
   PdfPageGeometry,
+  PdfPageLayoutDiagnostics,
   PdfSafetyFinding,
   PdfTextElement,
   PdfTextSemanticHint,
@@ -13,6 +15,10 @@ import type {
 import { tablesToMarkdown } from './tableExtractor.js';
 
 const DEFAULT_CHUNK_MAX_CHARS = 1800;
+const LAYOUT_COLUMN_MIN_GAP = 48;
+const LAYOUT_COLUMN_MIN_GAP_RATIO = 0.14;
+const LAYOUT_SPANNING_WIDTH_RATIO = 0.72;
+const LAYOUT_POSITIONED_RATIO_WARNING = 0.8;
 
 const buildElementId = (page: number, type: PdfDocumentElement['type'], index: number): string =>
   `p${String(page)}-${type}-${String(index)}`;
@@ -419,6 +425,222 @@ export const buildCitationChunks = (
 
   return chunks;
 };
+
+const roundRatio = (value: number): number => Math.round(value * 100) / 100;
+
+const clampConfidence = (value: number): number => Math.max(0.2, Math.min(0.98, roundRatio(value)));
+
+const boxWidth = (box: PageContentItem['bounding_box']): number =>
+  box ? Math.max(0, box.right - box.left) : 0;
+
+const boxArea = (box: PageContentItem['bounding_box']): number => {
+  if (!box) return 0;
+  return Math.max(0, box.right - box.left) * Math.max(0, box.top - box.bottom);
+};
+
+const boxCenterX = (box: PageContentItem['bounding_box']): number =>
+  box ? (box.left + box.right) / 2 : 0;
+
+const toLayoutColumn = (items: PageContentItem[], index: number): PdfLayoutColumn => {
+  const boxes = items.map((item) => item.bounding_box).filter((box) => box !== undefined);
+  return {
+    index,
+    left: Math.min(...boxes.map((box) => box.left)),
+    right: Math.max(...boxes.map((box) => box.right)),
+    item_count: items.length,
+  };
+};
+
+const detectLayoutColumns = (positionedItems: PageContentItem[]): PdfLayoutColumn[] => {
+  if (positionedItems.length < 4) return [];
+
+  const left = Math.min(...positionedItems.map((item) => item.bounding_box?.left ?? 0));
+  const right = Math.max(...positionedItems.map((item) => item.bounding_box?.right ?? 0));
+  const pageWidth = right - left;
+  if (pageWidth <= 0) return [];
+
+  const candidates = positionedItems.filter(
+    (item) => boxWidth(item.bounding_box) < pageWidth * LAYOUT_SPANNING_WIDTH_RATIO
+  );
+  if (candidates.length < 4) return [];
+
+  const sorted = [...candidates].sort(
+    (a, b) => (a.bounding_box?.left ?? 0) - (b.bounding_box?.left ?? 0)
+  );
+  let currentRight = sorted[0]?.bounding_box?.right;
+  if (currentRight === undefined) return [];
+
+  let largestGap = 0;
+  let cutPosition: number | undefined;
+  for (let i = 1; i < sorted.length; i++) {
+    const box = sorted[i]?.bounding_box;
+    if (!box) continue;
+
+    if (box.left > currentRight) {
+      const gap = box.left - currentRight;
+      if (gap > largestGap) {
+        largestGap = gap;
+        cutPosition = (box.left + currentRight) / 2;
+      }
+    }
+    currentRight = Math.max(currentRight, box.right);
+  }
+
+  const minGap = Math.max(LAYOUT_COLUMN_MIN_GAP, pageWidth * LAYOUT_COLUMN_MIN_GAP_RATIO);
+  if (cutPosition === undefined || largestGap < minGap) return [];
+
+  const leftColumn = candidates.filter((item) => boxCenterX(item.bounding_box) < cutPosition);
+  const rightColumn = candidates.filter((item) => boxCenterX(item.bounding_box) >= cutPosition);
+  if (leftColumn.length < 2 || rightColumn.length < 2) return [];
+
+  return [toLayoutColumn(leftColumn, 1), toLayoutColumn(rightColumn, 2)];
+};
+
+const overlapArea = (
+  first: PageContentItem['bounding_box'],
+  second: PageContentItem['bounding_box']
+): number => {
+  if (!first || !second) return 0;
+  const width = Math.max(
+    0,
+    Math.min(first.right, second.right) - Math.max(first.left, second.left)
+  );
+  const height = Math.max(
+    0,
+    Math.min(first.top, second.top) - Math.max(first.bottom, second.bottom)
+  );
+  return width * height;
+};
+
+const countSignificantOverlaps = (items: PageContentItem[]): number => {
+  const positionedItems = items.filter((item) => item.bounding_box !== undefined).slice(0, 200);
+  let overlaps = 0;
+
+  for (let i = 0; i < positionedItems.length; i++) {
+    for (let j = i + 1; j < positionedItems.length; j++) {
+      const first = positionedItems[i];
+      const second = positionedItems[j];
+      if (!first?.bounding_box || !second?.bounding_box) continue;
+
+      const smallerArea = Math.min(boxArea(first.bounding_box), boxArea(second.bounding_box));
+      if (smallerArea <= 0) continue;
+
+      if (overlapArea(first.bounding_box, second.bounding_box) / smallerArea > 0.45) {
+        overlaps++;
+      }
+    }
+  }
+
+  return overlaps;
+};
+
+export const buildLayoutDiagnostics = (
+  pageContents: Array<{ page: number; items: PageContentItem[] }>
+): PdfPageLayoutDiagnostics[] =>
+  pageContents.map((pageContent) => {
+    const itemCount = pageContent.items.length;
+    const textItemCount = pageContent.items.filter((item) => item.type === 'text').length;
+    const imageItemCount = pageContent.items.filter((item) => item.type === 'image').length;
+    const positionedItems = pageContent.items.filter((item) => item.bounding_box !== undefined);
+    const positionedItemRatio =
+      itemCount === 0 ? 0 : roundRatio(positionedItems.length / itemCount);
+    const columns = detectLayoutColumns(positionedItems);
+    const left = positionedItems.length
+      ? Math.min(...positionedItems.map((item) => item.bounding_box?.left ?? 0))
+      : 0;
+    const right = positionedItems.length
+      ? Math.max(...positionedItems.map((item) => item.bounding_box?.right ?? 0))
+      : 0;
+    const pageWidth = right - left;
+    const spanningItemCount =
+      pageWidth > 0
+        ? positionedItems.filter(
+            (item) => boxWidth(item.bounding_box) >= pageWidth * LAYOUT_SPANNING_WIDTH_RATIO
+          ).length
+        : 0;
+    const overlapCount = countSignificantOverlaps(pageContent.items);
+    const signals = new Set<string>();
+    const warnings: string[] = [];
+
+    if (itemCount === 0) signals.add('empty-page-content');
+    if (textItemCount > 0) signals.add('text-items');
+    if (imageItemCount > 0) signals.add('image-items');
+    if (positionedItems.length > 0) signals.add('positioned-items');
+    if (positionedItemRatio < 1 && itemCount > 0) signals.add('unpositioned-items');
+    if (columns.length >= 2) signals.add('two-column-layout');
+    if (spanningItemCount > 0) signals.add('spanning-items');
+    if (itemCount > 0 && itemCount < 3) signals.add('sparse-page');
+    if (overlapCount > 0) signals.add('overlap-risk');
+
+    if (positionedItemRatio < LAYOUT_POSITIONED_RATIO_WARNING && itemCount > 0) {
+      warnings.push(
+        'Some content items are missing coordinates; reading-order confidence is reduced.'
+      );
+    }
+    if (overlapCount > 0) {
+      warnings.push(
+        'Some positioned items overlap significantly; verify reading order before citation-critical use.'
+      );
+    }
+
+    const profile =
+      itemCount === 0
+        ? 'unknown'
+        : textItemCount === 0
+          ? 'image_or_sparse'
+          : columns.length >= 2 && spanningItemCount > 0
+            ? 'mixed_layout'
+            : columns.length >= 2
+              ? 'multi_column'
+              : positionedItems.length > 0
+                ? 'single_column'
+                : 'unknown';
+    const readingOrder =
+      profile === 'multi_column'
+        ? 'columnar'
+        : profile === 'mixed_layout'
+          ? 'mixed'
+          : profile === 'single_column'
+            ? 'natural'
+            : 'uncertain';
+    const baseConfidence =
+      profile === 'single_column'
+        ? 0.92
+        : profile === 'multi_column'
+          ? 0.86
+          : profile === 'mixed_layout'
+            ? 0.78
+            : profile === 'image_or_sparse'
+              ? 0.42
+              : 0.3;
+    const confidence = clampConfidence(
+      baseConfidence -
+        (1 - positionedItemRatio) * 0.35 -
+        (overlapCount > 0 ? 0.12 : 0) -
+        (itemCount > 0 && itemCount < 3 ? 0.12 : 0)
+    );
+
+    if (confidence < 0.7 && itemCount > 0) {
+      warnings.push(
+        'Layout confidence is below the recommended threshold for unattended RAG chunking.'
+      );
+    }
+
+    return {
+      page: pageContent.page,
+      profile,
+      reading_order: readingOrder,
+      confidence,
+      item_count: itemCount,
+      text_item_count: textItemCount,
+      image_item_count: imageItemCount,
+      positioned_item_ratio: positionedItemRatio,
+      column_count: columns.length > 0 ? columns.length : positionedItems.length > 0 ? 1 : 0,
+      ...(columns.length > 0 ? { columns } : {}),
+      signals: [...signals],
+      ...(warnings.length > 0 ? { warnings } : {}),
+    };
+  });
 
 const PROMPT_INJECTION_PATTERNS = [
   /\bignore (all )?(previous|prior|above) instructions\b/i,

--- a/src/pdf/inspector.ts
+++ b/src/pdf/inspector.ts
@@ -189,6 +189,7 @@ export const buildInspectionRecommendation = (
       include_chunks: true,
       include_semantic_hints: true,
       include_safety_findings: true,
+      include_layout_diagnostics: true,
       include_markdown: true,
       include_tables: true,
     });
@@ -206,6 +207,7 @@ export const buildInspectionRecommendation = (
       include_chunks: true,
       include_semantic_hints: true,
       include_safety_findings: true,
+      include_layout_diagnostics: true,
       include_markdown: true,
       include_tables: true,
     });

--- a/src/schemas/readPdf.ts
+++ b/src/schemas/readPdf.ts
@@ -140,6 +140,13 @@ export const readPdfArgsSchema = object({
       )
     )
   ),
+  include_layout_diagnostics: optional(
+    bool(
+      description(
+        'Include deterministic page layout profiles, reading-order confidence, column signals, and warnings for agent routing.'
+      )
+    )
+  ),
 });
 
 export type ReadPdfArgs = InferOutput<typeof readPdfArgsSchema>;

--- a/src/types/pdf.ts
+++ b/src/types/pdf.ts
@@ -187,6 +187,37 @@ export interface PdfSafetyFinding {
   bounding_box?: BoundingBox | undefined;
 }
 
+export type PdfLayoutProfile =
+  | 'single_column'
+  | 'multi_column'
+  | 'mixed_layout'
+  | 'image_or_sparse'
+  | 'unknown';
+
+export type PdfReadingOrderModel = 'natural' | 'columnar' | 'mixed' | 'uncertain';
+
+export interface PdfLayoutColumn {
+  index: number;
+  left: number;
+  right: number;
+  item_count: number;
+}
+
+export interface PdfPageLayoutDiagnostics {
+  page: number;
+  profile: PdfLayoutProfile;
+  reading_order: PdfReadingOrderModel;
+  confidence: number;
+  item_count: number;
+  text_item_count: number;
+  image_item_count: number;
+  positioned_item_ratio: number;
+  column_count: number;
+  columns?: PdfLayoutColumn[] | undefined;
+  signals: string[];
+  warnings?: string[] | undefined;
+}
+
 // Content item with position for ordering
 export interface PageContentItem {
   type: 'text' | 'image';
@@ -220,6 +251,7 @@ export interface PdfResultData {
   elements?: PdfDocumentElement[];
   chunks?: PdfChunk[];
   safety_findings?: PdfSafetyFinding[];
+  layout_diagnostics?: PdfPageLayoutDiagnostics[];
   images?: ExtractedImage[];
   tables?: ExtractedTable[];
   warnings?: string[];
@@ -318,6 +350,7 @@ export interface ReadPdfOptions {
   include_attachments: boolean;
   include_structure_tree: boolean;
   include_safety_findings: boolean;
+  include_layout_diagnostics: boolean;
 }
 
 export interface InspectPdfOptions {

--- a/test/evals/pdfIntelligenceQuality.test.ts
+++ b/test/evals/pdfIntelligenceQuality.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildCitationChunks,
+  buildLayoutDiagnostics,
   buildSafetyFindings,
   buildStructuredElements,
   renderHtmlFromPageContents,
@@ -119,6 +120,7 @@ const evaluateCase = (qualityCase: QualityCase) => {
     maxChars: 140,
   });
   const safetyFindings = buildSafetyFindings(qualityCase.pageContents, qualityCase.pageGeometry);
+  const layoutDiagnostics = buildLayoutDiagnostics(qualityCase.pageContents);
   const markdown = renderMarkdownFromPageContents(qualityCase.pageContents, qualityCase.tables);
   const html = renderHtmlFromPageContents(qualityCase.pageContents, qualityCase.tables);
 
@@ -174,6 +176,14 @@ const evaluateCase = (qualityCase: QualityCase) => {
       name: 'bounding boxes are preserved on citation chunks',
       pass: chunks.every((chunk) => (chunk.bounding_boxes?.length ?? 0) > 0),
     },
+    {
+      name: 'layout diagnostics expose reading-order confidence',
+      pass:
+        layoutDiagnostics[0]?.profile === 'single_column' &&
+        layoutDiagnostics[0].reading_order === 'natural' &&
+        layoutDiagnostics[0].confidence >= 0.8 &&
+        layoutDiagnostics[0].signals.includes('positioned-items'),
+    },
   ];
 
   const failures = assertions.filter((assertion) => !assertion.pass).map((assertion) => assertion.name);
@@ -195,8 +205,8 @@ describe('PDF intelligence quality evals', () => {
 
       expect(result.failures).toEqual([]);
       expect(result).toMatchObject({
-        passed: 9,
-        total: 9,
+        passed: 10,
+        total: 10,
         score: 1,
       });
     });

--- a/test/handlers/readPdf.test.ts
+++ b/test/handlers/readPdf.test.ts
@@ -630,6 +630,93 @@ describe('handleReadPdfFunc Integration Tests', () => {
     }
   });
 
+  it('should include layout diagnostics without forcing full text output', async () => {
+    mockGetPage.mockImplementation((pageNum: number) => {
+      if (pageNum === 1) {
+        return {
+          getTextContent: vi.fn().mockResolvedValue({
+            items: [
+              {
+                str: 'Left column top',
+                transform: [1, 0, 0, 10, 40, 720],
+                width: 110,
+                height: 10,
+              },
+              {
+                str: 'Left column bottom',
+                transform: [1, 0, 0, 10, 40, 690],
+                width: 130,
+                height: 10,
+              },
+              {
+                str: 'Right column top',
+                transform: [1, 0, 0, 10, 330, 720],
+                width: 120,
+                height: 10,
+              },
+              {
+                str: 'Right column bottom',
+                transform: [1, 0, 0, 10, 330, 690],
+                width: 140,
+                height: 10,
+              },
+            ],
+          }),
+          getOperatorList: vi.fn().mockResolvedValue({ fnArray: [], argsArray: [] }),
+          getAnnotations: vi.fn().mockResolvedValue([]),
+          objs: { get: vi.fn() },
+        };
+      }
+      throw new Error(`Mock getPage error: Invalid page number ${String(pageNum)}`);
+    });
+
+    const args = {
+      sources: [{ path: 'test.pdf', pages: [1] }],
+      include_layout_diagnostics: true,
+      include_metadata: false,
+      include_page_count: false,
+      include_full_text: false,
+    };
+
+    const result = await handler(args);
+
+    if (result.content?.[0]) {
+      const parsed = JSON.parse(result.content[0].text) as {
+        results: Array<{
+          data?: {
+            full_text?: string;
+            layout_diagnostics?: Array<{
+              page: number;
+              profile: string;
+              reading_order: string;
+              confidence: number;
+              column_count: number;
+              columns?: Array<{ index: number; item_count: number }>;
+              signals: string[];
+            }>;
+          };
+        }>;
+      };
+
+      const diagnostics = parsed.results[0]?.data?.layout_diagnostics;
+      expect(parsed.results[0]?.data?.full_text).toBeUndefined();
+      expect(diagnostics?.[0]).toMatchObject({
+        page: 1,
+        profile: 'multi_column',
+        reading_order: 'columnar',
+        column_count: 2,
+        columns: [
+          { index: 1, item_count: 2 },
+          { index: 2, item_count: 2 },
+        ],
+      });
+      expect(diagnostics?.[0]?.confidence).toBeGreaterThanOrEqual(0.8);
+      expect(diagnostics?.[0]?.signals).toEqual(expect.arrayContaining(['positioned-items', 'two-column-layout']));
+    } else {
+      expect.fail('result.content[0] was undefined');
+    }
+  });
+
   it('should include document outline, page labels, and permission signals without page extraction', async () => {
     mockGetOutline.mockResolvedValue([
       {


### PR DESCRIPTION
## Summary

- add optional `include_layout_diagnostics` for page layout profiles, reading-order confidence, column signals, and warnings
- use existing extracted item geometry only; no OCR, vision, Java, Python, or external parser dependency
- recommend layout diagnostics from `inspect_pdf` for agentic RAG workflows
- update README, docs, specs, package keywords, tests, and bundled dist output

## Why

This is a low-overhead way to make PDF extraction more agent-native: agents can now see when local reading order is likely reliable, and when uncertain pages should be routed to heavier parsing, OCR/vision, or human review.

## Validation

- `bun run check`
- `bun run typecheck`
- `bun run build`
- `bun test --reporter=dot`
- `bun run docs:build`
- `bun changeset status`
- `git diff --check`
- live HTTP MCP smoke for `/mcp/health`, `initialize`, and `read_pdf` with `include_layout_diagnostics` on `test/fixtures/sample.pdf`

## Release

- includes a patch Changeset for `@sylphx/pdf-reader-mcp`
