### PR TITLE
docs: clean release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,63 +131,6 @@
   kind-specific assertions, crop provenance, and capability-summary coverage
   before publishing evidence can pass.
 
-## Unreleased
-
-- Add a `tesseract-tsv` OCR provider preset that runs Tesseract TSV output and
-  normalizes page text, confidence, language, and word-level bounding boxes
-  into the OCR text layer.
-- Add `bun run benchmark:providers`, an optional installed-provider benchmark
-  for the Tesseract TSV OCR path and configured visual-region providers. It now
-  reports certification profiles for OCR text-layer word boxes and
-  visual-full-fidelity table/formula/chart/figure/image-description crop
-  evidence, reports skipped providers explicitly by default, and can be made
-  blocking with `MCP_PDF_PROVIDER_BENCHMARK_REQUIRED=true`.
-- Extend deterministic semantic hints and the document AST with caption,
-  header, and footer roles. Header/footer detection uses page-edge geometry and
-  horizontal page bounds so off-page text remains available as evidence without
-  being misclassified as a footer.
-- Add cross-page section context to the document AST. Continued paragraphs,
-  subsections, tables, images, and visual regions can now expose `section_path`
-  and `continued_from_section_id` while preserving page-local evidence nodes.
-- Link document AST captions to nearby table, image, figure, chart, formula, or
-  diagram evidence with `caption_links`, target-side `caption_ids`, confidence,
-  relation, and signals so agents can keep captions attached to source-backed
-  visual or tabular evidence.
-- Link selectable text-layer evidence into `document_map`. Page records now
-  expose text-layer page indexes plus run, line, word, character, and bounding
-  box coverage counts, and the map summary reports text-layer totals without
-  forcing top-level `text_layer` output.
-- Add tag-to-visible-content correlation to the accessibility report. Page
-  reports now expose visible element counts, structure content-reference counts,
-  and tag-content coverage, and the report can flag tagged pages whose structure
-  tree does not reference enough visible content.
-- Split unsafe PDF link schemes into a dedicated trust-report signal. The
-  report now distinguishes ordinary external links from unsafe URL schemes and
-  the deterministic quality benchmark verifies unsafe-link routing guidance.
-- Add a dedicated `hidden_text` safety finding for selectable text with zero or
-  near-zero geometry. The trust report now emits high-severity content-safety
-  signals and rendering/crop verification guidance for hidden or near-invisible
-  text.
-- Add table cell evidence coverage metrics. Table quality now reports cell
-  bounding-box coverage, inferred-cell counts/ratios, and incomplete geometry
-  signals so agents can route weak table evidence to visual verification.
-- Add OCR-derived table extraction for scanned pages. `read_pdf` can now use
-  normalized OCR word boxes to produce table evidence when both
-  `include_ocr_text_layer` and `include_tables` are enabled, with provenance
-  back to the source page render.
-- Replace the empty generated API page with a maintained MCP API reference and
-  remove unused TypeDoc tooling from the docs pipeline.
-- Add an env-only HTTP adapter for `analyze_regions` so local model servers can
-  receive crop image bytes and return the same normalized table, formula, chart,
-  figure, image-description, confidence, warning, and provenance fields as
-  command providers.
-- Add ordered `next_tools` to `inspect_pdf` recommendations so agents can route
-  from inspection into `read_pdf`, `search_pdf`, `render_page`, `extract_regions`,
-  `analyze_regions`, or `ocr_pages` with executable arguments, missing inputs,
-  and provider requirements made explicit.
-- Update public docs to distinguish deterministic PDF intelligence quality
-  gates from installed-provider OCR and visual-region smoke checks.
-
 ## 2.6.0
 
 ### Minor Changes

--- a/test/integration/mcp-server.test.ts
+++ b/test/integration/mcp-server.test.ts
@@ -80,6 +80,7 @@ describe('MCP Server Integration', () => {
         ...process.env,
         NODE_ENV: 'test',
         MCP_PDF_OCR_COMMAND: process.execPath,
+        MCP_PDF_OCR_PRESET: '',
         MCP_PDF_OCR_ARGS_JSON: JSON.stringify([
           mockOcrProviderPath,
           '{input}',

--- a/test/pdf/ocr.test.ts
+++ b/test/pdf/ocr.test.ts
@@ -156,6 +156,7 @@ describe('ocr', () => {
   it('should run the configured command OCR provider and normalize JSON output', async () => {
     const scriptPath = path.resolve(__dirname, '../fixtures/mock-ocr-provider.mjs');
     process.env['MCP_PDF_OCR_COMMAND'] = process.execPath;
+    Reflect.deleteProperty(process.env, 'MCP_PDF_OCR_PRESET');
     process.env['MCP_PDF_OCR_ARGS_JSON'] = JSON.stringify([
       scriptPath,
       '{input}',


### PR DESCRIPTION
## Summary
- remove the stale Unreleased changelog block that was already included in the 2.7.0 release notes
- isolate mock JSON OCR tests from release-level MCP_PDF_OCR_PRESET=tesseract-tsv so Changesets publish can rerun release:preflight safely
- keep public-facing release history focused after the SOTA release

## Root cause
The main Release workflow passed the explicit preflight steps, then Changesets reran `bun run release` in the publish step with `MCP_PDF_OCR_PRESET=tesseract-tsv`. Two mock JSON OCR tests inherited that preset and parsed their JSON fixture output as TSV/raw text.

## Validation
- bun run check-format CHANGELOG.md
- rg -n "^## Unreleased|Powered by Sylphx|OpenDataLoader|opendataloader" README.md docs package.json CHANGELOG.md .changeset 2>/dev/null || true
- bun run build && MCP_PDF_OCR_PRESET=tesseract-tsv bun test test/pdf/ocr.test.ts test/integration/mcp-server.test.ts
- MCP_PDF_OCR_PRESET=tesseract-tsv MCP_PDF_REGION_ANALYSIS_COMMAND=bun MCP_PDF_REGION_ANALYSIS_ARGS_JSON='["scripts/reference-region-analysis-provider.mjs","{input}","{page}","{region_id}","{languages}"]' bun run test:cov

No changeset: docs/test release-path cleanup, no package version change.