### PR TITLE
chore: add GHCR Docker workflow, fix CONTRIBUTING.md, fix copyright consistency

### DIFF
--- a/.changeset/sota-tier4-consistency.md
+++ b/.changeset/sota-tier4-consistency.md
@@ -1,0 +1,10 @@
+---
+"@sylphx/pdf-reader-mcp": patch
+---
+
+Add GHCR Docker publish workflow, fix CONTRIBUTING.md staleness, fix copyright consistency.
+
+- New `.github/workflows/docker.yml` — builds and pushes Docker image to GitHub Container Registry on main push and version tags, so the `ghcr.io/sylphxai/pdf-reader-mcp` reference resolves to a real image
+- Rewrote `CONTRIBUTING.md` — fixed stale org name (sylphlab → SylphxAI), corrected tooling references (ESLint/Prettier → Biome), corrected commands (npm → bun), added development setup and release process guidance
+- Fixed VitePress footer copyright (2024 Sylphx → 2024-2026 SylphxAI)
+- Updated README Docker section to show both GHCR pre-built image and local build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,57 @@
+name: Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build and Push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,53 +1,72 @@
-# Contributing to PDF Reader MCP Server
+# Contributing to PDF Reader MCP
 
 Thank you for considering contributing! We welcome contributions from the community.
 
 ## How to Contribute
 
-1.  **Reporting Issues:** If you find a bug or have a feature request, please open an issue on GitHub.
+1. **Reporting Issues:** If you find a bug or have a feature request, please open an issue on GitHub.
+   - Provide a clear description of the issue.
+   - Include steps to reproduce (for bugs).
+   - Explain the motivation for the feature request.
 
-    - Provide a clear description of the issue.
-    - Include steps to reproduce (for bugs).
-    - Explain the motivation for the feature request.
-
-2.  **Submitting Pull Requests:**
-    - Fork the repository.
-    - Create a new branch for your feature or bugfix (e.g., `feature/new-pdf-feature` or `bugfix/parsing-error`).
-    - Make your changes, adhering to the project's coding style and guidelines (ESLint, Prettier).
-    - Add tests for your changes and ensure all tests pass (`npm test`).
-    - Ensure your commit messages follow the Conventional Commits standard.
-    - Push your branch to your fork.
-    - Open a Pull Request against the `main` branch of the `sylphlab/pdf-reader-mcp` repository.
-    - Provide a clear description of your changes in the PR.
+2. **Submitting Pull Requests:**
+   - Fork the repository.
+   - Create a new branch for your feature or bugfix (e.g., `feature/new-pdf-feature` or `bugfix/parsing-error`).
+   - Make your changes, adhering to the project's coding style and guidelines.
+   - Add tests for your changes and ensure all tests pass.
+   - Ensure your commit messages follow the conventional commits standard.
+   - Push your branch to your fork.
+   - Open a Pull Request against the `main` branch of the [SylphxAI/pdf-reader-mcp](https://github.com/SylphxAI/pdf-reader-mcp) repository.
 
 ## Development Setup
 
-1.  Clone the repository: `git clone https://github.com/sylphlab/pdf-reader-mcp.git`
-2.  Navigate into the directory: `cd pdf-reader-mcp`
-3.  Install dependencies: `npm install`
-4.  Build the project: `npm run build`
-5.  Run tests: `npm test`
-6.  Use `npm run watch` during development for automatic recompilation.
-7.  Use `npm run validate` before committing to check formatting, linting, and tests.
+This project uses [Bun](https://bun.sh/) and [Biome](https://biomejs.dev/).
 
-## Code Style
+### Prerequisites
 
-- We use Prettier for code formatting and ESLint (with strict TypeScript rules) for linting.
-- Please run `npm run format` and `npm run lint:fix` before committing your changes.
-- Git hooks are set up using Husky and lint-staged to automatically check staged files.
+- Node.js >= 22.13.0
+- Bun >= 1.3.12
 
-## Commit Messages
+### Getting Started
 
-We follow the [Conventional Commits](https://www.conventionalcommits.org/) specification. Commit messages are linted using `commitlint` via a Git hook.
-
-Example:
-
+```bash
+git clone https://github.com/SylphxAI/pdf-reader-mcp.git
+cd pdf-reader-mcp
+bun install
+bun run build
 ```
-feat: add support for encrypted PDFs
 
-Implemented handling for password-protected PDF files using an optional password parameter.
+### Useful Commands
+
+```bash
+bun run check          # Lint and format check (Biome)
+bun run check:fix      # Auto-fix lint and format issues
+bun run typecheck      # TypeScript type checking
+bun test               # Run tests
+bun run test:cov       # Run tests with coverage
+bun run build          # Build the package
+bun run package:smoke  # Verify package tarball
+bun run docs:build     # Build docs site
+bun run benchmark      # Run performance benchmark
 ```
+
+### Coding Standards
+
+- **Formatting and linting:** Handled by Biome (configuration in `biome.json`). Run `bun run check` before submitting.
+- **Testing:** Write tests using Bun's built-in test runner. Place test files in `test/` mirroring the source structure.
+- **Types:** All code must pass `bun run typecheck` with no errors.
+- **Commits:** Follow conventional commits (e.g., `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`).
+
+### Release Process
+
+Releases are automated via [Changesets](https://github.com/changesets/changesets):
+
+1. Add a changeset describing your change: `bunx changeset`
+2. The changeset bot will create a "Version Packages" PR when changesets accumulate.
+3. Merging the version PR triggers the release workflow to publish to npm and create a GitHub Release.
+
+Do not manually publish to npm or create tags/releases.
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License that covers the project.
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,12 @@ OCR models, vision models, Ollama, LM Studio, llama.cpp, or cloud credentials.
 ### Docker
 
 ```bash
+# Pre-built image from GitHub Container Registry
 docker run --rm -i -v /path/to/pdfs:/workspace ghcr.io/sylphxai/pdf-reader-mcp
+
+# Or build locally
+docker build -t pdf-reader-mcp . && \
+  docker run --rm -i -v /path/to/pdfs:/workspace pdf-reader-mcp
 ```
 
 Need Cursor, VS Code, Windsurf, Cline, Warp, HTTP transport, Docker customization, or

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -136,7 +136,7 @@ export default defineConfig({
 
     footer: {
       message: 'Released under the MIT License.',
-      copyright: 'Copyright 2024 Sylphx',
+      copyright: 'Copyright 2024-2026 SylphxAI',
     },
 
     search: {


### PR DESCRIPTION
## Summary

Fixes three concrete consistency gaps that would confuse new contributors and Docker users.

### Changes

**GHCR Docker Workflow**
- New `.github/workflows/docker.yml` — builds and pushes Docker image to `ghcr.io/sylphxai/pdf-reader-mcp` on main push and version tags
- The README already references this image; now it will actually exist
- Uses semantic versioning tags: `latest`, `3.0`, `3.0.4`, etc.
- Includes build cache via GitHub Actions cache

**CONTRIBUTING.md Rewrite**
- Fixed stale org name: `sylphlab/pdf-reader-mcp` → `SylphxAI/pdf-reader-mcp`
- Fixed tooling references: ESLint/Prettier → Biome
- Fixed commands: `npm test` → `bun test`, added `bun run check`, `bun run typecheck`
- Added development setup section (prerequisites, getting started, useful commands)
- Added coding standards (Biome, Bun test runner, TypeScript, conventional commits)
- Added release process documentation (Changesets flow)

**Copyright Fix**
- VitePress footer: `Copyright 2024 Sylphx` → `Copyright 2024-2026 SylphxAI`

**README Docker Section**
- Added local `docker build` fallback alongside the GHCR reference

### Verification
- ✅ `bun run docs:build` passes
- ✅ `bun run check` (Biome) passes
- ✅ `bun run typecheck` (tsc) passes
- ✅ No competitor mentions
- ✅ No runtime code changes