### PR TITLE
fix(http): enforce X-API-Key auth and default to loopback

### DIFF
--- a/.changeset/enforce-http-api-key-auth.md
+++ b/.changeset/enforce-http-api-key-auth.md
@@ -1,0 +1,20 @@
+---
+"@sylphx/pdf-reader-mcp": patch
+---
+
+Security: enforce HTTP transport authentication (X-API-Key).
+
+Previously the HTTP transport (`MCP_TRANSPORT=http`) read `MCP_API_KEY` and
+logged "API key authentication enabled" but never checked the header, so any
+client that could reach the port could call every PDF tool. The key is now
+enforced — when `MCP_API_KEY` is set, every `/mcp` request must present a
+matching `X-API-Key` header (constant-time comparison) or it is rejected with
+`401`; `/mcp/health` stays open. (CWE-306, reported by novice-22.)
+
+Hardening, both behavior changes for HTTP deployments:
+
+- `MCP_HTTP_HOST` now defaults to `127.0.0.1` (loopback) instead of `0.0.0.0`.
+  Set it explicitly to expose other interfaces.
+- The server warns at startup when it binds a non-loopback host with no API key.
+
+`stdio` (the default transport) is unaffected.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,56 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes land on the latest published `@sylphx/pdf-reader-mcp` release. We
+fix forward — please upgrade to the newest version before reporting.
+
+## Reporting a vulnerability
+
+**Please report privately. Do not open a public issue for security defects.**
+
+Preferred channel — GitHub private vulnerability reporting (does not depend on
+email delivery):
+
+1. Go to the repository's **Security** tab.
+2. Click **Report a vulnerability** (GitHub private advisory).
+3. Include the details below.
+
+This routes straight to the maintainers and lets us collaborate on a fix and a
+coordinated advisory in one place.
+
+Please include:
+
+- affected version(s) and transport (`stdio` or `http`);
+- a clear description and impact;
+- minimal steps to reproduce or a proof of concept;
+- any suggested remediation.
+
+We aim to acknowledge a report within a few days, agree on severity and a fix
+window, and publish a GitHub Security Advisory (GHSA, with a CVE where it
+qualifies) once a fixed version ships. We are glad to credit reporters by their
+chosen handle.
+
+## Scope
+
+In scope: defects in this package's own code — authentication/authorization
+bypass, information disclosure, path traversal, SSRF, and similar. Issues in
+third-party dependencies should be reported upstream; tell us if this package's
+configuration meaningfully amplifies them.
+
+## Operator hardening checklist (HTTP transport)
+
+The HTTP transport (`MCP_TRANSPORT=http`) exposes every PDF tool to any client
+that can reach the port. It is opt-in; the default transport is `stdio`.
+
+- Binds to `127.0.0.1` (loopback) by default. Set `MCP_HTTP_HOST` to a
+  non-loopback host only when you intend remote access.
+- Set `MCP_API_KEY` whenever the server is reachable from another machine.
+  Every `/mcp` request must then present a matching `X-API-Key` header;
+  unauthenticated requests get `401`. The server warns at startup if it binds a
+  non-loopback host without a key.
+- Restrict filesystem reach with `--allow-dir=<path>` (repeatable) or
+  `MCP_PDF_ALLOWED_DIRS`. Without an allowlist the process can read any PDF it
+  has OS permission to open.
+- URL sources resolving to private/loopback addresses are blocked by default
+  (SSRF guard); only pass `--allow-private-ips` in a trusted network.

--- a/dist/index.js
+++ b/dist/index.js
@@ -4,6 +4,7 @@
 import { createRequire as createRequire3 } from "node:module";
 
 // src/mcp.ts
+import { createHash, timingSafeEqual } from "node:crypto";
 import { createServer as createHttpServer } from "node:http";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -60,6 +61,22 @@ var withCors = (res, origin) => {
   res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
   res.setHeader("Access-Control-Allow-Headers", "Content-Type, Accept, MCP-Protocol-Version, Mcp-Session-Id, X-API-Key");
 };
+var isApiKeyValid = (configuredKey, presented) => {
+  const provided = Array.isArray(presented) ? presented[0] : presented;
+  if (typeof provided !== "string" || provided.length === 0)
+    return false;
+  const expected = createHash("sha256").update(configuredKey).digest();
+  const actual = createHash("sha256").update(provided).digest();
+  return timingSafeEqual(expected, actual);
+};
+var unauthorized = (res) => {
+  res.writeHead(401, { "Content-Type": "application/json", "WWW-Authenticate": "X-API-Key" });
+  res.end(JSON.stringify({
+    jsonrpc: "2.0",
+    id: null,
+    error: { code: -32001, message: "Unauthorized: missing or invalid X-API-Key header" }
+  }));
+};
 var ensureStreamableAcceptHeader = (req) => {
   const accept = req.headers.accept;
   const acceptValues = Array.isArray(accept) ? accept.join(", ") : accept ?? "";
@@ -74,34 +91,46 @@ var ensureStreamableAcceptHeader = (req) => {
   }
   req.rawHeaders.push("Accept", "application/json, text/event-stream");
 };
+var handleNonMcpRoute = (req, res, pathname, transportConfig) => {
+  if (pathname === "/mcp/health" && req.method === "GET") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "ok" }));
+    return true;
+  }
+  if (pathname !== "/mcp") {
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Not found" }));
+    return true;
+  }
+  if (req.method === "OPTIONS") {
+    res.writeHead(204);
+    res.end();
+    return true;
+  }
+  if (transportConfig.apiKey !== undefined && !isApiKeyValid(transportConfig.apiKey, req.headers["x-api-key"])) {
+    unauthorized(res);
+    return true;
+  }
+  return false;
+};
+var handleHttpRequest = async (req, res, mcpServer, transportConfig) => {
+  const url = new URL(req.url ?? "/", `http://${req.headers.host ?? transportConfig.hostname}`);
+  withCors(res, transportConfig.cors);
+  if (handleNonMcpRoute(req, res, url.pathname, transportConfig))
+    return;
+  ensureStreamableAcceptHeader(req);
+  const transport = new StreamableHTTPServerTransport({ enableJsonResponse: true });
+  try {
+    await mcpServer.connect(transport);
+    await transport.handleRequest(req, res);
+  } finally {
+    await mcpServer.close();
+  }
+};
 var startHttpServer = async (serverInfo, transportConfig) => {
   const mcpServer = buildMcpServer(serverInfo);
-  const httpServer = createHttpServer(async (req, res) => {
-    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? transportConfig.hostname}`);
-    withCors(res, transportConfig.cors);
-    if (url.pathname === "/mcp/health" && req.method === "GET") {
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ status: "ok" }));
-      return;
-    }
-    if (url.pathname !== "/mcp") {
-      res.writeHead(404, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "Not found" }));
-      return;
-    }
-    if (req.method === "OPTIONS") {
-      res.writeHead(204);
-      res.end();
-      return;
-    }
-    ensureStreamableAcceptHeader(req);
-    const transport = new StreamableHTTPServerTransport({ enableJsonResponse: true });
-    try {
-      await mcpServer.connect(transport);
-      await transport.handleRequest(req, res);
-    } finally {
-      await mcpServer.close();
-    }
+  const httpServer = createHttpServer((req, res) => {
+    handleHttpRequest(req, res, mcpServer, transportConfig);
   });
   await new Promise((resolve, reject) => {
     httpServer.once("error", reject);
@@ -8459,15 +8488,17 @@ var require4 = createRequire3(import.meta.url);
 var packageJson = require4("../package.json");
 var transportType = process.env["MCP_TRANSPORT"] ?? "stdio";
 var httpPort = Number.parseInt(process.env["MCP_HTTP_PORT"] ?? "8080", 10);
-var httpHost = process.env["MCP_HTTP_HOST"] ?? "0.0.0.0";
+var httpHost = process.env["MCP_HTTP_HOST"] ?? "127.0.0.1";
 var apiKey = process.env["MCP_API_KEY"];
 var corsOrigin = process.env["MCP_CORS_ORIGIN"];
+var isLoopbackHost = (host) => host === "localhost" || host === "::1" || host === "127.0.0.1" || host.startsWith("127.");
 function createTransport() {
   if (transportType === "http") {
     return http({
       port: httpPort,
       hostname: httpHost,
-      ...corsOrigin ? { cors: corsOrigin } : {}
+      ...corsOrigin ? { cors: corsOrigin } : {},
+      ...apiKey ? { apiKey } : {}
     });
   }
   return stdio();
@@ -8490,6 +8521,8 @@ async function main() {
     console.log(`[PDF Reader MCP] Health check: http://${httpHost}:${httpPort}/mcp/health`);
     if (apiKey) {
       console.log("[PDF Reader MCP] API key authentication enabled (X-API-Key header)");
+    } else if (!isLoopbackHost(httpHost)) {
+      console.warn(`[PDF Reader MCP] WARNING: bound to non-loopback host ${httpHost} with no API key. ` + "Any client that can reach this port can read every PDF this process can access. " + "Set MCP_API_KEY to require an X-API-Key header, or bind MCP_HTTP_HOST=127.0.0.1.");
     }
     if (corsOrigin) {
       console.log(`[PDF Reader MCP] CORS allowed origin: ${corsOrigin}`);

--- a/docs/adr/0002-enforce-http-transport-authentication.md
+++ b/docs/adr/0002-enforce-http-transport-authentication.md
@@ -1,0 +1,103 @@
+# ADR-0002: Enforce HTTP Transport Authentication (X-API-Key)
+
+**Status:** Accepted
+**Date:** 2026-06-25
+**Deciders:** Kyle Tse, Claude
+**Project:** pdf-reader-mcp
+
+## Context
+
+A security researcher (handle "novice-22") privately reported that the HTTP
+transport (`MCP_TRANSPORT=http`) accepted unauthenticated requests even when the
+operator configured an API key.
+
+The defect was confirmed in code, including the current `v3.0.0`:
+
+- `src/index.ts` read `MCP_API_KEY` into a variable but never passed it to the
+  transport, and logged `API key authentication enabled (X-API-Key header)` at
+  startup regardless.
+- `src/mcp.ts` (the local HTTP layer built on `node:http` +
+  `@modelcontextprotocol/sdk`'s `StreamableHTTPServerTransport`) had no
+  authentication check on `/mcp`.
+- `MCP_HTTP_HOST` defaulted to `0.0.0.0`, binding all interfaces.
+
+Result: any client that could reach the port could call every PDF tool and read
+any PDF the process could open — while the startup log falsely asserted the
+endpoint was authenticated. The silent, misleading affirmation is the
+aggravating factor: an operator who set `MCP_API_KEY` reasonably believed the
+server was protected. (CWE-306 Missing Authentication for a Critical Function →
+CWE-200 Information Disclosure.)
+
+### Ownership / boundary
+
+The vulnerability is owned by **this package**, not by an SDK. The bug is a
+*false promise*: pdf-reader-mcp advertised and logged an authentication control
+it never enforced. As of `v3.0.0` the package no longer depends on
+`@sylphx/mcp-server-sdk`; it owns its HTTP request handling directly in
+`src/mcp.ts`, so the fix is fully in-repo (see [ADR-0001](0001-2027-sota-document-intelligence-boundary.md)
+for why this package stays standard-SDK-based and dependency-light).
+
+A separate, lesser observation — that `@sylphx/mcp-server-sdk`'s `http()`
+transport exposes no auth option — is a capability gap in that SDK, not this
+CVE, and is out of scope here because v3 does not use that SDK. If that SDK is
+still consumed elsewhere, closing that gap belongs in the SDK's own repo.
+
+## Decision
+
+1. **Enforce `X-API-Key`.** When `MCP_API_KEY` is set, every data-bearing
+   `/mcp` request must present a matching `X-API-Key` header; missing or
+   mismatched keys are rejected with `401`. The comparison is constant-time
+   (SHA-256 + `timingSafeEqual`) so it leaks neither the key nor its length via
+   timing. `/mcp/health` and CORS preflight (`OPTIONS`) stay open — the former
+   carries no PDF data, the latter no credentials.
+2. **Default to loopback.** `MCP_HTTP_HOST` defaults to `127.0.0.1`. Exposing
+   other interfaces is an explicit opt-in.
+3. **Tell the truth at startup.** The "authentication enabled" line prints only
+   because the key is now actually enforced. When the server binds a
+   non-loopback host with no key, it logs a prominent warning.
+4. **Encode the guarantee as a CI gate.** Integration tests assert `401` without
+   a key, `401` with a wrong key, `200` with the correct key, that `tools/list`
+   is refused unauthenticated, and that `/mcp/health` stays open.
+5. **Disclose.** Publish a GitHub Security Advisory (GHSA, CVE where it
+   qualifies) crediting "novice-22", and add a `SECURITY.md` that routes future
+   reports through GitHub private vulnerability reporting (the prior
+   `hi@sylphx.com` channel was bouncing under the domain's MTA-STS policy).
+
+Filesystem confinement stays opt-in (`--allow-dir` / `MCP_PDF_ALLOWED_DIRS`) for
+now; defaulting to a restrictive allowlist is a separate, more disruptive change
+tracked outside this ADR.
+
+## Affected and fixed versions
+
+- **Affected:** `>=2.2.0` (the release that introduced the HTTP transport)
+  through `3.0.0`.
+- **Fixed:** the next patch release (`3.0.1`). Fix-forward only; no backport to
+  the `2.x` line.
+
+## Alternatives considered
+
+### Only fix the misleading log
+
+Rejected. Removing the false claim without enforcing the key still leaves the
+endpoint open; operators want the control to work, not just to stop lying.
+
+### Add an auth option to `@sylphx/mcp-server-sdk`
+
+Moot for this CVE. `v3.0.0` does not depend on that SDK, and coupling a public,
+portable package back to an in-house SDK would contradict ADR-0001.
+
+### Default to a deny-by-default filesystem allowlist
+
+Deferred. Worth doing, but it breaks existing single-tenant users who rely on
+unrestricted local reads and is orthogonal to the authentication defect.
+
+## Consequences
+
+- **Breaking for some deployments.** Servers that relied on the `0.0.0.0`
+  default must now set `MCP_HTTP_HOST` explicitly. Clients that talk to a
+  key-protected server must send the `X-API-Key` header — which is the point.
+- Operators who already set `MCP_API_KEY` are protected for the first time.
+- The HTTP transport now has authentication regression coverage; a future change
+  that drops enforcement fails CI.
+- Future hosted/commercial offerings still live outside this package boundary
+  (ADR-0001); this change does not turn the package into a hosted service.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -16,10 +16,17 @@ analysis operations behind one specialist tool.
 | Setting | Description | Default |
 | --- | --- | --- |
 | `MCP_TRANSPORT` | `stdio` or `http` | `stdio` |
-| `MCP_HTTP_HOST` | HTTP bind host when `MCP_TRANSPORT=http` | `0.0.0.0` |
+| `MCP_HTTP_HOST` | HTTP bind host when `MCP_TRANSPORT=http`. Defaults to loopback; set explicitly (and set `MCP_API_KEY`) to expose on other interfaces. | `127.0.0.1` |
 | `MCP_HTTP_PORT` | HTTP port when `MCP_TRANSPORT=http` | `8080` |
-| `MCP_API_KEY` | Optional HTTP `X-API-Key` authentication | unset |
+| `MCP_API_KEY` | When set, every `/mcp` request must send a matching `X-API-Key` header or it is rejected with `401`. The `/mcp/health` check stays open. Leave unset only for a loopback-bound, single-tenant server. | unset |
 | `MCP_CORS_ORIGIN` | Optional explicit CORS origin | unset |
+
+> **Security:** The HTTP transport exposes every PDF tool to whoever can reach
+> the port. It binds to loopback (`127.0.0.1`) by default. Before binding any
+> non-loopback host, set `MCP_API_KEY` so callers must authenticate with an
+> `X-API-Key` header, and restrict filesystem reach with `--allow-dir` /
+> `MCP_PDF_ALLOWED_DIRS`. The server warns at startup if it binds a non-loopback
+> host without a key.
 
 ## Tools
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,14 +12,20 @@ const packageJson = require('../package.json') as { version: string };
 // Transport configuration via environment variables
 // MCP_TRANSPORT: 'stdio' (default) | 'http'
 // MCP_HTTP_PORT: HTTP port (default: 8080)
-// MCP_HTTP_HOST: HTTP hostname (default: '0.0.0.0')
-// MCP_API_KEY: Optional API key for authentication (X-API-Key header)
+// MCP_HTTP_HOST: HTTP hostname (default: '127.0.0.1' — loopback only; set
+//   explicitly to expose on other interfaces, and set MCP_API_KEY when you do)
+// MCP_API_KEY: Optional API key. When set, every /mcp request must present a
+//   matching X-API-Key header; requests without it are rejected with 401.
 // MCP_CORS_ORIGIN: CORS allowed origin (e.g. 'https://myapp.example.com'). Not set by default (no cross-origin access).
 const transportType = process.env['MCP_TRANSPORT'] ?? 'stdio';
 const httpPort = Number.parseInt(process.env['MCP_HTTP_PORT'] ?? '8080', 10);
-const httpHost = process.env['MCP_HTTP_HOST'] ?? '0.0.0.0';
+const httpHost = process.env['MCP_HTTP_HOST'] ?? '127.0.0.1';
 const apiKey = process.env['MCP_API_KEY'];
 const corsOrigin = process.env['MCP_CORS_ORIGIN'];
+
+/** Loopback hosts never reachable from another machine without extra config. */
+const isLoopbackHost = (host: string): boolean =>
+  host === 'localhost' || host === '::1' || host === '127.0.0.1' || host.startsWith('127.');
 
 /**
  * Create the appropriate transport based on configuration
@@ -30,6 +36,7 @@ function createTransport() {
       port: httpPort,
       hostname: httpHost,
       ...(corsOrigin ? { cors: corsOrigin } : {}),
+      ...(apiKey ? { apiKey } : {}),
     });
   }
   return stdio();
@@ -56,7 +63,14 @@ async function main(): Promise<void> {
     console.log(`[PDF Reader MCP] Server running on http://${httpHost}:${httpPort}/mcp`);
     console.log(`[PDF Reader MCP] Health check: http://${httpHost}:${httpPort}/mcp/health`);
     if (apiKey) {
+      // Truthful only because the transport now enforces this key (see src/mcp.ts).
       console.log('[PDF Reader MCP] API key authentication enabled (X-API-Key header)');
+    } else if (!isLoopbackHost(httpHost)) {
+      console.warn(
+        `[PDF Reader MCP] WARNING: bound to non-loopback host ${httpHost} with no API key. ` +
+          'Any client that can reach this port can read every PDF this process can access. ' +
+          'Set MCP_API_KEY to require an X-API-Key header, or bind MCP_HTTP_HOST=127.0.0.1.'
+      );
     }
     if (corsOrigin) {
       console.log(`[PDF Reader MCP] CORS allowed origin: ${corsOrigin}`);

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,3 +1,4 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
 import { createServer as createHttpServer, type Server as HttpServer } from 'node:http';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -73,6 +74,11 @@ interface HttpTransportConfig {
   port: number;
   hostname: string;
   cors?: string;
+  /**
+   * When set, every `/mcp` request must present a matching `X-API-Key` header.
+   * When undefined, the endpoint is unauthenticated (the historical behavior).
+   */
+  apiKey?: string;
 }
 
 type TransportConfig = StdioTransportConfig | HttpTransportConfig;
@@ -83,6 +89,7 @@ export const http = (config: {
   port: number;
   hostname: string;
   cors?: string;
+  apiKey?: string;
 }): HttpTransportConfig => ({ kind: 'http', ...config });
 
 interface CreateServerOptions {
@@ -120,6 +127,34 @@ const withCors = (res: import('node:http').ServerResponse, origin: string | unde
   );
 };
 
+/**
+ * Constant-time check of a presented `X-API-Key` header against the configured
+ * key. Both sides are SHA-256 hashed before comparison so the comparison is
+ * length-independent and does not leak the key (or its length) through response
+ * timing. Returns true only when a non-empty header exactly matches the key.
+ */
+const isApiKeyValid = (
+  configuredKey: string,
+  presented: string | string[] | undefined
+): boolean => {
+  const provided = Array.isArray(presented) ? presented[0] : presented;
+  if (typeof provided !== 'string' || provided.length === 0) return false;
+  const expected = createHash('sha256').update(configuredKey).digest();
+  const actual = createHash('sha256').update(provided).digest();
+  return timingSafeEqual(expected, actual);
+};
+
+const unauthorized = (res: import('node:http').ServerResponse) => {
+  res.writeHead(401, { 'Content-Type': 'application/json', 'WWW-Authenticate': 'X-API-Key' });
+  res.end(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id: null,
+      error: { code: -32001, message: 'Unauthorized: missing or invalid X-API-Key header' },
+    })
+  );
+};
+
 const ensureStreamableAcceptHeader = (req: import('node:http').IncomingMessage) => {
   const accept = req.headers.accept;
   const acceptValues = Array.isArray(accept) ? accept.join(', ') : (accept ?? '');
@@ -138,43 +173,79 @@ const ensureStreamableAcceptHeader = (req: import('node:http').IncomingMessage) 
   req.rawHeaders.push('Accept', 'application/json, text/event-stream');
 };
 
+/**
+ * Resolve a request against the non-MCP routes (health, unknown paths, CORS
+ * preflight) and the API-key gate. Returns true when the request was fully
+ * handled here and the MCP pipeline should be skipped.
+ */
+const handleNonMcpRoute = (
+  req: import('node:http').IncomingMessage,
+  res: import('node:http').ServerResponse,
+  pathname: string,
+  transportConfig: HttpTransportConfig
+): boolean => {
+  if (pathname === '/mcp/health' && req.method === 'GET') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: 'ok' }));
+    return true;
+  }
+
+  if (pathname !== '/mcp') {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+    return true;
+  }
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return true;
+  }
+
+  // Authenticate every data-bearing /mcp request when a key is configured.
+  // Health and CORS-preflight (above) stay open: the former carries no PDF
+  // data, the latter no credentials.
+  if (
+    transportConfig.apiKey !== undefined &&
+    !isApiKeyValid(transportConfig.apiKey, req.headers['x-api-key'])
+  ) {
+    unauthorized(res);
+    return true;
+  }
+
+  return false;
+};
+
+const handleHttpRequest = async (
+  req: import('node:http').IncomingMessage,
+  res: import('node:http').ServerResponse,
+  mcpServer: McpServer,
+  transportConfig: HttpTransportConfig
+): Promise<void> => {
+  const url = new URL(req.url ?? '/', `http://${req.headers.host ?? transportConfig.hostname}`);
+
+  withCors(res, transportConfig.cors);
+
+  if (handleNonMcpRoute(req, res, url.pathname, transportConfig)) return;
+
+  ensureStreamableAcceptHeader(req);
+  const transport = new StreamableHTTPServerTransport({ enableJsonResponse: true });
+
+  try {
+    await mcpServer.connect(transport as unknown as Parameters<McpServer['connect']>[0]);
+    await transport.handleRequest(req, res);
+  } finally {
+    await mcpServer.close();
+  }
+};
+
 const startHttpServer = async (
   serverInfo: Pick<CreateServerOptions, 'name' | 'version' | 'instructions' | 'tools'>,
   transportConfig: HttpTransportConfig
 ): Promise<{ mcpServer: McpServer; httpServer: HttpServer }> => {
   const mcpServer = buildMcpServer(serverInfo);
-  const httpServer = createHttpServer(async (req, res) => {
-    const url = new URL(req.url ?? '/', `http://${req.headers.host ?? transportConfig.hostname}`);
-
-    withCors(res, transportConfig.cors);
-
-    if (url.pathname === '/mcp/health' && req.method === 'GET') {
-      res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ status: 'ok' }));
-      return;
-    }
-
-    if (url.pathname !== '/mcp') {
-      res.writeHead(404, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Not found' }));
-      return;
-    }
-
-    if (req.method === 'OPTIONS') {
-      res.writeHead(204);
-      res.end();
-      return;
-    }
-
-    ensureStreamableAcceptHeader(req);
-    const transport = new StreamableHTTPServerTransport({ enableJsonResponse: true });
-
-    try {
-      await mcpServer.connect(transport as unknown as Parameters<McpServer['connect']>[0]);
-      await transport.handleRequest(req, res);
-    } finally {
-      await mcpServer.close();
-    }
+  const httpServer = createHttpServer((req, res) => {
+    void handleHttpRequest(req, res, mcpServer, transportConfig);
   });
 
   await new Promise<void>((resolve, reject) => {

--- a/test/integration/http-transport.test.ts
+++ b/test/integration/http-transport.test.ts
@@ -217,3 +217,98 @@ describe('MCP Server HTTP Transport Integration', () => {
     expect([-32600, -32700]).toContain(data.error.code);
   });
 });
+
+describe('MCP Server HTTP Transport Authentication', () => {
+  const API_KEY = 'test-secret-key-123';
+  let serverProc: ChildProcess;
+  let authBaseUrl: string;
+
+  beforeAll(async () => {
+    const serverPath = path.resolve(__dirname, '../../dist/index.js');
+    const testPort = await getFreePort();
+    authBaseUrl = `http://${TEST_HOST}:${String(testPort)}/mcp`;
+    serverProc = spawn('bun', [serverPath], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        NODE_ENV: 'test',
+        MCP_TRANSPORT: 'http',
+        MCP_HTTP_PORT: testPort.toString(),
+        MCP_HTTP_HOST: TEST_HOST,
+        MCP_API_KEY: API_KEY,
+      },
+    });
+
+    await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error('Server startup timeout'));
+      }, 10000);
+
+      serverProc.stdout?.on('data', (data) => {
+        if (data.toString().includes('Server running on http://')) {
+          clearTimeout(timeout);
+          setTimeout(resolve, 200);
+        }
+      });
+
+      serverProc.stderr?.on('data', (data) => {
+        console.error('Server stderr:', data.toString());
+      });
+    });
+  });
+
+  afterAll(() => {
+    serverProc?.kill('SIGTERM');
+  });
+
+  const initialize = (headers: Record<string, string>) =>
+    fetch(authBaseUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json', ...headers },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'auth-test-client', version: '1.0.0' },
+        },
+      }),
+    });
+
+  it('rejects requests with no X-API-Key header (401)', async () => {
+    const response = await initialize({});
+    expect(response.status).toBe(401);
+    const data = await response.json();
+    expect(data.error?.message).toContain('X-API-Key');
+  });
+
+  it('rejects requests with a wrong X-API-Key (401)', async () => {
+    const response = await initialize({ 'X-API-Key': 'wrong-key' });
+    expect(response.status).toBe(401);
+  });
+
+  it('accepts requests carrying the correct X-API-Key', async () => {
+    const response = await initialize({ 'X-API-Key': API_KEY });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.result?.serverInfo?.name).toBe('pdf-reader-mcp');
+  });
+
+  it('does not list tools to an unauthenticated caller', async () => {
+    const response = await fetch(authBaseUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }),
+    });
+    expect(response.status).toBe(401);
+  });
+
+  it('keeps the health endpoint open without a key', async () => {
+    const response = await fetch(`${authBaseUrl}/health`);
+    expect(response.ok).toBe(true);
+    const data = await response.json();
+    expect(data.status).toBe('ok');
+  });
+});


### PR DESCRIPTION
## Summary

Security fix for the HTTP transport (`MCP_TRANSPORT=http`). The server read
`MCP_API_KEY` and logged `API key authentication enabled (X-API-Key header)`,
but **never checked the header** — so any client that could reach the port
could call every PDF tool and read any PDF the process can open. The misleading
log made the exposure silent. Present through `v3.0.0`.

- **CWE-306** Missing Authentication for a Critical Function → **CWE-200**
  Information Disclosure.
- Reported privately by **novice-22**. GHSA to follow.
- Boundary: the defect is owned by **this package** (a false auth promise), not
  by an SDK. As of v3 the HTTP layer lives in `src/mcp.ts`, so the fix is fully
  in-repo. See `docs/adr/0002-enforce-http-transport-authentication.md`.

## What changed

- **Enforce `X-API-Key`** on every `/mcp` request when `MCP_API_KEY` is set —
  constant-time (`SHA-256` + `timingSafeEqual`) comparison, `401` on
  missing/mismatched. `/mcp/health` and CORS preflight stay open.
- **Default `MCP_HTTP_HOST` to `127.0.0.1`** (loopback) instead of `0.0.0.0`.
- **Warn at startup** when binding a non-loopback host with no API key.
- **Regression gate:** integration tests for 401 (no key / wrong key), 200
  (correct key), `tools/list` refused unauthenticated, health open.
- Docs, `SECURITY.md` (GitHub private vulnerability reporting), `ADR-0002`,
  changeset.

## ⚠️ Behavior changes (HTTP transport only)

- Servers relying on the `0.0.0.0` default must now set `MCP_HTTP_HOST`
  explicitly to expose non-loopback interfaces.
- Clients talking to a key-protected server must now send the `X-API-Key`
  header (this is the point).
- `stdio` (the default transport) is unaffected.

## Verification

`bun run build && bun test` → **348 pass / 0 fail** (incl. 5 new auth tests);
`biome check` and `tsc --noEmit` clean.

## Notes for review

- Changeset is `patch` (→ `3.0.1`), matching ADR-0002. Bump level is a release
  policy call — switch to `minor`/`major` if you prefer strict semver for the
  default-host + auth behavior changes.
- ADR numbered `0002` to match the repo's sequential scheme (existing `0001`).
- Defaulting the filesystem allowlist to deny-by-default is intentionally **not**
  in this PR (more disruptive, orthogonal to the auth defect) — see ADR-0002.