### PR TITLE
docs: clarify MCP portfolio boundary

### DIFF
--- a/docs/adr/0001-2027-sota-document-intelligence-boundary.md
+++ b/docs/adr/0001-2027-sota-document-intelligence-boundary.md
@@ -45,6 +45,23 @@ If a hosted PDF/document-intelligence product is created, it must be a separate
 service with its own ADR/spec and commercial controls. This package may become
 the engine or SDK for that service, but it remains usable as a local package.
 
+## Portfolio Integration Boundary
+
+Sylphx Gateway, Spiron, Platform, or another product may register this package
+as an external MCP tool source or consume its schemas through an adapter, but
+that integration does not move the package boundary:
+
+- `pdf-reader-mcp` remains the SSOT for local document-intelligence MCP tool
+  schemas, provenance contracts, provider adapters, benchmarks, and release
+  evidence.
+- Gateway owns any model-facing manifest, native late-loading projection,
+  tenant policy, hosted execution, cache diagnostics, and billing surface around
+  registered tools.
+- Product apps own product permissions, credential handles, audit, and durable
+  state created after using the tool.
+- Hosted multi-tenant document intelligence still requires a separate service
+  ADR with auth, billing, storage, retention, quota, and privacy controls.
+
 ## SOTA Invariants
 
 - The MCP schema is the public contract and must be versioned, documented, and

--- a/docs/specs/2026-06-16-2027-sota-document-intelligence-operating-model.md
+++ b/docs/specs/2026-06-16-2027-sota-document-intelligence-operating-model.md
@@ -35,6 +35,17 @@ local-first privacy and a clean boundary from hosted Platform services.
 | Security/privacy | Path handling, URL handling, file size limits, remote-processing opt-in, no secret logging. |
 | Release quality | Typecheck, tests, benchmark gate, docs build, changelog, npm package smoke, compatibility smoke. |
 
+## Portfolio Integration Rules
+
+- Gateway may register this package as an external MCP tool source, but Gateway
+  owns any model-facing manifest, native late-loading projection, tenant policy,
+  hosted execution, cache diagnostics, billing, and usage surface around that
+  registration.
+- Product apps own product permissions, credential handles, audit, and durable
+  outcomes created after using these tools.
+- A hosted multi-tenant document-intelligence product is a separate service,
+  not a mutation of this local MCP package.
+
 ## Provider Boundary
 
 Provider adapters may exist for OCR, vision, or layout analysis, but they must:


### PR DESCRIPTION
## Summary
- Clarify that pdf-reader-mcp remains the SSOT for local/public document-intelligence MCP contracts
- Define how Gateway/product apps may register or consume it without moving package ownership
- Keep hosted multi-tenant document intelligence as a separate service boundary

## Validation
- bun run docs:build