### PR TITLE
ci: adopt ADR-6 security:secrets gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,17 @@ jobs:
           name: coverage-report
           path: coverage/
 
+  security-secrets:
+    name: security:secrets
+    runs-on: [self-hosted, sylphx-linux-standard]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0 # full history for the new-commit range
+      - name: Secret scan (ADR-6 security:secrets)
+        uses: SylphxAI/.github/.github/actions/secret-scan@main
+
   release-evidence:
     name: Release Evidence Gate
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds the `security:secrets` job calling the org SSOT `SylphxAI/.github/.github/actions/secret-scan@main` (merged in SylphxAI/.github#19). Implements the ADR-6 baseline secret-detection gate: gitleaks over only newly added commits, `--redact`ed, blocking on new secrets. After merge, add `security:secrets` to required checks via the org ruleset (ADR-6 §4).