### PR TITLE
Dogfood GroundAtlas package gate

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -68,6 +68,11 @@
         "type": "status-context",
         "name": "Required branch context",
         "location": "Validate Code Quality"
+      },
+      {
+        "type": "manifest",
+        "name": "Vendor-neutral GroundAtlas project manifest",
+        "location": "project.manifest.json"
       }
     ],
     "allowedDependencies": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,60 @@ jobs:
           name: coverage-report
           path: coverage/
 
+  groundatlas:
+    name: groundatlas package dogfood
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22.14.0"
+
+      - name: Run GroundAtlas package gate
+        id: groundatlas
+        uses: SylphxAI/groundatlas@v0.1.2
+        with:
+          package-spec: groundatlas@0.1.2
+          output-dir: .groundatlas-pilot
+          require-atlas: "true"
+          strict: "true"
+
+      - name: Assert GroundAtlas truth boundary
+        run: |
+          node - "${{ steps.groundatlas.outputs.manifest-report-path }}" "${{ steps.groundatlas.outputs.fleet-report-path }}" <<'NODE'
+          const [manifestPath, fleetPath] = process.argv.slice(2);
+          const { readFileSync } = require("node:fs");
+          const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+          const fleet = JSON.parse(readFileSync(fleetPath, "utf8"));
+          const project = fleet.projects?.[0];
+
+          function assert(condition, message) {
+            if (!condition) throw new Error(message);
+          }
+
+          assert(manifest.selected?.path === "project.manifest.json", "GroundAtlas must select the vendor-neutral project.manifest.json file.");
+          assert(manifest.selected?.adapter === false, "Selected GroundAtlas manifest must not be an ecosystem adapter.");
+          assert(manifest.adapters?.some((item) => item.path === ".doctrine/project.json" && item.adapter === true), "Doctrine project manifest must be reported only as an adapter.");
+          assert(fleet.summary?.blocked === 0, "GroundAtlas fleet report must not have blocked projects.");
+          assert(fleet.summary?.warning === 0, "GroundAtlas strict fleet report must not have warning projects.");
+          assert(project?.status === "adopted", "This repository must be adopted in the GroundAtlas fleet report.");
+          assert(project?.manifest?.path === "project.manifest.json", "Fleet report must select project.manifest.json.");
+          assert(project?.manifestAdapters?.some((item) => item.path === ".doctrine/project.json" && item.adapter === true), "Fleet report must keep .doctrine/project.json as an adapter.");
+          NODE
+
+      - name: Upload GroundAtlas reports
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: groundatlas-package-dogfood
+          path: |
+            ${{ steps.groundatlas.outputs.manifest-report-path }}
+            ${{ steps.groundatlas.outputs.fleet-report-path }}
+          if-no-files-found: error
+
   security-secrets:
     name: security:secrets
     runs-on: [self-hosted, sylphx-linux-standard]

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -12,6 +12,7 @@ evidence without becoming a hosted Sylphx Platform BaaS service.
 - Layer: `tooling`
 - Doctrine source of truth: [SylphxAI/doctrine](https://github.com/SylphxAI/doctrine)
 - Machine manifest: `.doctrine/project.json`
+- Vendor-neutral GroundAtlas manifest: `project.manifest.json`
 
 ## Goals
 

--- a/project.manifest.json
+++ b/project.manifest.json
@@ -9,38 +9,16 @@
     "visibility": "open-source",
     "repository": "https://github.com/SylphxAI/pdf-reader-mcp",
     "homepage": "https://sylphxai.github.io/pdf-reader-mcp/",
-    "tags": [
-      "mcp",
-      "pdf",
-      "document-intelligence",
-      "tooling",
-      "local-first"
-    ]
+    "tags": ["mcp", "pdf", "document-intelligence", "tooling", "local-first"]
   },
   "truth": {
     "humanProjectFile": "PROJECT.md",
     "agentAdapter": "AGENTS.md",
-    "specs": [
-      "docs/specs/"
-    ],
-    "adrs": [
-      "docs/adr/"
-    ],
-    "source": [
-      "src/",
-      "scripts/",
-      "package.json",
-      "tsconfig.json"
-    ],
-    "tests": [
-      "test/",
-      "src/"
-    ],
-    "runbooks": [
-      "README.md",
-      "CONTRIBUTING.md",
-      "SECURITY.md"
-    ]
+    "specs": ["docs/specs/"],
+    "adrs": ["docs/adr/"],
+    "source": ["src/", "scripts/", "package.json", "tsconfig.json"],
+    "tests": ["test/", "src/"],
+    "runbooks": ["README.md", "CONTRIBUTING.md", "SECURITY.md"]
   },
   "surfaces": [
     {

--- a/project.manifest.json
+++ b/project.manifest.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://raw.githubusercontent.com/SylphxAI/groundatlas/main/schemas/project.manifest.schema.json",
+  "schemaVersion": 1,
+  "project": {
+    "id": "pdf-reader-mcp",
+    "name": "PDF Reader MCP",
+    "summary": "Local-first public MCP package for PDF and document intelligence with typed tools, provenance, OCR routing, trust/accessibility reports, benchmarks, docs, and release evidence.",
+    "lifecycle": "production",
+    "visibility": "open-source",
+    "repository": "https://github.com/SylphxAI/pdf-reader-mcp",
+    "homepage": "https://sylphxai.github.io/pdf-reader-mcp/",
+    "tags": [
+      "mcp",
+      "pdf",
+      "document-intelligence",
+      "tooling",
+      "local-first"
+    ]
+  },
+  "truth": {
+    "humanProjectFile": "PROJECT.md",
+    "agentAdapter": "AGENTS.md",
+    "specs": [
+      "docs/specs/"
+    ],
+    "adrs": [
+      "docs/adr/"
+    ],
+    "source": [
+      "src/",
+      "scripts/",
+      "package.json",
+      "tsconfig.json"
+    ],
+    "tests": [
+      "test/",
+      "src/"
+    ],
+    "runbooks": [
+      "README.md",
+      "CONTRIBUTING.md",
+      "SECURITY.md"
+    ]
+  },
+  "surfaces": [
+    {
+      "type": "cli",
+      "name": "pdf-reader-mcp CLI",
+      "path": "package.json bin: pdf-reader-mcp",
+      "description": "Local MCP server executable shipped by the npm package."
+    },
+    {
+      "type": "package",
+      "name": "@sylphx/pdf-reader-mcp package",
+      "path": "package.json",
+      "description": "Public npm package and package export contract."
+    },
+    {
+      "type": "docs",
+      "name": "Public README",
+      "path": "README.md",
+      "description": "Public install, tool, benchmark, and package contract."
+    },
+    {
+      "type": "docs",
+      "name": "Project control plane",
+      "path": "PROJECT.md",
+      "description": "Human project identity, lifecycle, boundary, and delivery entry point."
+    },
+    {
+      "type": "docs",
+      "name": "Doctrine adapter manifest",
+      "path": ".doctrine/project.json",
+      "description": "Sylphx Doctrine adapter; not the vendor-neutral GroundAtlas default."
+    },
+    {
+      "type": "schema",
+      "name": "MCP tool schemas",
+      "path": "src/",
+      "description": "Typed public MCP schemas, handlers, and output contracts."
+    },
+    {
+      "type": "workflow",
+      "name": "CI",
+      "path": ".github/workflows/ci.yml",
+      "description": "Code quality, package smoke, tests, docs, release evidence, secret scan, and GroundAtlas package dogfood."
+    },
+    {
+      "type": "website",
+      "name": "Public docs site",
+      "path": "docs/",
+      "description": "VitePress public documentation source."
+    }
+  ],
+  "commands": [
+    {
+      "name": "check",
+      "command": "bun run check",
+      "purpose": "Run Biome code quality checks."
+    },
+    {
+      "name": "typecheck",
+      "command": "bun run typecheck",
+      "purpose": "Run TypeScript type checks."
+    },
+    {
+      "name": "build",
+      "command": "bun run build",
+      "purpose": "Build the public package."
+    },
+    {
+      "name": "package:smoke",
+      "command": "bun run package:smoke",
+      "purpose": "Verify package tarball behavior before release."
+    },
+    {
+      "name": "test:cov",
+      "command": "bun run test:cov",
+      "purpose": "Run tests with coverage."
+    },
+    {
+      "name": "docs:build",
+      "command": "bun run docs:build",
+      "purpose": "Build public documentation."
+    }
+  ],
+  "adoption": {
+    "status": "adopted",
+    "notes": "Vendor-neutral GroundAtlas manifest for package/action dogfooding. .doctrine/project.json remains the Sylphx Doctrine adapter and local governance catalog."
+  }
+}


### PR DESCRIPTION
## Summary
- add vendor-neutral `project.manifest.json` for GroundAtlas package/action dogfooding
- keep `.doctrine/project.json` as the Sylphx Doctrine adapter and record the neutral manifest as a public surface
- add an isolated `groundatlas package dogfood` CI job using `SylphxAI/groundatlas@v0.1.2` / `groundatlas@0.1.2`
- assert the truth boundary: selected manifest is `project.manifest.json`, `.doctrine/project.json` is adapter-only, and strict fleet status has no warnings/blocked projects
- upload manifest/fleet JSON reports as `groundatlas-package-dogfood`

## Validation
- `python3 -c 'import yaml, json; yaml.safe_load(open(".github/workflows/ci.yml")); json.load(open("project.manifest.json")); json.load(open(".doctrine/project.json"))'`
- `python3 /home/codex/.codex/worktrees/b190/doctrine/scripts/project-control-plane-audit.py --local . --fail-on-drift --json`
- `npm exec --yes --package groundatlas@0.1.2 -- ga manifest project.manifest.json --json`
- `npm exec --yes --package groundatlas@0.1.2 -- ga update --out .groundatlas-pilot`
- `npm exec --yes --package groundatlas@0.1.2 -- ga audit --out .groundatlas-pilot`
- `npm exec --yes --package groundatlas@0.1.2 -- ga fleet . --out .groundatlas-pilot --require-atlas --strict --json`
- local Node assertion for selected neutral manifest + Doctrine adapter boundary

## Boundary
- No runtime behavior, package build, MCP schema, provider, credential, release, or npm publish behavior changes.
- GroundAtlas generated output is written to `.groundatlas-pilot` in CI and remains navigation-only.
- This is package/action adoption, not standalone manifest-library extraction.
