### PR TITLE
docs: sharpen public PDF intelligence positioning

### DIFF
--- a/.changeset/public-docs-positioning.md
+++ b/.changeset/public-docs-positioning.md
@@ -1,0 +1,5 @@
+---
+"@sylphx/pdf-reader-mcp": patch
+---
+
+Refresh public-facing positioning for the full-fidelity PDF intelligence release, including README, docs, comparison, release-proof labels, and npm metadata.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 📄 @sylphx/pdf-reader-mcp
 
-> Production-ready PDF processing server for AI agents
+> Full-fidelity PDF intelligence MCP for AI agents
 
 [![npm version](https://img.shields.io/npm/v/@sylphx/pdf-reader-mcp?style=flat-square)](https://www.npmjs.com/package/@sylphx/pdf-reader-mcp)
 [![License](https://img.shields.io/badge/License-MIT-blue?style=flat-square)](https://opensource.org/licenses/MIT)
@@ -11,7 +11,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg?style=flat-square)](https://www.typescriptlang.org/)
 [![Downloads](https://img.shields.io/npm/dm/@sylphx/pdf-reader-mcp?style=flat-square)](https://www.npmjs.com/package/@sylphx/pdf-reader-mcp)
 
-**PDF inspection** • **PDF search** • **Agent document map** • **Trust report** • **Accessibility report** • **Visual evidence** • **Region crops** • **Configured OCR**
+**Agent Document Twin** • **Evidence-first extraction** • **PDF search** • **Visual evidence** • **Region crops** • **Configured OCR** • **Tables, charts, formulas, figures** • **Trust & accessibility reports** • **Benchmark-gated releases**
 
 <a href="https://mseep.ai/app/SylphxAI-pdf-reader-mcp">
 <img src="https://mseep.net/pr/SylphxAI-pdf-reader-mcp-badge.png" alt="Security Validated" width="200"/>
@@ -23,44 +23,24 @@
 
 ## 🚀 Overview
 
-PDF Reader MCP is a **production-ready** Model Context Protocol server that empowers AI agents with **structured, local-first PDF processing capabilities**. Inspect PDFs before extraction, get an ordered MCP tool plan, search text evidence with page and bbox provenance, render page-level visual evidence, crop bbox-grounded page regions, run configured OCR for scanned-page text layers and OCR-derived tables, then extract a full agent document map, trust report, accessibility report, text, Markdown, semantic citation chunks, images, tables, annotations, outlines, structure trees, form fields, attachment metadata, and agent-ready document elements with strong performance and reliability.
+PDF Reader MCP is a **production-ready** Model Context Protocol server for turning PDFs into agent-readable evidence. It gives agents a full **Agent Document Twin** instead of plain text alone: selectable text, run/line/word/character evidence, semantic AST nodes, tables, citations, page geometry, visual crops, OCR text layers, trust signals, accessibility signals, provider-backed visual enrichments, and benchmark proof in one local-first workflow.
 
-**The Problem:**
-```typescript
-// Traditional PDF processing
-- Sequential page processing (slow)
-- No natural content ordering
-- Complex path handling
-- Poor error isolation
-```
+Agents can inspect a PDF before extraction, search with page and bounding-box provenance, render source pages, crop focused regions, route scanned pages through configured OCR, enrich table/chart/formula/figure regions through configured local providers, then read the same document as Markdown, JSON, HTML, citation chunks, or a linked document map.
 
-**The Solution:**
-```typescript
-// PDF Reader MCP
-- Preflight PDF inspection with ordered MCP tool routing 🔎
-- MCP-native PDF search with snippets and bbox evidence 🔎
-- Bounded page rendering for visual evidence and OCR routing 🖼️
-- Bbox-grounded region crops for source evidence 🔍
-- Configured local OCR provider for scanned-page text layers 🔡
-- Opt-in OCR text layer fusion for `read_pdf` document maps 🧾
-- 5-10x faster parallel processing ⚡
-- Full agent document map linking pages, elements, text-layer and metadata coverage, chunks, layout, safety, trust routing and signal indexes, accessibility routing and issue indexes, visual routing, and geometry 🧭
-- Semantic document AST for page/section/paragraph/list/caption/header/footer/table/image traversal, including numbered/appendix headings, rich list prefixes, equation/chart caption aliases, and above/below/side caption-to-evidence links 🌳
-- PDF trust report for content safety, visual-spoofing, redacted evidence, layout, table, link-risk, and document-map routing 🛡️
-- Accessibility report for tagged-PDF coverage, tag-to-visible-content coverage, headings, images, forms, links, and permissions ♿
-- Structured element output for agent workflows 🧩
-- Table quality diagnostics with inferred cell spans and continuation candidates 📊
-- Markdown rendering for RAG and summarization 📝
-- Citation-ready semantic/table/page chunks 🔗
-- Layout diagnostics with reading-order confidence 📐
-- Outlines, annotations, structure trees, forms, attachments, labels, and permission signals 🗂️
-- Recursive band and column reading order 📐
-- Flexible path support (absolute/relative) 🎯
-- Per-page error resilience 🛡️
-- CI-backed quality ✅
-```
+### Capability Labels
 
-**Result: Production-ready PDF processing that scales.**
+| Layer | What agents get |
+| --- | --- |
+| **Lossless text layer** | Direction-aware text runs, lines, words, characters, page ranges, metadata coverage, and estimated geometry. |
+| **Visual evidence layer** | Bounded page renders and bbox-grounded region crops with evidence IDs and provenance. |
+| **Semantic layer** | Document AST nodes for pages, sections, paragraphs, lists, captions, headers, footers, tables, images, charts, formulas, figures, and diagrams where available. |
+| **Table intelligence** | Selectable-text and OCR-derived tables, cell geometry, quality metrics, inferred spans, continuation candidates, and visual-provider enrichment hooks. |
+| **Scanned PDF path** | Rendered pages routed through configured OCR providers, with OCR text kept separate from selectable PDF text and linked back to source pixels. |
+| **Visual provider path** | Command, HTTP, Ollama, OpenAI-compatible, LM Studio, and llama.cpp adapters normalize table, chart, formula, figure, and image-description evidence. |
+| **Trust & accessibility** | Prompt-injection, hidden-text, visual-spoofing, unsafe-link, redaction, tagged-PDF, tag-visible coverage, form, image, heading, link, and permission routing. |
+| **Release proof** | Reproducible performance, quality, corpus, provider, package-smoke, and SOTA release-gate artifacts. |
+
+**Result:** a TypeScript-first local MCP server that lets agents read PDFs with source evidence, routing signals, and reproducible quality gates.
 
 ---
 
@@ -1788,63 +1768,28 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ---
 
-## 🗺️ Roadmap
+## 🗺️ Product Surface
 
-**✅ Completed**
-- [x] Image extraction (v1.1.0)
-- [x] 5-10x parallel speedup (v1.1.0)
-- [x] Y-coordinate ordering (v1.2.0)
-- [x] Absolute paths (v1.3.0)
-- [x] Table extraction
-- [x] Structured element output
-- [x] Semantic document AST
-- [x] PDF trust report
-- [x] PDF accessibility report
-- [x] Table quality diagnostics, cell evidence coverage, inferred cell spans, and continuation candidates
-- [x] Markdown rendering
-- [x] Citation-ready page, semantic, size, and table chunks
-- [x] MCP-native PDF search with snippets and bbox provenance
-- [x] Outlines, annotations, structure trees, form fields, attachment metadata, page labels, and permission signals
-- [x] Recursive band and column ordering for common multi-column PDFs
-- [x] Layout diagnostics with reading-order confidence
-- [x] Configured local OCR provider for scanned-page text layers
-- [x] Opt-in OCR text layer fusion for `read_pdf`, agent document maps, and OCR-derived table structure
-- [x] Tesseract OCR provider presets for plain text and TSV word-box output without bundling OCR model assets
-- [x] Configured local visual region analysis providers over command, HTTP, Ollama `/api/generate`, OpenAI-compatible chat completions, LM Studio, and llama.cpp adapters for table, chart, formula, figure, and image-description enrichment, including crop-image requests, JSON-only normalization, local chat-completions data URL payloads, and caption-derived formula/chart/figure candidate routing from above/below and side-caption layouts
-- [x] Visual-region candidate routing plan in `read_pdf` and `document_map`, preserved even when the optional visual provider is not configured
-- [x] Quality evals for semantic chunks, table ordering, renderers, and safety findings
-- [x] Public deterministic quality benchmark for Agent Document Twin, semantic layout variants, side-caption evidence links, inspection tool routing, real PDF document-signal fixtures, real PDF reading-order fixtures, scanned-PDF OCR pipeline routing, OCR normalization, OCR-derived table extraction, caption-derived visual candidate routing, command/HTTP/Ollama/OpenAI-compatible/LM Studio/llama.cpp visual region normalization, table evidence coverage, document-map trust routing, document-map trust signal indexing, document-map accessibility routing, document-map accessibility issue indexing, selected-page-scoped trust-report category summaries, configurable trust evidence redaction, visual-spoofing guidance, hidden-text/unsafe-link trust routing, routeable accessibility summaries, search evidence, and machine-readable SOTA final-bar coverage
-- [x] JSON benchmark artifact output for performance, deterministic quality, corpus, installed-provider, provider-manifest crop, and provider-manifest scoring evidence reports
-- [x] SOTA release gate that blocks release artifacts until deterministic quality, corpus, deterministic provider-manifest crop/scoring, and installed-provider final-bar evidence are complete
-- [x] Package smoke gate that verifies the published tarball contains the executable runtime artifact, matching `bin`/`exports` contract, and required public corpus/provider capability coverage manifests
-- [x] Runtime-generated PDF fixture coverage for outline, page labels, mark info, annotations, AcroForm fields, embedded attachment metadata, page geometry, tagged structure trees, tag-content coverage, and accessibility report fusion with issue and page-grade summaries
-- [x] Tag-to-visible-content coverage and routeable issue summaries in the accessibility report without forcing raw structure-tree output
-- [x] Runtime-generated multi-column PDF fixture coverage for spanning headers, independent column ordering, short footer placement, text-layer line order, and mixed-layout diagnostics
-- [x] Optional provider benchmark for installed Tesseract TSV OCR word-box checks over multiple runtime OCR fixtures and configured visual-region `visual-full-fidelity` certification over 10 runtime table, formula, chart, figure, and image-description PDF fixtures, with a deterministic reference visual provider and machine-readable final-bar provider evidence summaries
-- [x] Provider quality metrics for fixture-level OCR token recall, word-box coverage, document-map fusion, visual fixture coverage, crop provenance, table cell boxes, formula formats, chart data, figure text, and image descriptions
-- [x] Public corpus benchmark artifact for checked-in sample PDFs plus runtime-generated reading-order, scanned-OCR routing, and OCR-table recovery archetypes, with case-level capability tags and artifact-level capability summaries, enforced by the SOTA release gate
-- [x] External corpus manifest support for operator-supplied and checked-in public URL PDFs, preserving deterministic CI while allowing scanned, visual, and domain-specific benchmark evidence to be written into the same corpus artifact shape with SHA256, cache provenance, source metadata, capability tags, and private-host protection
-- [x] Public provider accuracy manifest support for opt-in visual-region provider scoring over checked-in public PDF crop manifests, preserving deterministic CI while letting users run real public visual evidence checks with SHA256, cache provenance, source metadata, region-level expectations, expected visual kind coverage, and capability-level summaries
-- [x] Package smoke gate for public evidence manifests, requiring corpus expected assertions/read options and provider region bbox/expected-kind/normalized-confidence/text contracts in the packed package
-- [x] Expanded public corpus and provider accuracy manifests with CDC public statistical chart evidence and arXiv public research-paper figure, formula, and table crops
-- [x] Deterministic provider-manifest crop release artifact over a local fixture, enforced by the SOTA release gate before publishing evidence can pass
-- [x] Deterministic provider-manifest scoring release artifact over local table, formula, chart, figure, and image regions, enforced by the SOTA release gate before publishing evidence can pass
-- [x] Deterministic semantic hints and AST nodes for numbered/appendix headings, richer list prefixes, equation/formula and graph/chart captions, headers, and footers, with page-edge safeguards for off-page text
-- [x] Cross-page section context in the document AST, preserving page-local evidence while linking continued paragraphs and subsections back to the active section
-- [x] Caption-to-evidence links in the document AST for nearby table, image, figure, chart, formula, and diagram nodes, including side-caption layouts with vertical-overlap evidence
-- [x] Multi-caption and multi-target visual-layout fixture coverage for independent formula, chart, figure, and side-caption routing
-- [x] Text-layer evidence and metadata coverage in the agent document map without forcing top-level text-layer output
-- [x] Trust report routing and signal-level evidence indexes in the agent document map without forcing raw safety, layout, annotation, or table outputs
-- [x] Accessibility report routing and issue-level evidence indexes in the agent document map without forcing raw structure-tree output
-- [x] Filesystem and HTTP access restrictions
+PDF Reader MCP is now organized around a full-fidelity agent document model, not
+a stream of isolated parser features.
 
-**🚀 Next**
-- [x] Expand curated public scanned-PDF and visual-region provider manifests beyond the initial checked-in public provider accuracy set
-- [ ] Further broaden public evidence manifests with additional independently licensed scanned, tabular, chart-heavy, and formula-heavy PDFs
-- [ ] Optional advanced parser engine presets beyond the local OCR, Ollama, OpenAI-compatible, LM Studio, and llama.cpp adapter set
-- [ ] Optional advanced parser engines
-- [ ] 100+ MB streaming
-- [ ] Advanced caching
+| Surface | Status |
+| --- | --- |
+| Agent Document Twin | Shipped: document map, document AST, text layer, semantic hints, citation chunks, layout diagnostics, tables, OCR layer links, visual enrichment links, trust routing, accessibility routing, and page geometry. |
+| Evidence-first MCP workflow | Shipped: `inspect_pdf`, `search_pdf`, `render_page`, `extract_regions`, `analyze_regions`, `ocr_pages`, and `read_pdf` cover preflight, search, source visuals, focused crops, local-provider enrichment, scanned-page OCR, and extraction. |
+| Scanned PDF handling | Shipped through configured local OCR providers, Tesseract presets, OCR word boxes, OCR text-layer fusion, OCR-derived tables, and source-render provenance. |
+| Tables, charts, formulas, figures, and images | Shipped through deterministic table extraction plus visual-region provider adapters for command, HTTP, Ollama, OpenAI-compatible, LM Studio, and llama.cpp runtimes. |
+| Trust and accessibility intelligence | Shipped: hidden-text, prompt-injection-like text, visual-spoofing, unsafe-link, redaction, tagged-PDF coverage, tag-visible coverage, headings, images, forms, links, permissions, issue summaries, and page grades. |
+| Reproducible proof | Shipped: performance, quality, corpus, provider, provider-manifest crop/scoring, package-smoke, and SOTA release-gate artifacts. |
+
+**Next evidence expansion**
+
+- Broaden independently licensed scanned, tabular, chart-heavy, and
+  formula-heavy public manifests.
+- Add optional advanced parser-engine presets only when they can feed the same
+  evidence model without becoming mandatory package dependencies.
+- Continue performance work for very large PDFs, streaming, and caching without
+  weakening the local-first MCP contract.
 
 Vote at [Discussions](https://github.com/SylphxAI/pdf-reader-mcp/discussions)
 
@@ -1864,7 +1809,6 @@ Vote at [Discussions](https://github.com/SylphxAI/pdf-reader-mcp/discussions)
 ## 🤝 Support
 
 [![GitHub Issues](https://img.shields.io/github/issues/SylphxAI/pdf-reader-mcp?style=flat-square)](https://github.com/SylphxAI/pdf-reader-mcp/issues)
-[![Discord](https://img.shields.io/discord/YOUR_DISCORD_ID?style=flat-square&logo=discord)](https://discord.gg/sylphx)
 
 - 🐛 [Bug Reports](https://github.com/SylphxAI/pdf-reader-mcp/issues)
 - 💬 [Discussions](https://github.com/SylphxAI/pdf-reader-mcp/discussions)

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitepress';
 export default defineConfig({
   title: 'PDF Reader MCP',
   description:
-    'MCP server for PDF inspection, layout confidence, citation chunks, and safety signals for AI agents',
+    'Full-fidelity PDF intelligence MCP with Agent Document Twin, visual evidence, OCR provenance, trust reports, accessibility reports, citations, and benchmark proof for AI agents',
 
   appearance: 'dark',
   lastUpdated: true,
@@ -18,14 +18,14 @@ export default defineConfig({
     ['meta', { property: 'og:type', content: 'website' }],
     [
       'meta',
-      { property: 'og:title', content: 'PDF Reader MCP - Inspect and Extract PDFs for AI Agents' },
+      { property: 'og:title', content: 'PDF Reader MCP - Full-Fidelity PDF Intelligence for AI Agents' },
     ],
     [
       'meta',
       {
         property: 'og:description',
         content:
-          'A high-performance MCP server for PDF inspection, layout confidence, citation chunks, and safety signals',
+          'A TypeScript-first MCP server for Agent Document Twin extraction, visual evidence, OCR provenance, trust reports, accessibility reports, citations, and benchmark-gated release proof',
       },
     ],
     ['meta', { property: 'og:url', content: 'https://pdf-reader-mcp.sylphx.com' }],
@@ -36,7 +36,8 @@ export default defineConfig({
       'meta',
       {
         name: 'twitter:description',
-        content: 'Inspect PDFs and extract layout-aware agent-ready content via MCP',
+        content:
+          'Turn PDFs into agent-readable evidence with document maps, visual crops, OCR provenance, trust reports, accessibility reports, and benchmark proof',
       },
     ],
     ['meta', { name: 'twitter:site', content: '@sylphxai' }],
@@ -45,7 +46,7 @@ export default defineConfig({
       {
         name: 'keywords',
         content:
-          'mcp, pdf, reader, ai, claude, model context protocol, typescript, rag, citations, pdf inspection, layout analysis, reading order',
+          'mcp, pdf, reader, ai, claude, model context protocol, typescript, rag, citations, pdf inspection, pdf intelligence, agent document twin, visual evidence, ocr provenance, trust report, accessibility report, layout analysis, reading order',
       },
     ],
     ['meta', { name: 'author', content: 'Sylphx' }],

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -4,6 +4,12 @@ PDF Reader MCP exposes an MCP server contract. The package entrypoint starts the
 server; it is not an importable TypeScript SDK. Agents and clients should call
 the MCP tools below over stdio or the optional HTTP transport.
 
+The API is organized as an evidence-first workflow. Agents can profile a PDF,
+search before reading, render source pages, crop precise regions, run configured
+OCR, analyze visual regions through local providers, and finally read the same
+document as an Agent Document Twin with text, semantic, visual, trust,
+accessibility, citation, and routing layers.
+
 ## Transports
 
 | Setting | Description | Default |
@@ -18,13 +24,13 @@ the MCP tools below over stdio or the optional HTTP transport.
 
 | Tool | Purpose |
 | --- | --- |
-| `inspect_pdf` | Classify a PDF, sample pages, and recommend the extraction route before doing expensive work. |
-| `read_pdf` | Extract text, metadata, structure, tables, chunks, safety signals, accessibility signals, OCR evidence, and visual enrichments. |
-| `search_pdf` | Search selectable text and OCR text with snippets, page numbers, and bounding-box provenance. |
-| `render_page` | Render selected pages as PNG visual evidence with bounded pixel budgets. |
-| `extract_regions` | Crop bounded regions from rendered pages and return focused image evidence. |
-| `analyze_regions` | Send cropped visual regions to a configured local command or HTTP provider and normalize table, formula, chart, figure, or image-description evidence. |
-| `ocr_pages` | Render selected pages and send them to a configured local OCR provider. |
+| `inspect_pdf` | Classify a PDF, sample pages, detect scanned/low-text risk, report provider readiness, and recommend the extraction route before doing expensive work. |
+| `search_pdf` | Search selectable text and optional OCR text with snippets, page numbers, offsets, bounding-box provenance, and routing evidence. |
+| `render_page` | Render selected pages as bounded PNG visual evidence with JSON provenance and pixel budgets. |
+| `extract_regions` | Crop PDF-coordinate regions from rendered pages and return focused image evidence for tables, charts, formulas, figures, annotations, and citations. |
+| `analyze_regions` | Send cropped visual regions to a configured local command, HTTP, Ollama, OpenAI-compatible, LM Studio, or llama.cpp provider and normalize table, formula, chart, figure, or image-description evidence. |
+| `ocr_pages` | Render selected pages and send them to a configured local OCR provider, returning text, confidence, word boxes, and render provenance. |
+| `read_pdf` | Extract text, metadata, Markdown, HTML, structure, tables, chunks, safety signals, trust reports, accessibility signals, OCR evidence, visual enrichments, and the Agent Document Twin. |
 
 ## Source Object
 

--- a/docs/comparison/index.md
+++ b/docs/comparison/index.md
@@ -1,106 +1,64 @@
-# Comparison with Other Solutions
+# Capability Overview
 
-## PDF Reader MCP vs Alternatives
+PDF Reader MCP is designed as a full-fidelity PDF intelligence layer for
+agents. The comparison below is category-based and focuses on the agent
+workflow: inspect, search, verify source evidence, enrich visual regions, and
+read a linked document twin.
 
-| Feature | PDF Reader MCP | CLI Tools | Cloud APIs | Generic FS MCP |
-|---------|---------------|-----------|------------|----------------|
-| Text Extraction | ✅ | ✅ | ✅ | ❌ |
-| Direction-Aware Text Layer With Metadata Coverage | ✅ | ❌ | ⚠️ | ❌ |
-| Search With Evidence | ✅ | ⚠️ | ✅ | ❌ |
-| Metadata | ✅ | ✅ | ✅ | ❌ |
-| Image Extraction | ✅ | ⚠️ | ✅ | ❌ |
-| Page Rendering Evidence | ✅ | ⚠️ | ✅ | ❌ |
-| Region Crop Evidence | ✅ | ❌ | ✅ | ❌ |
-| Configured OCR Text Layer | ✅ | ⚠️ | ✅ | ❌ |
-| Page Ranges | ✅ | ⚠️ | ✅ | ❌ |
-| Batch Processing | ✅ | ❌ | ✅ | ❌ |
-| URL Support | ✅ | ❌ | ✅ | ❌ |
-| MCP Native | ✅ | ❌ | ❌ | ✅ |
-| Local Processing | ✅ | ✅ | ❌ | ✅ |
-| No API Keys | ✅ | ✅ | ❌ | ✅ |
-| Structured Output | ✅ | ❌ | ✅ | ❌ |
-| Agent Document Map | ✅ | ❌ | ⚠️ | ❌ |
-| Trust Report | ✅ | ❌ | ⚠️ | ❌ |
-| Accessibility Report | ✅ | ❌ | ⚠️ | ❌ |
+| Capability | PDF Reader MCP | Text/CLI tools | Cloud PDF APIs | Generic filesystem MCP |
+| --- | --- | --- | --- | --- |
+| MCP-native PDF tools | ✅ | ❌ | ❌ | ⚠️ raw file access only |
+| Preflight inspection and routing | ✅ | ❌ | ⚠️ API-specific | ❌ |
+| Literal search with evidence | ✅ snippets, offsets, boxes, provenance | ⚠️ text only | ⚠️ varies | ❌ |
+| Text layer fidelity | ✅ runs, lines, words, chars, metadata coverage | ⚠️ usually text only | ⚠️ varies | ❌ |
+| Agent Document Twin | ✅ document map plus AST and evidence indexes | ❌ | ⚠️ vendor-specific | ❌ |
+| Page rendering evidence | ✅ bounded MCP image parts | ⚠️ external commands | ✅ | ❌ |
+| Region crop evidence | ✅ PDF-coordinate crops | ⚠️ custom glue | ✅ | ❌ |
+| Scanned-page OCR path | ✅ configured local provider with provenance | ⚠️ external glue | ✅ | ❌ |
+| OCR-derived tables | ✅ when OCR word boxes are available | ❌ | ⚠️ varies | ❌ |
+| Table quality diagnostics | ✅ cells, geometry, spans, warnings, continuation hints | ❌ | ⚠️ varies | ❌ |
+| Formula/chart/figure/image enrichment | ✅ configured visual-provider adapters | ❌ | ⚠️ vendor-specific | ❌ |
+| Trust report | ✅ hidden text, prompt-injection-like text, visual spoofing, unsafe links, redaction | ❌ | ⚠️ varies | ❌ |
+| Accessibility report | ✅ tagged-PDF, tag-visible coverage, forms, links, images, permissions, grades | ❌ | ⚠️ varies | ❌ |
+| Citation chunks | ✅ page, semantic, size, and table chunks | ❌ | ⚠️ varies | ❌ |
+| Local-first default | ✅ | ✅ | ❌ | ✅ |
+| No required API key | ✅ | ✅ | ❌ | ✅ |
+| Reproducible release proof | ✅ quality, corpus, provider, package-smoke, and release-gate artifacts | ❌ | ❌ | ❌ |
 
-## Detailed Comparison
+## Why It Matters
 
-### CLI Tools (pdftotext, pdfinfo)
+Agents need more than extracted text. For high-value PDFs they need to know
+where content came from, which page or crop proves it, whether the reading order
+looks uncertain, whether a page needs OCR, whether a table has weak geometry,
+and whether hidden or unsafe content should be treated as untrusted data.
 
-**Pros:**
-- Can extract text and metadata
-- Works locally
+PDF Reader MCP exposes that as one workflow:
 
-**Cons:**
-- Requires executing shell commands
-- Output needs parsing
-- No native MCP integration
-- No batch processing
-- No image extraction (usually)
+1. `inspect_pdf` profiles the document and recommends the next tools.
+2. `search_pdf` finds source-backed text matches before spending context.
+3. `render_page` and `extract_regions` provide visual evidence.
+4. `ocr_pages` recovers text from scanned or sparse pages through configured
+   local OCR providers.
+5. `analyze_regions` normalizes configured visual-provider output for tables,
+   charts, formulas, figures, and image descriptions.
+6. `read_pdf` returns text, Markdown, HTML, chunks, tables, document signals,
+   trust reports, accessibility reports, and the linked Agent Document Twin.
 
-### Cloud PDF APIs
+## When PDF Reader MCP Is The Better Fit
 
-**Pros:**
-- Rich features (OCR, conversion)
-- Structured output
+- You want agents to inspect and route PDFs instead of blindly extracting text.
+- You need stable page, element, chunk, crop, table, OCR, trust, and
+  accessibility references for downstream citations.
+- You need local-first execution and want OCR or visual models configured by the
+  deployment, not selected by each request.
+- You need source evidence for tables, charts, formulas, figures, and scanned
+  pages.
+- You want public benchmark artifacts and a release gate that prove the shipped
+  capability surface.
 
-**Cons:**
-- Requires API keys and billing
-- Data sent to third party
-- Network latency
-- Not MCP native
+## Boundaries
 
-### Generic Filesystem MCP
-
-**Pros:**
-- Can read files
-- MCP native
-
-**Cons:**
-- Returns raw binary for PDFs
-- No PDF parsing
-- No text/metadata extraction
-- No image extraction
-
-### PDF Reader MCP
-
-**Pros:**
-- Purpose-built for PDF extraction
-- MCP native integration
-- Local processing (privacy)
-- No API keys needed
-- Batch processing
-- Search with snippets, match offsets, character-derived or text-item bounding boxes, and provenance
-- Direction-aware text layer with run records, line records, word records, character records, estimated bounding boxes, provenance, and metadata coverage diagnostics
-- Image extraction
-- Page rendering evidence with bounded PNG image parts
-- Region crop evidence for bbox-grounded verification
-- Configured local OCR provider pipeline with opt-in `read_pdf` OCR layer fusion
-- URL support
-- Structured JSON output
-- Agent document maps with linked pages, elements, text-layer and metadata coverage, chunks, layout confidence, safety findings, trust report routing and signal indexes, accessibility report routing and issue indexes, visual evidence routing, and geometry
-- Trust reports with page risk, score, signal counters, redacted evidence snippets, and optional document-map signal routing
-- Accessibility reports with tagged-PDF coverage, tag-to-visible-content coverage, heading, image, form, link, permission signals, and optional document-map issue routing
-
-**Cons:**
-- PDF-specific (not general file access)
-- Requires Node.js 22+
-
-## When to Use PDF Reader MCP
-
-- You need AI agents to read PDF content
-- You need direction-aware line/word text evidence with character ranges, metadata coverage, and best-effort boxes
-- Privacy matters (local processing)
-- You want simple MCP integration
-- You need to process multiple PDFs
-- You need to find evidence before reading, rendering, cropping, or citing a PDF region
-- You need image extraction
-- You need page images for visual verification or OCR routing
-- You need focused crops from table, figure, chart, formula, or citation bounding boxes
-- You need scanned-page OCR through a local provider without making a cloud API the default path
-- You need table quality signals, sparse-cell warnings, or continuation candidates for agent routing
-- You need a semantic document AST for page, section, paragraph, list, caption, header, footer, table, and image traversal with continued section context and caption-to-evidence links
-- You need a local trust report before using PDF content, annotations, or links as instructions, evidence, or retrieval context
-- You need an accessibility report before relying on tagged structure, tag-to-visible-content coverage, headings, images, forms, links, issue summaries, or copy-based accessibility workflows
-- You want structured, parseable output
-- You want agents to navigate PDF evidence through stable references
+PDF Reader MCP does not bundle heavy OCR, vision, formula, or layout model
+weights. The default package stays TypeScript-first and local-first; advanced
+OCR and visual understanding are enabled through explicit local providers and
+validated through provider benchmarks.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -1,6 +1,11 @@
 # Design Philosophy
 
-PDF Reader MCP is built on these core principles:
+PDF Reader MCP is designed as an Agent Document Twin engine for MCP clients. The
+core design goal is to preserve source evidence and routing signals across text,
+visual, semantic, trust, accessibility, OCR, and provider-enriched layers while
+keeping the default package TypeScript-first and local-first.
+
+It is built on these core principles:
 
 ## 1. Performance First
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,10 +1,22 @@
 # Introduction
 
-PDF Reader MCP is a Model Context Protocol (MCP) server that enables AI agents to inspect, read, and extract content from PDF files.
+PDF Reader MCP is a full-fidelity Model Context Protocol (MCP) server that
+turns PDFs into agent-readable evidence. It is built around an Agent Document
+Twin: text layers, semantic structure, source visuals, region crops, OCR
+provenance, tables, citations, trust signals, accessibility signals, and
+provider-backed visual enrichments linked through stable IDs.
+
+The default package stays TypeScript-first and local-first. Selectable-text
+PDFs, inspection, search, rendering, crops, document maps, trust reports,
+accessibility reports, Markdown/HTML/JSON extraction, and safety signals work
+without heavy model downloads. Scanned OCR and visual table/chart/formula/figure
+understanding are enabled through configured local providers.
 
 ## What It Does
 
-AI agents often need to access information from PDF documents - reports, invoices, research papers, manuals, and more. This server provides tools to inspect and extract:
+AI agents often need to access information from PDF documents - reports,
+invoices, research papers, manuals, and more. This server provides tools to
+inspect, verify, enrich, and extract:
 
 - **PDF profiles** - Detect text-rich, low-text, mixed, or scanned/image-like PDFs before extraction
 - **PDF search evidence** - Locate literal text matches with snippets, match offsets, character-derived or text-item bounding boxes, and provenance
@@ -12,6 +24,7 @@ AI agents often need to access information from PDF documents - reports, invoice
 - **Region crop evidence** - Crop PDF-coordinate bounding boxes as focused PNG evidence
 - **Visual region analysis** - Send focused crops to a configured local provider and normalize table, chart, formula, figure, and image-description results
 - **Configured OCR text layers** - Run selected rendered pages through a local OCR provider and normalize text, confidence, words, language, and provenance
+- **Agent Document Twin** - Read one linked document map with pages, elements, text-layer coverage, chunks, layout diagnostics, OCR evidence, visual enrichment indexes, trust routing, accessibility routing, and page geometry
 - **Full text content** - Get all text from a PDF
 - **PDF text layers** - Return direction-aware run records, line records, word records, character records, estimated boxes, provenance, and metadata coverage diagnostics
 - **Page-specific text** - Extract text from specific pages or page ranges

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: PDF Reader MCP
-  text: Inspect and Extract PDFs for AI Agents
-  tagline: A high-performance MCP server for local-first PDF inspection, PDF search, visual evidence, region crops, configured OCR text layers, agent document maps, trust reports, accessibility reports, citations, and safety signals.
+  text: Full-Fidelity PDF Intelligence for AI Agents
+  tagline: "A TypeScript-first MCP server that turns PDFs into an Agent Document Twin: text layers, semantic AST, tables, visual evidence, OCR provenance, trust reports, accessibility reports, citations, and benchmark-gated release proof."
   image:
     src: /logo.svg
     alt: PDF Reader MCP Logo
@@ -15,42 +15,48 @@ hero:
     - theme: alt
       text: View on GitHub
       link: https://github.com/SylphxAI/pdf-reader-mcp
+    - theme: alt
+      text: Benchmark Proof
+      link: /performance/
 
 features:
   - icon: "\U0001F4C4"
-    title: Inspect Before Extraction
-    details: Profile unfamiliar PDFs, detect low-text or scanned pages, and get ordered extraction and evidence-routing plans for agent workflows.
+    title: Agent Document Twin
+    details: Return one linked document map with pages, elements, text-layer coverage, chunks, layout diagnostics, trust routing, accessibility routing, visual routing, OCR evidence, and page geometry.
   - icon: "\U0001F50E"
-    title: Search Evidence
-    details: Locate literal text matches with snippets, match offsets, character-derived, text-item, or opt-in OCR-word bounding boxes, and provenance before reading, rendering, cropping, or citing.
+    title: Evidence-First Search
+    details: Locate literal text matches with snippets, match offsets, character-derived, text-item, or opt-in OCR-word boxes, and provenance before reading, rendering, cropping, or citing.
   - icon: "\u26A1"
-    title: High Performance
-    details: Built with pdfjs-dist and optimized for speed. Supports concurrent processing, batch operations, and recursive band/column ordering.
+    title: Performance-Bounded Local Execution
+    details: Built on pdfjs-dist with concurrent processing, bounded rendering, page limits, pixel budgets, package smoke checks, and reproducible benchmark artifacts.
   - icon: "\U0001F50C"
-    title: Easy Integration
-    details: Works with Claude Desktop, Claude Code, Cursor, and any MCP-compatible client. One command to install.
+    title: MCP-Native Tool Routing
+    details: Use inspect_pdf, search_pdf, render_page, extract_regions, analyze_regions, ocr_pages, and read_pdf as a focused agent workflow instead of a single opaque parser call.
   - icon: "\U0001F5BC\uFE0F"
-    title: Agent-Ready Context
-    details: Return an agent document map, text layer, semantic document AST, trust report, and accessibility report with stable element IDs, text-layer and metadata coverage, caption links, citation chunks, table quality diagnostics, layout confidence, hidden-text, visual-spoofing, redacted trust-evidence, unsafe-link signals, document-map trust signal routing, document-map accessibility issue routing, routeable accessibility summaries, page geometry, provenance, and best-effort coordinates.
+    title: Visual Evidence and Crops
+    details: Render source pages and crop PDF-coordinate regions into bounded image evidence for tables, figures, charts, formulas, annotations, and citations.
   - icon: "\U0001F9FE"
     title: Text Layer Fidelity
     details: Expose direction-aware run, line, word, and character records with page-level ranges, estimated bounding boxes, provenance, and metadata coverage diagnostics for citation and extraction workflows.
   - icon: "\U0001F5BC\uFE0F"
-    title: Visual Evidence
-    details: Render selected pages as bounded PNG MCP image parts with JSON provenance, evidence IDs, and pixel budgets for OCR routing and page inspection.
+    title: Visual Provider Enrichment
+    details: Normalize table, formula, chart, figure, diagram, and image-description evidence from configured command, HTTP, Ollama, OpenAI-compatible, LM Studio, or llama.cpp providers.
   - icon: "\U0001F50D"
-    title: Region Crops
-    details: Crop PDF-coordinate bounding boxes into focused visual evidence for tables, figures, charts, formulas, and citation verification, with rich local-provider analysis when configured.
+    title: Table Intelligence
+    details: Extract selectable-text and OCR-derived tables with rows, cells, geometry, confidence, quality metrics, inferred spans, warnings, and continuation candidates.
   - icon: "\U0001F524"
-    title: Configured OCR
-    details: Route selected rendered pages through an environment-configured local OCR provider and optionally fuse OCR text layers into read_pdf document maps with provenance.
+    title: Scanned PDF OCR Path
+    details: Route selected rendered pages through configured OCR providers, keep OCR separate from selectable text, and link OCR words and tables back to source-render evidence.
   - icon: "\U0001F9ED"
-    title: Layout Confidence
-    details: Surface page layout profiles, reading-order confidence, column signals, and warnings so agents can route uncertain pages safely.
+    title: Semantic AST and Layout Confidence
+    details: Traverse sections, paragraphs, lists, captions, tables, images, charts, formulas, and figures while preserving reading-order diagnostics and caption-to-evidence links.
   - icon: "\U0001F6E1\uFE0F"
-    title: Content Safety Signals
-    details: Surface deterministic findings for prompt-injection patterns, tiny text, and off-page text before agents use PDF content.
+    title: Trust Report
+    details: Surface deterministic prompt-injection, hidden-text, tiny/off-page, overlapping, visual-spoofing, unsafe-link, layout, table-quality, redaction, and page-risk signals.
   - icon: "\u267F"
     title: Accessibility Report
     details: Summarize tagged-PDF coverage, tag-to-visible-content coverage, structure trees, headings, image alt-text verifiability, form labels, link labels, accessibility permissions, issue types, severities, page grades, and document-map routing without claiming PDF/UA certification.
+  - icon: "\U0001F9EA"
+    title: Benchmark-Gated Releases
+    details: Release evidence includes performance, deterministic quality, corpus, installed-provider, provider-manifest crop/scoring, package-smoke, and SOTA release-gate artifacts.
 ---

--- a/docs/performance/index.md
+++ b/docs/performance/index.md
@@ -1,6 +1,24 @@
 # Performance
 
-PDF Reader MCP is optimized for speed and efficiency.
+PDF Reader MCP is optimized for speed, bounded local execution, and
+reproducible release evidence. Performance claims should stay tied to benchmark
+commands and artifacts, while quality claims are gated through deterministic
+fixtures, corpus cases, provider certification, package smoke checks, and the
+SOTA release gate.
+
+## Release Proof Snapshot
+
+The checked-in release artifacts expose machine-readable proof for the current
+capability surface:
+
+| Artifact | Current release evidence |
+| --- | --- |
+| `pdf_sota_release_gate.json` | `passed`, 39/39 release-gate checks passing |
+| `pdf_quality_benchmark.json` | score `1`, 69/69 deterministic quality checks passing |
+| `pdf_provider_benchmark.json` | strict provider evidence enabled, 4/4 final-bar provider profiles certified |
+| `pdf_corpus_benchmark.json` | corpus-style PDF intelligence assertions with capability summaries |
+| `pdf_provider_manifest_crop_benchmark.json` | deterministic crop-substrate proof for provider-manifest regions |
+| `pdf_provider_manifest_benchmark.json` | deterministic provider-manifest scoring proof for table, formula, chart, figure, and image regions |
 
 ## Reproducible Benchmark
 
@@ -18,7 +36,7 @@ with average, minimum, and maximum latency for these fixed scenarios:
 | `metadata_page_count` | Fast metadata and page-count path |
 | `full_text` | Full selectable-text extraction |
 | `selected_page_text` | Single-page extraction |
-| `v3_agent_document_twin` | Document map, text layer, document AST, trust report, accessibility report, chunks, semantic hints, layout diagnostics, tables, and trust/accessibility routing plus index fusion |
+| `v3_agent_document_twin` | Agent Document Twin scenario: document map, text layer, document AST, trust report, accessibility report, chunks, semantic hints, layout diagnostics, tables, and trust/accessibility routing plus index fusion |
 
 Treat benchmark output as machine- and fixture-specific. Public performance
 claims should cite the command, fixture, runtime, and measured output.

--- a/docs/specs/2026-06-14-capability-gap-matrix.md
+++ b/docs/specs/2026-06-14-capability-gap-matrix.md
@@ -1,11 +1,11 @@
-# Capability Gap Matrix
+# Capability Coverage Matrix
 
 Date: 2026-06-14
 Status: active
 
-This matrix tracks the capabilities PDF Reader MCP needs in order to feel like
-a category-leading PDF intelligence server for AI agents. It intentionally uses
-neutral capability names and avoids public comparison language.
+This matrix tracks PDF Reader MCP's shipped and planned capability coverage for
+agent-facing PDF intelligence. It intentionally uses neutral capability names
+and avoids public comparison language.
 
 ## Legend
 

--- a/docs/specs/2026-06-14-pdf-intelligence-vnext.md
+++ b/docs/specs/2026-06-14-pdf-intelligence-vnext.md
@@ -1,13 +1,13 @@
-# PDF Intelligence vNext
+# Full-Fidelity PDF Intelligence Direction
 
 Date: 2026-06-14
-Status: active
+Status: superseded by shipped release gates
 
 ## Goal
 
-Make PDF Reader MCP the strongest practical PDF intelligence layer for AI
-agents while preserving its current install experience: local-first, MCP-native,
-simple to run with `npx`, and safe by default.
+Make PDF Reader MCP a full-fidelity PDF intelligence layer for AI agents while
+preserving its install experience: local-first, MCP-native, simple to run with
+`npx`, and safe by default.
 
 The product direction is not to become a monolithic PDF desktop converter. The
 product direction is to become the agent-facing control plane for PDF
@@ -130,7 +130,7 @@ Candidate engines:
   request payloads.
 - `vision`: optional enrichment for charts, figures, and formulas.
 
-## Phased Roadmap
+## Implementation Plan
 
 1. Structured foundation
    - Add `inspect_pdf` for bounded preflight profiling, OCR triage, and

--- a/docs/specs/2026-06-15-agent-document-map-v3.md
+++ b/docs/specs/2026-06-15-agent-document-map-v3.md
@@ -1,11 +1,11 @@
-# Agent Document Map v3
+# Agent Document Map
 
 Date: 2026-06-15
-Status: active
+Status: shipped
 
 ## Goal
 
-Make PDF Reader MCP expose a single agent-native map of a PDF: pages,
+PDF Reader MCP exposes a single agent-native map of a PDF: pages,
 elements, selectable text-layer and metadata coverage, chunks, layout
 confidence, safety findings, trust report routing and signal indexes,
 accessibility report routing and issue indexes, OCR evidence, visual evidence
@@ -15,11 +15,12 @@ without forcing agents to learn a new response shape each time.
 
 ## Product Positioning
 
-This is a capability release track, not a one-feature patch track. Public
-messaging should describe the shipped outcome as full-fidelity, agent-ready PDF
+This is the shipped full-fidelity PDF intelligence surface, not a one-feature
+parser patch. Public messaging should describe the outcome as agent-ready PDF
 understanding with performance-bounded local execution. Do not mention external
-projects or imply built-in OCR models, formula, chart, or tagged-PDF
-generation before those capabilities are shipped and validated.
+projects or imply built-in OCR models, formula, chart, or tagged-PDF generation;
+those remain provider-backed or explicitly out of scope unless validated by
+dedicated tests and benchmarks.
 
 ## Non-Goals
 
@@ -27,8 +28,7 @@ generation before those capabilities are shipped and validated.
   mandatory for the default TypeScript package.
 - Do not put image base64 data inside the JSON document map.
 - Do not create a second table, chunk, or element vocabulary.
-- Do not publish a package release until the v3 capability batch is large
-  enough to read as a planned milestone.
+- Do not describe provider-backed or advanced parser capabilities as built in.
 
 ## Public Contract
 
@@ -268,9 +268,9 @@ Each successful source may include:
   document-level trust summary counts without forcing raw safety, layout,
   annotation, or table outputs into top-level output.
 
-## v3 Capability Batch
+## Capability Batch
 
-Required before publishing the next package release:
+The shipped capability batch includes:
 
 - `include_document_map` public schema, handler, types, tests, docs.
 - Inspector recommendations include `include_document_map` for digital and
@@ -307,7 +307,7 @@ Required before publishing the next package release:
   accurately, and keep built-in OCR model, bundled VLM, and PDF/UA generation
   capabilities in roadmap language only.
 
-Next slices for the same v3 track:
+Next evidence-expansion slices:
 
 - Additional OCR provider presets, scanned fixtures, and accuracy/latency
   benchmarks.

--- a/docs/specs/2026-06-15-document-ast.md
+++ b/docs/specs/2026-06-15-document-ast.md
@@ -1,4 +1,4 @@
-# Document AST V3
+# Document AST
 
 Date: 2026-06-15
 Status: shipped

--- a/docs/specs/2026-06-15-table-intelligence.md
+++ b/docs/specs/2026-06-15-table-intelligence.md
@@ -1,4 +1,4 @@
-# Table Intelligence V3
+# Table Intelligence
 
 Date: 2026-06-15
 Status: shipped

--- a/docs/specs/2026-06-15-trust-report.md
+++ b/docs/specs/2026-06-15-trust-report.md
@@ -1,4 +1,4 @@
-# Trust Report V3
+# Trust Report
 
 Date: 2026-06-15
 Status: shipped

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sylphx/pdf-reader-mcp",
   "version": "2.7.0",
-  "description": "Agent-native MCP server for PDF inspection, extraction, OCR evidence, citation chunks, and safety signals.",
+  "description": "Full-fidelity PDF intelligence MCP server with Agent Document Twin, visual evidence, OCR provenance, trust reports, accessibility reports, and benchmark-gated release proof.",
   "type": "module",
   "bin": {
     "pdf-reader-mcp": "./dist/index.js"
@@ -44,6 +44,12 @@
     "tool",
     "rag",
     "citations",
+    "agent-document-twin",
+    "pdf-intelligence",
+    "ocr",
+    "visual-evidence",
+    "trust-report",
+    "accessibility-report",
     "pdf-inspection",
     "layout-analysis",
     "reading-order",


### PR DESCRIPTION
## Summary

- Reposition public README/docs around the shipped Agent Document Twin, evidence-first MCP workflow, visual/OCR/provider layers, trust/accessibility reports, and benchmark-gated release proof.
- Replace the old long README roadmap checklist with a concise Product Surface table plus neutral next-evidence-expansion language.
- Refresh docs home, comparison, guide, API, performance, design, spec titles, VitePress metadata, npm package description/keywords, and add a patch changeset for the public npm metadata update.

## Audit Notes

- Public README/docs/package metadata no longer contain competitor references, `Powered by Sylphx`, placeholder Discord badge text, or current Foundation package positioning.
- Historical CHANGELOG entries still mention older Sylphx tooling because they are release history, not current positioning.
- Heavy OCR/vision/model capabilities remain described as configured-provider paths, not bundled defaults.

## Validation

- `bun run check`
- `bun run docs:build`
- `bun run typecheck`
- `bun test`
- `bun run package:smoke`