### PR TITLE
docs: add PDF Reader MCP agent boundary guide

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -1,0 +1,164 @@
+{
+  "schemaVersion": 1,
+  "project": {
+    "repo": "SylphxAI/pdf-reader-mcp",
+    "name": "PDF Reader MCP",
+    "lifecycle": "production",
+    "layer": "tooling",
+    "summary": "PDF Reader MCP is a local-first public MCP package for PDF and document intelligence, including inspection, search, rendering, region crops, OCR routing, extraction, document maps, trust and accessibility reports, provenance, benchmarks, docs, and package release evidence.",
+    "goals": [
+      "Own public MCP tool schemas, handlers, parser and extractor adapters, provenance contracts, provider-neutral optional OCR and vision interfaces, benchmarks, docs, and release evidence.",
+      "Keep document processing local-first by default with explicit local-vs-remote provider behavior.",
+      "Preserve source, page, and region provenance so downstream agents can cite and verify evidence."
+    ],
+    "nonGoals": [
+      "Become Sylphx Platform Auth, Billing, Storage, Durable Work, Gateway, hosted multi-tenant execution, or customer data retention.",
+      "Own Spiron, Cubeage, or customer-specific product semantics.",
+      "Store direct provider secrets or product-specific model routing inside this package."
+    ]
+  },
+  "boundaries": {
+    "owns": [
+      {
+        "name": "document-intelligence-mcp-contract",
+        "description": "Public MCP tools, schemas, handlers, package API, install surface, compatibility docs, and regression tests."
+      },
+      {
+        "name": "local-document-processing-engine",
+        "description": "PDF parsing, extraction, search, rendering, region crops, OCR/vision provider adapters, provenance, trust/accessibility reports, benchmarks, and release evidence."
+      }
+    ],
+    "doesNotOwn": [
+      "Sylphx Platform Durable Work, Auth, Billing, Storage, Gateway, hosted multi-tenant execution, customer accounts, or production data retention.",
+      "Gateway model-facing manifests, tenant policy, hosted execution, cache diagnostics, or billing surfaces around registered tools.",
+      "Spiron, Cubeage, or customer-specific permissions, audit, durable outcomes, or product semantics."
+    ],
+    "publicSurfaces": [
+      {
+        "type": "cli",
+        "name": "pdf-reader-mcp CLI",
+        "location": "package.json"
+      },
+      {
+        "type": "package-export",
+        "name": "@sylphx/pdf-reader-mcp package",
+        "location": "package.json"
+      },
+      {
+        "type": "documentation",
+        "name": "Public README",
+        "location": "README.md"
+      },
+      {
+        "type": "documentation",
+        "name": "Document intelligence boundary ADR",
+        "location": "docs/adr/0001-2027-sota-document-intelligence-boundary.md"
+      },
+      {
+        "type": "workflow",
+        "name": "CI workflow",
+        "location": ".github/workflows/ci.yml"
+      },
+      {
+        "type": "workflow",
+        "name": "Release workflow",
+        "location": ".github/workflows/release.yml"
+      },
+      {
+        "type": "status-context",
+        "name": "Required branch context",
+        "location": "Validate Code Quality"
+      }
+    ],
+    "allowedDependencies": [
+      {
+        "repo": "SylphxAI/doctrine",
+        "surface": "enterprise engineering doctrine",
+        "direction": "downward"
+      }
+    ],
+    "forbiddenCouplings": [
+      "Do not upload customer documents or call remote providers unless the caller explicitly selects a provider adapter that requires it.",
+      "Do not add hosted auth, billing, storage, tenancy, retention, durable work, or customer-account state inside this package.",
+      "Do not add direct provider secrets, Sylphx AI Gateway credentials, or product-specific model routing to this repository.",
+      "Do not publish packages from a human shell or personal token."
+    ]
+  },
+  "documentation": {
+    "adr": {
+      "path": "docs/adr/",
+      "status": "present"
+    },
+    "specs": {
+      "path": "docs/specs/",
+      "status": "present"
+    },
+    "catalog": {
+      "path": "PROJECT.md",
+      "status": "present"
+    },
+    "runbooks": {
+      "path": "AGENTS.md",
+      "status": "present"
+    },
+    "generatedReferences": {
+      "path": "dist/",
+      "status": "generated"
+    }
+  },
+  "delivery": {
+    "ciModel": "legacy-ci",
+    "requiredContexts": [
+      "Validate Code Quality"
+    ],
+    "deployPath": "No hosted deploy path is declared. Package release is Changesets-driven through .github/workflows/release.yml using a GitHub App release token and npm credentials.",
+    "productionProof": "Required CI context, typecheck/test/check/build/docs evidence as applicable, benchmark evidence for performance claims, Changesets release intent for package changes, and npm package readback after publication.",
+    "recoveryClass": "forward-fix-only",
+    "packageRelease": {
+      "publishesPackages": true,
+      "ecosystems": [
+        "npm",
+        "changesets"
+      ],
+      "releaseIntent": "Changesets capture package release intent and the release workflow creates version PRs or publishes.",
+      "versionPr": "changesets/action creates the release PR with title chore(release): version packages.",
+      "publisher": ".github/workflows/release.yml creates a GitHub App token, checks out with that token, builds, and uses changesets/action to publish with NPM_TOKEN.",
+      "requiredContexts": [
+        "Validate Code Quality"
+      ],
+      "publishProof": "npm package readback for @sylphx/pdf-reader-mcp plus GitHub release/version evidence."
+    }
+  },
+  "commercial": {
+    "status": "researching",
+    "decisionHome": "docs/adr/0001-2027-sota-document-intelligence-boundary.md",
+    "pricingSourceOfTruth": "not-applicable",
+    "metricsSourceOfTruth": "not-applicable",
+    "requiredRecords": [
+      "market-positioning",
+      "packaging",
+      "roadmap"
+    ],
+    "guardrails": [
+      "Hosted document intelligence, enterprise packaging, or pricing changes require a separate service ADR/spec and commercial controls.",
+      "Commercial decisions must not move hosted auth, billing, storage, retention, or provider secrets into the local MCP package."
+    ]
+  },
+  "adoption": {
+    "status": "baseline",
+    "gaps": [
+      {
+        "id": "central-admission",
+        "description": "CI is repo-local legacy GitHub Actions; migrate to central admission or stable status fan-in when the fleet workflow is ready.",
+        "owner": "SylphxAI/pdf-reader-mcp",
+        "target": "before full doctrine adoption"
+      },
+      {
+        "id": "hosted-product-boundary",
+        "description": "If hosted PDF/document intelligence becomes commercial product scope, create a separate service ADR/spec rather than expanding this local MCP package boundary.",
+        "owner": "SylphxAI/pdf-reader-mcp",
+        "target": "before hosted document-intelligence launch"
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# PDF Reader MCP Agent Instructions
+
+## Scope
+
+This file is the repo-local operating policy for agents working in
+`SylphxAI/pdf-reader-mcp`. Org-wide engineering doctrine is owned by
+`SylphxAI/doctrine`; this file only specializes that SSOT for this public MCP
+package boundary.
+
+`@sylphx/pdf-reader-mcp` is a local-first, public Model Context Protocol package
+for PDF/document intelligence. It is not a hosted Sylphx Platform BaaS service
+and must not absorb product-specific Spiron, Gateway, Cubeage, or customer-data
+semantics.
+
+## Read First
+
+Before proposing or implementing changes, read the smallest relevant set of
+these source-of-truth documents:
+
+1. `README.md` — public package contract, supported MCP tools, install surface,
+   performance claims, and user-facing behavior.
+2. `docs/adr/0001-2027-sota-document-intelligence-boundary.md` — package
+   ownership, portfolio integration boundary, and SOTA invariants.
+3. `docs/specs/2026-06-16-2027-sota-document-intelligence-operating-model.md`
+   — implementation target, non-goals, provider boundary, acceptance criteria,
+   and release quality bar.
+4. The touched tool/spec document under `docs/specs/`, such as text layer,
+   OCR provider, region crop/evidence, trust report, accessibility, or document
+   AST specs.
+5. `CONTRIBUTING.md` and `package.json` before changing development commands,
+   release, or validation workflows.
+6. The paired schema/handler/test files for any public MCP tool change.
+
+## Non-Negotiables
+
+- Preserve local-first privacy. Do not upload documents or call remote providers
+  unless the caller explicitly selects a provider/adapter that requires it.
+- Do not add hosted auth, billing, storage, tenancy, durable work, retention, or
+  customer-account state inside this package.
+- Do not add direct provider secrets, Sylphx AI Gateway credentials, or
+  product-specific model routing to this repository.
+- Keep optional OCR, vision, and region-analysis providers behind typed adapters
+  with explicit provenance, cost/latency/error metadata where available, and
+  clear local-vs-remote behavior.
+- Public MCP schemas are contracts. Version, document, and regression-test tool
+  option/output changes.
+- Preserve page/region/source provenance for extraction, search, rendering,
+  crop, OCR, table, and visual-analysis outputs.
+- Keep product integration boundaries clean: Gateway may expose/route tools,
+  product apps own permissions/audit/durable outcomes, and hosted document
+  intelligence requires a separate ADR/service.
+- Do not commit secrets, private documents, customer data, provider keys, or
+  generated credentials.
+
+## Workflow
+
+1. Identify the owning boundary: MCP schema, handler, parser/extractor, document
+   model, provenance, provider adapter, benchmark, docs, release gate, or package
+   distribution.
+2. Check the related ADR/spec and open PRs before editing; avoid broad shared-doc
+   conflicts with large WIP PRs.
+3. Prefer small, evidence-backed slices with paired tests and docs.
+4. For tool behavior changes, update schema, handler, tests, docs, and release
+   evidence together.
+5. Use branch → commit → PR. Do not push directly to `main`, force-push, merge,
+   release, or publish without manager-visible evidence and required gates.
+
+## Validation
+
+Use the narrowest meaningful validation first, then broaden as needed:
+
+- `bun run typecheck`
+- `bun run test`
+- `bun run check`
+- `bun run build`
+- `bun run docs:build`
+- release/benchmark gates named by the touched spec or workflow
+
+Docs-only boundary changes may be validated by reviewing the diff and checking
+referenced files exist. Runtime/schema/provider changes need targeted tests and
+compatibility evidence.
+
+## Reporting
+
+When reporting completed work, include changed files, boundaries read, validation
+run, PR/issue links, and residual risk. Be explicit when no runtime behavior,
+provider dispatch, credentials, package build, npm release, or customer data
+handling changed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@
 
 This file is the repo-local operating policy for agents working in
 `SylphxAI/pdf-reader-mcp`. Org-wide engineering doctrine is owned by
-`SylphxAI/doctrine`; this file only specializes that SSOT for this public MCP
-package boundary.
+`SylphxAI/doctrine`; `PROJECT.md` and `.doctrine/project.json` own this
+repository's local identity, lifecycle, boundary, and delivery facts.
 
 `@sylphx/pdf-reader-mcp` is a local-first, public Model Context Protocol package
 for PDF/document intelligence. It is not a hosted Sylphx Platform BaaS service
@@ -19,17 +19,20 @@ these source-of-truth documents:
 
 1. `README.md` — public package contract, supported MCP tools, install surface,
    performance claims, and user-facing behavior.
-2. `docs/adr/0001-2027-sota-document-intelligence-boundary.md` — package
+2. `PROJECT.md` and `.doctrine/project.json` — project goal, lifecycle,
+   boundaries, public surfaces, delivery proof, package release path, and
+   adoption gaps.
+3. `docs/adr/0001-2027-sota-document-intelligence-boundary.md` — package
    ownership, portfolio integration boundary, and SOTA invariants.
-3. `docs/specs/2026-06-16-2027-sota-document-intelligence-operating-model.md`
+4. `docs/specs/2026-06-16-2027-sota-document-intelligence-operating-model.md`
    — implementation target, non-goals, provider boundary, acceptance criteria,
    and release quality bar.
-4. The touched tool/spec document under `docs/specs/`, such as text layer,
+5. The touched tool/spec document under `docs/specs/`, such as text layer,
    OCR provider, region crop/evidence, trust report, accessibility, or document
    AST specs.
-5. `CONTRIBUTING.md` and `package.json` before changing development commands,
+6. `CONTRIBUTING.md` and `package.json` before changing development commands,
    release, or validation workflows.
-6. The paired schema/handler/test files for any public MCP tool change.
+7. The paired schema/handler/test files for any public MCP tool change.
 
 ## Non-Negotiables
 
@@ -46,6 +49,9 @@ these source-of-truth documents:
   option/output changes.
 - Preserve page/region/source provenance for extraction, search, rendering,
   crop, OCR, table, and visual-analysis outputs.
+- Package publishing must remain Changesets-driven and bot/workflow-owned via
+  the repository release workflow. Do not publish from a human shell or personal
+  token.
 - Keep product integration boundaries clean: Gateway may expose/route tools,
   product apps own permissions/audit/durable outcomes, and hosted document
   intelligence requires a separate ADR/service.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,70 @@
+# PDF Reader MCP Project
+
+PDF Reader MCP is a local-first public Model Context Protocol package for PDF
+and document intelligence. It gives agents typed tools for PDF inspection,
+search, rendering, region crops, OCR routing, extraction, document maps, trust
+signals, accessibility reports, provenance, benchmarks, and package release
+evidence without becoming a hosted Sylphx Platform BaaS service.
+
+## Lifecycle
+
+- Lifecycle: `production`
+- Layer: `tooling`
+- Doctrine source of truth: [SylphxAI/doctrine](https://github.com/SylphxAI/doctrine)
+- Machine manifest: `.doctrine/project.json`
+
+## Goals
+
+- Own the public MCP tool schemas, handlers, parser/extractor adapters,
+  provenance model, provider-neutral optional OCR/vision interfaces, benchmarks,
+  docs, and release evidence.
+- Keep document processing local-first by default with explicit local-vs-remote
+  provider behavior.
+- Preserve source/page/region provenance so downstream agents can cite and
+  verify evidence.
+
+## Non-Goals
+
+- Do not become Sylphx Platform Auth, Billing, Storage, Durable Work, Gateway,
+  hosted multi-tenant execution, or customer data retention.
+- Do not own Spiron, Cubeage, or customer-specific product semantics.
+- Do not store direct provider secrets or product-specific model routing inside
+  this package.
+
+## Boundaries
+
+PDF Reader MCP owns the local/open-source document-intelligence package and its
+public MCP contract. It does not own hosted customer accounts, billing, storage,
+tenant policy, Gateway routing, product audit, or durable state created after a
+tool is used. Hosted document intelligence must be a separate service with its
+own ADR/spec and commercial controls.
+
+## Public Surfaces
+
+- MCP package and CLI: `package.json`
+- Public docs: `README.md`
+- Boundary ADR:
+  `docs/adr/0001-2027-sota-document-intelligence-boundary.md`
+- Tool/spec docs: `docs/specs/`
+- CI workflow: `.github/workflows/ci.yml`
+- Release workflow: `.github/workflows/release.yml`
+
+## Delivery
+
+Pull requests use the legacy `Validate Code Quality` context on Sylphx
+self-hosted runners. Package release is Changesets-driven through the repo
+release workflow, which mints a GitHub App token before creating version PRs or
+publishing to npm.
+
+Docs-only boundary changes do not alter runtime behavior, provider dispatch,
+credentials, package output, npm release, or customer data handling. MCP schema,
+handler, parser, provider, benchmark, or package changes require focused tests,
+docs, build/coverage evidence, release intent, and npm readback after publish.
+
+## Commercial Direction
+
+This repo is a public utility package and can support commercial offerings only
+through clean packaging, benchmarks, trust, compatibility, and separately owned
+hosted/enterprise products. Pricing, hosted document intelligence, enterprise
+packaging, or roadmap changes require decision records backed by market and
+customer analysis.


### PR DESCRIPTION
## Why

`pdf-reader-mcp` has an accepted document-intelligence boundary ADR and an operating-model spec, but no root agent guide tying future implementation work to those SSOTs. This repo is a public local-first MCP package, so keeping hosted Platform/product semantics and provider secrets out of the package is an important cross-repo boundary.

This is a small ADR/spec implementation slice from the guarded pilot while the broad full-fidelity PDF intelligence work continues in #314.

## What changed

- Added root `AGENTS.md` with:
  - org-wide doctrine pointer (`SylphxAI/doctrine`);
  - PDF Reader MCP read-first order;
  - local-first privacy and hosted-service non-goals;
  - provider-adapter, schema-contract, provenance, and product-integration boundaries;
  - validation commands and reporting expectations.

## Boundary / safety

- Docs-only change.
- No runtime code, MCP schemas, provider dispatch, credentials, package build, release, or customer-data behavior changed.
- No direct push to `main`; branch is `agent/repo-boundary-guide`.

## Validation

- Verified all referenced ADR/spec/package files exist with a small Python path check.
- Reviewed diff: one new root `AGENTS.md` file only.
