### PR TITLE
refactor: consolidate last duplicate geometry helpers

### DIFF
--- a/.changeset/consolidate-final-dupes.md
+++ b/.changeset/consolidate-final-dupes.md
@@ -1,0 +1,16 @@
+---
+"@sylphx/pdf-reader-mcp": patch
+---
+
+Consolidate last remaining duplicate geometry helpers.
+
+- Remove local `roundRatio` from `documentModel.ts` and `ocr.ts` — now import from `utils/geometry.ts`
+- Remove local `mergeBoxes` from `documentModel.ts` — replaced with `mergeBoundingBoxes` from `utils/geometry.ts`
+- Remove local `mergeBoundingBoxes` from `search.ts` — now imports from `utils/geometry.ts`
+
+After this change there is exactly ONE definition of each geometry helper:
+- `roundRatio`: 1 (was 3)
+- `mergeBoundingBoxes`: 1 (was 3 counting `mergeBoxes`)
+- Zero local duplicates remain.
+
+377 tests pass. No behavior changes.

--- a/src/pdf/documentModel.ts
+++ b/src/pdf/documentModel.ts
@@ -12,6 +12,7 @@ import type {
   PdfTextSemanticHint,
   PdfTextSemanticRole,
 } from '../types/pdf.js';
+import { mergeBoundingBoxes, roundRatio } from '../utils/geometry.js';
 import { hasSemanticCaptionPrefix } from './semanticPatterns.js';
 import { tablesToMarkdown } from './tableExtractor.js';
 
@@ -635,8 +636,6 @@ export const buildCitationChunks = (
   return chunks;
 };
 
-const roundRatio = (value: number): number => Math.round(value * 100) / 100;
-
 const clampConfidence = (value: number): number => Math.max(0.2, Math.min(0.98, roundRatio(value)));
 
 const boxWidth = (box: PageContentItem['bounding_box']): number =>
@@ -867,20 +866,6 @@ const snippetFromText = (value: string): string => {
 const normalizeSafetyText = (value: string): string =>
   value.replace(/\s+/g, ' ').trim().toLowerCase();
 
-const mergeBoxes = (
-  first: PageContentItem['bounding_box'],
-  second: PageContentItem['bounding_box']
-): PageContentItem['bounding_box'] | undefined => {
-  if (!first || !second) return first ?? second;
-
-  return {
-    left: Math.min(first.left, second.left),
-    bottom: Math.min(first.bottom, second.bottom),
-    right: Math.max(first.right, second.right),
-    top: Math.max(first.top, second.top),
-  };
-};
-
 const isOutsideViewBox = (
   box: PageContentItem['bounding_box'],
   viewBox: PdfPageGeometry['view_box']
@@ -1022,7 +1007,7 @@ export const buildSafetyFindings = (
         if (overlapRatio < SAFETY_TEXT_OVERLAP_RATIO) continue;
 
         const differentText = normalizeSafetyText(first.text) !== normalizeSafetyText(second.text);
-        const boundingBox = mergeBoxes(first.bounding_box, second.bounding_box);
+        const boundingBox = mergeBoundingBoxes([first.bounding_box, second.bounding_box]);
         findings.push({
           type: 'overlapping_text',
           severity: differentText ? 'high' : 'medium',

--- a/src/pdf/ocr.ts
+++ b/src/pdf/ocr.ts
@@ -12,6 +12,7 @@ import type {
   PdfSource,
 } from '../types/pdf.js';
 import { ErrorCode, PdfError } from '../utils/errors.js';
+import { roundRatio } from '../utils/geometry.js';
 import { createLogger } from '../utils/logger.js';
 import { execFileAsync } from '../utils/pdfjs.js';
 import {
@@ -107,7 +108,6 @@ export const defaultOcrPagesOptions = (): OcrPagesOptions => ({
   max_output_chars: DEFAULT_OCR_MAX_OUTPUT_CHARS,
 });
 
-const roundRatio = (value: number): number => Math.round(value * 100) / 100;
 const roundCoordinate = (value: number): number => Math.round(value * 100) / 100;
 
 const normalizeWordBoxesToPdfCoordinates = (

--- a/src/pdf/search.ts
+++ b/src/pdf/search.ts
@@ -9,6 +9,7 @@ import type {
   SearchPdfOptions,
 } from '../types/pdf.js';
 import { ErrorCode, PdfError } from '../utils/errors.js';
+import { mergeBoundingBoxes } from '../utils/geometry.js';
 import { createLogger } from '../utils/logger.js';
 import { destroyLoadingTask } from '../utils/pdfjs.js';
 import { buildWarnings, extractPageContent } from './extractor.js';
@@ -94,22 +95,6 @@ const findMatchesInText = (
   }
 
   return matches;
-};
-
-const mergeBoundingBoxes = (
-  boxes: Array<NonNullable<PageContentItem['bounding_box']> | PdfOcrWord['bounding_box']>
-): NonNullable<PageContentItem['bounding_box']> | undefined => {
-  const validBoxes = boxes.filter(
-    (box): box is NonNullable<PageContentItem['bounding_box']> => box !== undefined
-  );
-  if (validBoxes.length === 0) return undefined;
-
-  return {
-    left: Math.min(...validBoxes.map((box) => box.left)),
-    bottom: Math.min(...validBoxes.map((box) => box.bottom)),
-    right: Math.max(...validBoxes.map((box) => box.right)),
-    top: Math.max(...validBoxes.map((box) => box.top)),
-  };
 };
 
 interface OcrWordOffset {


### PR DESCRIPTION
Eliminates the final DRY violations found during completion audit.

- roundRatio: 3 definitions (geometry.ts, documentModel.ts, ocr.ts) → 1 (shared util)
- mergeBoundingBoxes/mergeBoxes: 3 definitions (geometry.ts, documentModel.ts, search.ts) → 1 (shared util)

Zero local duplicates remain. 377 tests pass. -14 lines net.