### PR TITLE
docs: neutralize public release gate wording

### DIFF
--- a/docs/specs/2026-06-15-sota-final-bar.md
+++ b/docs/specs/2026-06-15-sota-final-bar.md
@@ -195,7 +195,7 @@ A new major release should not be treated as complete until:
 - `bun run benchmark:release-gate` passes against the release benchmark
   artifacts.
 - `bun run package:smoke` passes against the packed package tarball.
-- Public docs match the verified behavior without competitor references or
+- Public docs match the verified behavior without external-project callouts or
   unproven superiority claims.
 - The package smoke test proves the release tarball exposes the executable
   runtime artifact, the expected `bin`/`exports` contract, required public


### PR DESCRIPTION
## Summary
- Remove the remaining public spec wording that names competitor references as a category
- Keep the release-gate requirement neutral: verified behavior, no external-project callouts, no unproven superiority claims

## Validation
- bun run check
- bun run docs:build
- public wording scan over README.md, docs, and package.json