### PR TITLE
fix(docs): set VitePress base path for GitHub Pages subpath

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitepress';
 
 export default defineConfig({
+  base: '/pdf-reader-mcp/',
+  cleanUrls: true,
   title: 'PDF Reader MCP',
   description:
     'Full-fidelity PDF intelligence MCP with Agent Document Twin, visual evidence, OCR provenance, trust reports, accessibility reports, citations, and benchmark proof for AI agents',


### PR DESCRIPTION
## Critical Fix

The docs site at `sylphxai.github.io/pdf-reader-mcp/` is completely broken — no CSS, JS, fonts, or images load because VitePress builds assets to `/assets/...` (root) instead of `/pdf-reader-mcp/assets/...` (subpath).

### Root Cause

VitePress `base` was not set. The site is hosted at a GitHub Pages subpath (`/pdf-reader-mcp/`), so all asset paths resolved to the wrong location and 404'd.

### Fix

- Add `base: '/pdf-reader-mcp/'` to VitePress config
- Add `cleanUrls: true` for clean URL paths

### Verification

- ✅ `bun run docs:build` — asset paths now correctly include `/pdf-reader-mcp/` prefix
- ✅ `bun run check` passes
- ✅ `bun run typecheck` passes

Before: `src="/assets/app.OIi0bGPy.js"` → 404
After: `src="/pdf-reader-mcp/assets/app.CjwrVFZL.js"` → 200