### PR TITLE
docs: post-release growth — docs site deployment, examples, and benchmark proof

### DIFF
--- a/.changeset/post-release-growth.md
+++ b/.changeset/post-release-growth.md
@@ -1,0 +1,11 @@
+---
+"@sylphx/pdf-reader-mcp": patch
+---
+
+Add GitHub Pages docs deployment workflow, examples directory with Agent Document Twin demo outputs and MCP client snippets, shareable benchmark proof page, and updated docs site navigation.
+
+- New `.github/workflows/docs.yml` deploys the VitePress docs site to GitHub Pages on every push to main.
+- New `examples/` directory with JSON request/response samples for all V3 tools (read_pdf, search_pdf, pdf_evidence) and MCP client installation snippets for Claude Code, Claude Desktop, Cursor, VS Code, Windsurf, Cline, Warp, and HTTP transport.
+- New `docs/benchmark.md` page with reproducible release evidence: 39/39 SOTA release gate checks, 69/69 quality checks, and performance benchmarks.
+- Updated VitePress config: benchmark page in nav and sidebar, corrected og:url and canonical for GitHub Pages.
+- Updated README documentation table with examples and benchmark links.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Docs Site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.12'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build docs
+        run: bun run docs:build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ an evidence workflow, not as a trusted text dump.
 | Getting started | [docs/guide/getting-started.md](docs/guide/getting-started.md) |
 | Installation and clients | [docs/guide/installation.md](docs/guide/installation.md) |
 | API reference | [docs/api/README.md](docs/api/README.md) |
+| Examples and workflows | [examples/](examples/) |
+| Benchmark proof | [docs/benchmark.md](docs/benchmark.md) |
 | Capability overview | [docs/comparison/index.md](docs/comparison/index.md) |
 | Architecture and design | [docs/design/index.md](docs/design/index.md) |
 | Performance and release proof | [docs/performance/index.md](docs/performance/index.md) |

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
           'A TypeScript-first MCP server for Agent Document Twin extraction, visual evidence, OCR provenance, trust reports, accessibility reports, citations, and benchmark-gated release proof',
       },
     ],
-    ['meta', { property: 'og:url', content: 'https://pdf-reader-mcp.sylphx.com' }],
+    ['meta', { property: 'og:url', content: 'https://sylphx-ai.github.io/pdf-reader-mcp/' }],
     ['meta', { property: 'og:site_name', content: 'PDF Reader MCP' }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
     ['meta', { name: 'twitter:title', content: 'PDF Reader MCP' }],
@@ -51,7 +51,7 @@ export default defineConfig({
     ],
     ['meta', { name: 'author', content: 'Sylphx' }],
     ['meta', { name: 'robots', content: 'index, follow' }],
-    ['link', { rel: 'canonical', href: 'https://pdf-reader-mcp.sylphx.com' }],
+    ['link', { rel: 'canonical', href: 'https://sylphx-ai.github.io/pdf-reader-mcp/' }],
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo.svg' }],
   ],
 
@@ -63,6 +63,7 @@ export default defineConfig({
       { text: 'Home', link: '/' },
       { text: 'Guide', link: '/guide/' },
       { text: 'API', link: '/api/' },
+      { text: 'Benchmark', link: '/benchmark' },
       { text: 'Design', link: '/design/' },
       { text: 'Performance', link: '/performance/' },
     ],
@@ -80,6 +81,7 @@ export default defineConfig({
         text: 'Reference',
         items: [
           { text: 'API Reference', link: '/api/' },
+          { text: 'Benchmark Proof', link: '/benchmark' },
           { text: 'Design Philosophy', link: '/design/' },
           { text: 'Performance', link: '/performance/' },
           { text: 'Comparison', link: '/comparison/' },

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,0 +1,99 @@
+---
+layout: doc
+
+title: Benchmark Proof
+description: Reproducible release evidence for PDF Reader MCP V3 — performance, quality, corpus, provider, and SOTA release gate results.
+---
+
+# Benchmark Proof
+
+Every PDF Reader MCP release is gated by reproducible, machine-checked benchmarks.
+The numbers below come from the checked-in release artifacts in
+`benchmark-artifacts/` and are produced by `bun run benchmark:release-gate`.
+
+## SOTA Release Gate
+
+| Metric | Result |
+| --- | --- |
+| Total checks | 39 |
+| Passing checks | 39 |
+| Failed checks | 0 |
+| Gate status | **Passed** ✅ |
+
+The release gate enforces deterministic quality coverage, corpus benchmark
+completeness, provider certification, package smoke, and cross-artifact
+consistency. It exits non-zero if any check fails.
+
+## Quality Benchmark
+
+| Metric | Result |
+| --- | --- |
+| Score | 1.0 (perfect) |
+| Deterministic quality checks | 69 / 69 passing ✅ |
+| Final-bar coverage | 5 / 5 deterministic + 4 / 4 provider-required |
+
+Quality checks cover document-signal detection, reading-order fidelity,
+scanned-PDF routing, text-layer structure, table extraction, trust-report
+signals, accessibility reporting, and provider manifest scoring — all against
+deterministic synthetic and runtime-generated fixtures.
+
+## Performance Benchmark
+
+Measured on the checked-in sample fixture (`test/fixtures/sample.pdf`) with
+20 iterations after 3 warmup iterations. Results are machine- and
+fixture-specific; reproduce with `bun run benchmark`.
+
+| Scenario | Average | Min | Max |
+| --- | --- | --- | --- |
+| Metadata + page count | 1.1 ms | 0.6 ms | 2.6 ms |
+| Full text extraction | 16.1 ms | 10.3 ms | 21.1 ms |
+| Single-page text | 13.7 ms | 8.3 ms | 24.4 ms |
+| Agent Document Twin | 27.2 ms | 20.1 ms | 39.0 ms |
+
+The **Agent Document Twin** scenario includes document map, text layer,
+semantic AST, trust report, accessibility report, citation chunks, layout
+diagnostics, tables, and trust/accessibility routing — all in one call.
+
+## Reproduce
+
+```bash
+# Performance benchmark only
+bun run benchmark
+
+# All benchmark profiles
+MCP_PDF_BENCHMARK_OUTPUT_DIR=./benchmark-artifacts bun run benchmark:all
+
+# Provider-certified release artifacts
+MCP_PDF_BENCHMARK_OUTPUT_DIR=./benchmark-artifacts MCP_PDF_PROVIDER_BENCHMARK_REQUIRED=true bun run benchmark:all
+bun run benchmark:release-artifacts
+
+# Run the SOTA release gate
+MCP_PDF_BENCHMARK_OUTPUT_DIR=./benchmark-artifacts bun run benchmark:release-gate
+```
+
+All benchmark scripts print JSON to stdout and can write formatted artifacts
+with `--output <path>` or `--output-dir <dir>`.
+
+## What This Proves
+
+- **Quality is deterministic**: 69/69 synthetic quality checks pass on every run,
+  not just on the release machine.
+- **Performance is bounded**: full Agent Document Twin extraction completes in
+  under 40 ms on a small fixture, with the metadata path under 3 ms.
+- **Release is gated**: no version ships unless all 39 release-gate checks pass.
+- **Providers are certified**: OCR, region analysis, and visual enrichment
+  providers are tested against deterministic manifests and crop substrates.
+- **Package is smoke-tested**: the published tarball is installed and exercised
+  before any release.
+
+## Benchmark Artifacts
+
+| Artifact | What it gates |
+| --- | --- |
+| `pdf_sota_release_gate.json` | Cross-artifact release gate (39 checks) |
+| `pdf_quality_benchmark.json` | Deterministic quality (69 checks, score 1.0) |
+| `pdf_performance_benchmark.json` | Latency across 4 fixed scenarios |
+| `pdf_corpus_benchmark.json` | Corpus-style PDF intelligence assertions |
+| `pdf_provider_benchmark.json` | Provider profiles (4 certified) |
+| `pdf_provider_manifest_benchmark.json` | Table, formula, chart, figure, image scoring |
+| `pdf_provider_manifest_crop_benchmark.json` | Deterministic crop-substrate proof |

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,8 @@ hero:
       link: https://github.com/SylphxAI/pdf-reader-mcp
     - theme: alt
       text: Benchmark Proof
-      link: /performance/
+      link: /benchmark
+      
 
 features:
   - icon: "\U0001F4C4"

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,151 @@
+# Examples
+
+Real-world workflows showing how AI agents use PDF Reader MCP to read, search,
+verify, and cite PDF documents with evidence.
+
+## Quick Examples
+
+| File | What it shows |
+| --- | --- |
+| [`read-pdf-basic.json`](./read-pdf-basic.json) | One-call smart read: `read_pdf` with only `sources` |
+| [`read-pdf-options.json`](./read-pdf-options.json) | Manual extraction with `include_*` flags |
+| [`search-then-verify.json`](./search-then-verify.json) | `search_pdf` → `pdf_evidence` workflow |
+| [`evidence-crop.json`](./evidence-crop.json) | Extract a region crop for citation |
+| [`ocr-scanned.json`](./ocr-scanned.json) | OCR path for scanned PDFs |
+| [`agent-document-twin.json`](./agent-document-twin.json) | Full Agent Document Twin output shape |
+
+## MCP Client Snippets
+
+### Claude Code
+
+```bash
+claude mcp add pdf-reader -- npx @sylphx/pdf-reader-mcp
+```
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "pdf-reader": {
+      "command": "npx",
+      "args": ["@sylphx/pdf-reader-mcp"]
+    }
+  }
+}
+```
+
+### Cursor
+
+```json
+{
+  "mcpServers": {
+    "pdf-reader": {
+      "command": "npx",
+      "args": ["@sylphx/pdf-reader-mcp"]
+    }
+  }
+}
+```
+
+### VS Code (Copilot Chat MCP)
+
+Add to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "pdf-reader": {
+      "command": "npx",
+      "args": ["@sylphx/pdf-reader-mcp"]
+    }
+  }
+}
+```
+
+### Windsurf
+
+```json
+{
+  "mcpServers": {
+    "pdf-reader": {
+      "command": "npx",
+      "args": ["@sylphx/pdf-reader-mcp"]
+    }
+  }
+}
+```
+
+### Cline
+
+Add to `cline_mcp_settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "pdf-reader": {
+      "command": "npx",
+      "args": ["@sylphx/pdf-reader-mcp"]
+    }
+  }
+}
+```
+
+### Warp Terminal
+
+```toml
+[mcp.pdf-reader]
+command = "npx"
+args = ["@sylphx/pdf-reader-mcp"]
+```
+
+### HTTP Transport (Remote)
+
+```bash
+MCP_TRANSPORT=http MCP_API_KEY=your-secret npx @sylphx/pdf-reader-mcp
+```
+
+Then connect any MCP client to `http://127.0.0.1:3000/mcp` with header
+`X-API-Key: your-secret`.
+
+## Agent Workflow Patterns
+
+### Pattern 1: Read First, Ask Questions Later
+
+```
+Agent → read_pdf(sources) → gets Agent Document Twin (markdown, chunks, tables, trust report)
+Agent → uses the twin to answer the user's question
+Agent → cites page numbers and evidence IDs from the twin
+```
+
+This is the default V3 path. One call, full document intelligence.
+
+### Pattern 2: Search, Then Verify
+
+```
+Agent → search_pdf(sources, query) → gets literal matches with page/box provenance
+Agent → pdf_evidence(operation: render_page, page) → visual proof of the match
+Agent → pdf_evidence(operation: extract_regions, regions) → crops the exact evidence
+```
+
+Cheap search first, spend context only on relevant evidence.
+
+### Pattern 3: Trust-Check Before Citing
+
+```
+Agent → read_pdf(sources) → gets trust_report in the twin
+Agent → reviews trust warnings (hidden text, prompt-injection-like content)
+Agent → decides whether to cite or flag as untrusted
+```
+
+Prevents agents from citing manipulated or unsafe PDF content.
+
+### Pattern 4: Scanned Document Recovery
+
+```
+Agent → read_pdf(sources) → auto-routes scanned pages to OCR if provider is ready
+Agent → pdf_evidence(operation: ocr_pages, pages) → explicit OCR with word boxes
+Agent → pdf_evidence(operation: analyze_regions, regions) → table/formula/chart enrichment
+```
+
+Scanned pages get OCR provenance linked back to source renders.

--- a/examples/agent-document-twin.json
+++ b/examples/agent-document-twin.json
@@ -1,0 +1,96 @@
+{
+  "tool": "read_pdf",
+  "description": "Full Agent Document Twin output shape (abbreviated). This is what read_pdf returns when auto_detail is 'full'.",
+  "_response_shape": {
+    "results": [
+      {
+        "source": { "path": "/absolute/path/to/report.pdf" },
+        "auto_read": {
+          "profile": {
+            "page_count": 42,
+            "has_selectable_text": true,
+            "has_embedded_fonts": true,
+            "is_likely_scanned": false,
+            "has_tables": true,
+            "has_forms": false,
+            "has_annotations": true
+          },
+          "workflow": "digital_text_route",
+          "provider_readiness": {
+            "ocr": "not_required",
+            "region_analysis": "available"
+          },
+          "selected_arguments": {
+            "include_markdown": true,
+            "include_tables": true,
+            "include_chunks": true,
+            "include_trust_report": true,
+            "include_accessibility_report": true,
+            "include_document_map": true,
+            "include_document_ast": true
+          }
+        },
+        "markdown": "# Annual Report 2026\n\n## Executive Summary\n\n...",
+        "page_count": 42,
+        "metadata": {
+          "title": "Annual Report 2026",
+          "author": "Example Corp",
+          "creationDate": "D:20260101000000Z"
+        },
+        "tables": [
+          {
+            "page": 5,
+            "rows": 4,
+            "columns": 3,
+            "cells": [
+              { "row": 0, "col": 0, "text": "Quarter", "bbox": [72, 650, 180, 670] },
+              { "row": 0, "col": 1, "text": "Revenue", "bbox": [200, 650, 300, 670] },
+              { "row": 0, "col": 2, "text": "Growth", "bbox": [320, 650, 400, 670] }
+            ],
+            "confidence": 0.95,
+            "quality_warnings": []
+          }
+        ],
+        "chunks": [
+          {
+            "id": "chunk-0001",
+            "type": "semantic",
+            "page": 1,
+            "text": "Executive Summary: The company achieved record revenue...",
+            "bbox": [72, 200, 540, 350]
+          }
+        ],
+        "document_map": {
+          "pages": [
+            {
+              "page": 1,
+              "elements": [
+                { "id": "el-001", "type": "heading", "text": "Annual Report 2026", "bbox": [72, 50, 540, 90] },
+                { "id": "el-002", "type": "heading", "text": "Executive Summary", "bbox": [72, 120, 540, 145] },
+                { "id": "el-003", "type": "paragraph", "text": "The company achieved...", "bbox": [72, 200, 540, 350] }
+              ]
+            }
+          ]
+        },
+        "trust_report": {
+          "findings": [
+            {
+              "type": "hidden_text",
+              "page": 7,
+              "severity": "medium",
+              "description": "Text layer contains content outside visible page bounds"
+            }
+          ],
+          "overall_risk": "low"
+        },
+        "accessibility_report": {
+          "tagged_pdf": false,
+          "page_grades": [
+            { "page": 1, "grade": "C", "issues": ["missing_heading_structure"] }
+          ]
+        },
+        "warnings": []
+      }
+    ]
+  }
+}

--- a/examples/evidence-crop.json
+++ b/examples/evidence-crop.json
@@ -1,0 +1,21 @@
+{
+  "tool": "pdf_evidence",
+  "description": "Extract a specific region crop for citation evidence.",
+  "arguments": {
+    "operation": "extract_regions",
+    "sources": [
+      {
+        "path": "/absolute/path/to/financial-report.pdf",
+        "regions": [
+          {
+            "page": 3,
+            "bbox": [72, 400, 540, 520],
+            "label": "Q4 Revenue Table"
+          }
+        ]
+      }
+    ],
+    "include_image": true,
+    "scale": 2.0
+  }
+}

--- a/examples/ocr-scanned.json
+++ b/examples/ocr-scanned.json
@@ -1,0 +1,16 @@
+{
+  "tool": "pdf_evidence",
+  "description": "OCR path for scanned PDFs. Requires a configured local OCR provider (e.g. tesseract).",
+  "arguments": {
+    "operation": "ocr_pages",
+    "sources": [
+      { "path": "/absolute/path/to/scanned-document.pdf" }
+    ],
+    "max_pages": 5,
+    "max_output_chars": 50000
+  },
+  "_provider_setup": {
+    "env": "MCP_PDF_OCR_PRESET=tesseract-tsv",
+    "note": "Set this environment variable before starting the MCP server. The server auto-detects tesseract on PATH."
+  }
+}

--- a/examples/read-pdf-basic.json
+++ b/examples/read-pdf-basic.json
@@ -1,0 +1,10 @@
+{
+  "tool": "read_pdf",
+  "description": "Smart one-call read: profile the PDF, choose the extraction route, return the Agent Document Twin.",
+  "arguments": {
+    "sources": [
+      { "path": "/absolute/path/to/report.pdf" }
+    ]
+  },
+  "_note": "With only sources and no include_* flags, read_pdf auto-inspects each PDF and chooses the best route."
+}

--- a/examples/read-pdf-options.json
+++ b/examples/read-pdf-options.json
@@ -1,0 +1,17 @@
+{
+  "tool": "read_pdf",
+  "description": "Manual extraction with explicit include_* flags and full detail depth.",
+  "arguments": {
+    "sources": [
+      { "path": "/absolute/path/to/contract.pdf" }
+    ],
+    "auto": false,
+    "include_markdown": true,
+    "include_tables": true,
+    "include_chunks": true,
+    "include_trust_report": true,
+    "include_accessibility_report": true,
+    "include_document_map": true,
+    "include_document_ast": true
+  }
+}

--- a/examples/search-then-verify.json
+++ b/examples/search-then-verify.json
@@ -1,0 +1,28 @@
+[
+  {
+    "step": 1,
+    "tool": "search_pdf",
+    "description": "Cheap literal search with evidence provenance before spending context on full reads.",
+    "arguments": {
+      "sources": [
+        { "path": "/absolute/path/to/spec.pdf" }
+      ],
+      "query": "warranty period",
+      "max_matches_per_source": 10,
+      "context_chars": 200
+    }
+  },
+  {
+    "step": 2,
+    "tool": "pdf_evidence",
+    "description": "Render the page containing the match for visual proof.",
+    "arguments": {
+      "operation": "render_page",
+      "sources": [
+        { "path": "/absolute/path/to/spec.pdf" }
+      ],
+      "max_pages": 1,
+      "include_image": true
+    }
+  }
+]


### PR DESCRIPTION
## Summary

Post-release growth work to strengthen first impression, discovery, and competitive proof.

### Changes

**GitHub Pages Deployment**
- New `.github/workflows/docs.yml` — deploys VitePress docs site to GitHub Pages on every push to main
- Updated `og:url` and `canonical` to `https://sylphx-ai.github.io/pdf-reader-mcp/`

**Examples Directory**
- New `examples/` with JSON request/response samples for all V3 tools:
  - `read-pdf-basic.json` — one-call smart read
  - `read-pdf-options.json` — manual extraction with include_* flags
  - `search-then-verify.json` — search → render_page workflow
  - `evidence-crop.json` — region crop for citation
  - `ocr-scanned.json` — OCR path for scanned PDFs
  - `agent-document-twin.json` — full output shape
- MCP client snippets for Claude Code, Claude Desktop, Cursor, VS Code, Windsurf, Cline, Warp, and HTTP transport
- Agent workflow patterns (read-first, search-then-verify, trust-check, scanned recovery)

**Benchmark Proof Page**
- New `docs/benchmark.md` with real numbers from checked-in artifacts:
  - SOTA release gate: 39/39 checks passing
  - Quality benchmark: 69/69 deterministic checks, score 1.0
  - Performance: Agent Document Twin in ~27ms average
  - Reproduction commands
- Added to VitePress nav and sidebar

**README Updates**
- Documentation table now includes examples and benchmark links

**VitePress Config**
- Benchmark page in top nav and sidebar
- Hero CTA "Benchmark Proof" now links to the dedicated page

### Verification
- ✅ `bun run docs:build` passes
- ✅ `bun run check` (Biome) passes
- ✅ `bun run typecheck` (tsc) passes
- ✅ No competitor mentions
- ✅ No banned Sylphx foundation packages reintroduced
- ✅ No runtime code changes

### GitHub Metadata (already applied)
- ✅ Repo description updated to V3 positioning
- ✅ Topics updated with V3 keywords (agent-document-twin, evidence-first, document-intelligence, ocr, citations, rag, pdf-intelligence, trust-report, visual-evidence, pdf-to-markdown)
- ✅ Homepage URL set to docs site