### PR TITLE
Define 2027 SOTA document intelligence boundary

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -83,6 +83,19 @@ export default defineConfig({
           { text: 'Comparison', link: '/comparison/' },
         ],
       },
+      {
+        text: 'Architecture',
+        items: [
+          {
+            text: '2027 SOTA Boundary',
+            link: '/adr/0001-2027-sota-document-intelligence-boundary',
+          },
+          {
+            text: 'Operating Model',
+            link: '/specs/2026-06-16-2027-sota-document-intelligence-operating-model',
+          },
+        ],
+      },
     ],
 
     socialLinks: [

--- a/docs/adr/0001-2027-sota-document-intelligence-boundary.md
+++ b/docs/adr/0001-2027-sota-document-intelligence-boundary.md
@@ -1,0 +1,92 @@
+# ADR-0001: 2027 SOTA Document Intelligence Boundary
+
+**Status:** Accepted
+**Date:** 2026-06-16
+**Deciders:** Kyle Tse, Codex
+**Project:** pdf-reader-mcp
+
+## Context
+
+`@sylphx/pdf-reader-mcp` is a public MCP package that gives agents PDF reading
+capability. It is not a Sylphx Platform BaaS service and should not become a
+product-specific Spiron or Cubeage component. Its value comes from being a
+reusable, benchmarked, provider-extensible, safe document-intelligence tool that
+can be used by many agents and products.
+
+The 2027 SOTA target is broader than text extraction. Agents increasingly need
+layout-aware extraction, visual region analysis, page-level provenance,
+streaming/batch behavior, robust error isolation, and public benchmark evidence.
+Those capabilities must be added without turning the package into a hidden
+hosted service or leaking customer documents into shared infrastructure.
+
+## Decision
+
+This repository owns the local/open-source document-intelligence package and
+its public MCP contract.
+
+It owns:
+
+- MCP tools, schemas, package API, parser adapters, extraction options, page and
+  region provenance, local file/URL handling, benchmarks, docs, and release
+  evidence;
+- provider-neutral document analysis interfaces for optional OCR, vision, or
+  region-analysis providers;
+- public compatibility with Claude Code, Claude Desktop, Cursor, VS Code,
+  Windsurf, Cline, Warp, and other MCP clients.
+
+It does not own:
+
+- Sylphx Platform Durable Work, Auth, Billing, Storage, Gateway, hosted
+  multi-tenant execution, customer accounts, or production data retention;
+- Spiron/Cubeage product semantics;
+- direct AI provider secrets or product-specific model routing.
+
+If a hosted PDF/document-intelligence product is created, it must be a separate
+service with its own ADR/spec and commercial controls. This package may become
+the engine or SDK for that service, but it remains usable as a local package.
+
+## SOTA Invariants
+
+- The MCP schema is the public contract and must be versioned, documented, and
+  regression-tested.
+- Extraction output must carry page/region provenance so downstream agents can
+  cite and verify source locations.
+- Benchmarks and release gates must be reproducible and published with version
+  context.
+- Optional visual/OCR providers must be adapters behind a typed interface; no
+  provider key or hosted credential belongs in the package.
+- Local processing must not upload customer documents unless the caller
+  explicitly selects a provider that requires remote processing.
+- Errors are isolated per source/page/operation where possible; one bad page
+  should not poison a whole batch unless the contract says so.
+- Commercial value is built through trust: public docs, compatibility,
+  benchmarks, security posture, release discipline, and optional hosted or
+  enterprise offerings outside the local package boundary.
+
+## Alternatives Considered
+
+### Turn the package into a hosted BaaS service
+
+Rejected. Hosted document intelligence may be valuable, but that requires
+auth, billing, storage, retention, quotas, audit, and customer data controls
+that do not belong inside this local MCP package.
+
+### Keep the package as text-only extraction
+
+Rejected. Text-only extraction is not 2027 SOTA for agent workflows. Layout,
+images, regions, provenance, benchmarks, and provider adapters are required to
+stay competitive.
+
+### Add provider-specific code directly to tools
+
+Rejected. Provider behavior must be isolated behind adapters so the public MCP
+contract stays stable and users can choose local-only or remote-provider modes.
+
+## Consequences
+
+- Future implementation must prioritize schema stability, provenance, provider
+  abstraction, benchmark evidence, and public docs.
+- Hosted/commercial services must be separate products that reuse the package,
+  not mutations of the local MCP runtime.
+- Release readiness requires tests, typecheck, benchmark gates, docs, changelog,
+  and package publish verification.

--- a/docs/specs/2026-06-16-2027-sota-document-intelligence-operating-model.md
+++ b/docs/specs/2026-06-16-2027-sota-document-intelligence-operating-model.md
@@ -1,0 +1,85 @@
+# 2027 SOTA Document Intelligence Operating Model
+
+Date: 2026-06-16
+Status: Implementation target
+Owner: pdf-reader-mcp
+Related: `docs/adr/0001-2027-sota-document-intelligence-boundary.md`
+
+## Goal
+
+Make `@sylphx/pdf-reader-mcp` a public, commercial-grade quality,
+state-of-the-art document-intelligence MCP package for agents, while preserving
+local-first privacy and a clean boundary from hosted Platform services.
+
+## Non-Goals
+
+- Do not add hosted auth, billing, storage, tenancy, or data retention inside
+  the package.
+- Do not add direct provider secrets or Sylphx AI Gateway credentials to the
+  package.
+- Do not optimize for one agent client at the expense of MCP contract
+  compatibility.
+- Do not claim release readiness without docs, tests, benchmarks, and changelog
+  evidence.
+
+## Capability Map
+
+| Area | SOTA requirement |
+|------|------------------|
+| MCP contract | Stable tool schemas, versioned options, compatibility fixtures, generated/API docs. |
+| Text extraction | Page-aware and full-document extraction with deterministic ordering and clear whitespace policy. |
+| Layout/provenance | Page, bounding region, image, table, and source metadata sufficient for citations and verification. |
+| Visual/OCR adapters | Optional provider interface for OCR and region analysis with local-only default behavior. |
+| Batch processing | Multiple sources, partial failure isolation, concurrency limits, cancellation-safe behavior. |
+| Performance | Reproducible benchmarks by document class, page count, image density, and operation type. |
+| Security/privacy | Path handling, URL handling, file size limits, remote-processing opt-in, no secret logging. |
+| Release quality | Typecheck, tests, benchmark gate, docs build, changelog, npm package smoke, compatibility smoke. |
+
+## Provider Boundary
+
+Provider adapters may exist for OCR, vision, or layout analysis, but they must:
+
+- be optional dependencies or optional runtime adapters;
+- accept credential handles from the caller environment, never hardcoded keys;
+- declare whether documents leave the local machine;
+- return typed, provenance-preserving results;
+- expose cost/latency/error metadata where available;
+- fail per page/source when possible.
+
+## Commercial Paths
+
+The local package remains free/open-source quality software. Commercial value
+can be created through:
+
+- a hosted document-intelligence service in a separate repo/service with
+  Platform Auth/Billing/Storage/Durable Work controls;
+- enterprise support and compatibility certification;
+- benchmark-backed performance claims;
+- private provider adapters or compliance packs;
+- integration bundles for agent platforms and CI/document workflows.
+
+## Acceptance Criteria
+
+- Every public tool option is covered by schema tests and docs.
+- Extraction results include source and page provenance.
+- Visual/OCR provider support is adapter-based and local-only remains the
+  default.
+- Benchmarks are reproducible and versioned with hardware/runtime context.
+- Release gate runs typecheck, tests, package build, benchmark release gate,
+  docs build, and npm smoke where credentials permit.
+- A failed page/source does not hide successful extraction from other pages or
+  sources unless the caller requested fail-fast behavior.
+- The README, docs site, changelog, and `progress.md` agree before release.
+
+## Implementation Slices
+
+1. Add schema-level contract fixtures for existing tools.
+2. Add provenance normalization for pages, images, and future regions.
+3. Add provider adapter interface for visual/OCR analysis without bundled
+   provider secrets.
+4. Add benchmark release gate that separates small, scanned, image-heavy,
+   table-heavy, and large-document classes.
+5. Add docs explaining privacy modes, local-only behavior, remote-provider
+   opt-in, and commercial hosted boundary.
+6. Add release checklist that blocks publish when docs, benchmarks, changelog,
+   and package smoke are out of sync.


### PR DESCRIPTION
## Summary
- Add the first ADR for pdf-reader-mcp as the local document intelligence package boundary.
- Add the 2027 SOTA operating spec for provider-backed document intelligence, benchmark evidence, privacy modes, and hosted/commercial separation.
- Register the ADR/spec in the VitePress docs nav.

## Validation
- git diff --cached --check
- bun run docs:build
- bun run validate (236 pass / 7 skip / 0 fail)