### PR TITLE
test(errors): characterize PdfError code/cause contract

### DIFF
--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { ErrorCode, PdfError } from '../src/utils/errors.js';
+
+describe('ErrorCode', () => {
+  it('maps to the JSON-RPC reserved error numbers', () => {
+    expect(ErrorCode.InvalidParams).toBe(-32602);
+    expect(ErrorCode.InvalidRequest).toBe(-32600);
+    expect(ErrorCode.MethodNotFound).toBe(-32601);
+  });
+});
+
+describe('PdfError', () => {
+  it('is an Error with a stable name and the carried code/message', () => {
+    const err = new PdfError(ErrorCode.InvalidParams, 'bad page range');
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(PdfError);
+    expect(err.name).toBe('PdfError');
+    expect(err.code).toBe(ErrorCode.InvalidParams);
+    expect(err.message).toBe('bad page range');
+  });
+
+  it('leaves cause unset when no options are passed', () => {
+    const err = new PdfError(ErrorCode.InvalidRequest, 'access denied');
+
+    expect(err.cause).toBeUndefined();
+  });
+
+  it('leaves cause unset when options omit a cause', () => {
+    const err = new PdfError(ErrorCode.InvalidRequest, 'access denied', {});
+
+    expect(err.cause).toBeUndefined();
+  });
+
+  it('attaches the underlying cause when one is provided', () => {
+    const underlying = new Error('ENOENT: no such file');
+    const err = new PdfError(ErrorCode.MethodNotFound, 'failed to load', {
+      cause: underlying,
+    });
+
+    expect(err.cause).toBe(underlying);
+    expect(err.message).toBe('failed to load');
+    expect(err.code).toBe(ErrorCode.MethodNotFound);
+  });
+
+  it('treats an explicit undefined cause the same as no cause', () => {
+    const err = new PdfError(ErrorCode.InvalidParams, 'oops', { cause: undefined });
+
+    expect(err.cause).toBeUndefined();
+  });
+
+  it('is catchable as a PdfError after being thrown', () => {
+    const throwIt = (): never => {
+      throw new PdfError(ErrorCode.InvalidParams, 'invalid');
+    };
+
+    expect(throwIt).toThrow(PdfError);
+    expect(throwIt).toThrow('invalid');
+  });
+});


### PR DESCRIPTION
## What

Adds a characterization test for `src/utils/errors.ts` (`PdfError` + `ErrorCode`) — the one `src/utils` module with no direct test coverage.

## Why

`PdfError` is the curated, safe-to-surface error type that the handler relies on to decide which messages reach the LLM (SSS-02). Its constructor has a real branch that was never exercised by any call site:

```ts
super(message, options?.cause ? { cause: options.cause } : undefined);
```

No `new PdfError(...)` anywhere in `src/` or `test/` passes a `cause`, so the cause-passthrough path had no verification. This pins:

- the JSON-RPC reserved error numbers (`-32602` / `-32600` / `-32601`),
- the stable `name`, carried `code`, and `message`,
- both sides of the cause branch (provided cause attached; absent/`undefined`/`{}` leaves `cause` unset),
- that it remains catchable as a `PdfError` after being thrown.

## Scope

Test-only. No production code changes. `bun run typecheck`, `bun run check` (biome), and the full `bun test` suite (243 pass / 7 skip / 0 fail) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)