### PR TITLE
ci: dogfood GroundAtlas 0.1.3 scorecards

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -117,7 +117,7 @@
       "Validate Code Quality"
     ],
     "deployPath": "No hosted deploy path is declared. Package release is Changesets-driven through .github/workflows/release.yml using a GitHub App release token and npm credentials.",
-    "productionProof": "Required CI context, typecheck/test/check/build/docs evidence as applicable, benchmark evidence for performance claims, Changesets release intent for package changes, and npm package readback after publication.",
+    "productionProof": "Required CI context, typecheck/test/check/build/docs evidence as applicable, GroundAtlas package dogfood JSON/Markdown evidence for project-control boundaries, benchmark evidence for performance claims, Changesets release intent for package changes, and npm package readback after publication.",
     "recoveryClass": "forward-fix-only",
     "packageRelease": {
       "publishesPackages": true,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,20 +112,21 @@ jobs:
 
       - name: Run GroundAtlas package gate
         id: groundatlas
-        uses: SylphxAI/groundatlas@v0.1.2
+        uses: SylphxAI/groundatlas@v0.1.3
         with:
-          package-spec: groundatlas@0.1.2
+          package-spec: groundatlas@0.1.3
           output-dir: .groundatlas-pilot
           require-atlas: "true"
           strict: "true"
 
       - name: Assert GroundAtlas truth boundary
         run: |
-          node - "${{ steps.groundatlas.outputs.manifest-report-path }}" "${{ steps.groundatlas.outputs.fleet-report-path }}" <<'NODE'
-          const [manifestPath, fleetPath] = process.argv.slice(2);
+          node - "${{ steps.groundatlas.outputs.manifest-report-path }}" "${{ steps.groundatlas.outputs.fleet-report-path }}" "${{ steps.groundatlas.outputs.fleet-markdown-report-path }}" <<'NODE'
+          const [manifestPath, fleetPath, fleetMarkdownPath] = process.argv.slice(2);
           const { readFileSync } = require("node:fs");
           const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
           const fleet = JSON.parse(readFileSync(fleetPath, "utf8"));
+          const fleetMarkdown = readFileSync(fleetMarkdownPath, "utf8");
           const project = fleet.projects?.[0];
 
           function assert(condition, message) {
@@ -135,11 +136,15 @@ jobs:
           assert(manifest.selected?.path === "project.manifest.json", "GroundAtlas must select the vendor-neutral project.manifest.json file.");
           assert(manifest.selected?.adapter === false, "Selected GroundAtlas manifest must not be an ecosystem adapter.");
           assert(manifest.adapters?.some((item) => item.path === ".doctrine/project.json" && item.adapter === true), "Doctrine project manifest must be reported only as an adapter.");
+          assert(fleet.summary?.adopted === 1, "GroundAtlas fleet report must have exactly one adopted project.");
           assert(fleet.summary?.blocked === 0, "GroundAtlas fleet report must not have blocked projects.");
           assert(fleet.summary?.warning === 0, "GroundAtlas strict fleet report must not have warning projects.");
+          assert(fleet.summary?.total === 1, "GroundAtlas fleet report must have exactly one project.");
           assert(project?.status === "adopted", "This repository must be adopted in the GroundAtlas fleet report.");
           assert(project?.manifest?.path === "project.manifest.json", "Fleet report must select project.manifest.json.");
           assert(project?.manifestAdapters?.some((item) => item.path === ".doctrine/project.json" && item.adapter === true), "Fleet report must keep .doctrine/project.json as an adapter.");
+          assert(fleetMarkdown.includes("# GroundAtlas fleet adoption report"), "GroundAtlas Markdown scorecard must include the report title.");
+          assert(fleetMarkdown.includes("Summary: 1 adopted, 0 warning, 0 blocked, 1 total."), "GroundAtlas Markdown scorecard must include the expected fleet summary.");
           NODE
 
       - name: Upload GroundAtlas reports
@@ -150,6 +155,7 @@ jobs:
           path: |
             ${{ steps.groundatlas.outputs.manifest-report-path }}
             ${{ steps.groundatlas.outputs.fleet-report-path }}
+            ${{ steps.groundatlas.outputs.fleet-markdown-report-path }}
           if-no-files-found: error
 
   security-secrets:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,17 +22,20 @@ these source-of-truth documents:
 2. `PROJECT.md` and `.doctrine/project.json` — project goal, lifecycle,
    boundaries, public surfaces, delivery proof, package release path, and
    adoption gaps.
-3. `docs/adr/0001-2027-sota-document-intelligence-boundary.md` — package
+3. `project.manifest.json` — vendor-neutral GroundAtlas project-control
+   manifest. Generated `.groundatlas*` outputs plus GroundAtlas JSON/Markdown
+   reports are evidence/read models only, not source of truth.
+4. `docs/adr/0001-2027-sota-document-intelligence-boundary.md` — package
    ownership, portfolio integration boundary, and SOTA invariants.
-4. `docs/specs/2026-06-16-2027-sota-document-intelligence-operating-model.md`
+5. `docs/specs/2026-06-16-2027-sota-document-intelligence-operating-model.md`
    — implementation target, non-goals, provider boundary, acceptance criteria,
    and release quality bar.
-5. The touched tool/spec document under `docs/specs/`, such as text layer,
+6. The touched tool/spec document under `docs/specs/`, such as text layer,
    OCR provider, region crop/evidence, trust report, accessibility, or document
    AST specs.
-6. `CONTRIBUTING.md` and `package.json` before changing development commands,
+7. `CONTRIBUTING.md` and `package.json` before changing development commands,
    release, or validation workflows.
-7. The paired schema/handler/test files for any public MCP tool change.
+8. The paired schema/handler/test files for any public MCP tool change.
 
 ## Non-Negotiables
 
@@ -80,6 +83,7 @@ Use the narrowest meaningful validation first, then broaden as needed:
 - `bun run check`
 - `bun run build`
 - `bun run docs:build`
+- `bun test test/project-control.test.ts`
 - release/benchmark gates named by the touched spec or workflow
 
 Docs-only boundary changes may be validated by reviewing the diff and checking

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -13,6 +13,8 @@ evidence without becoming a hosted Sylphx Platform BaaS service.
 - Doctrine source of truth: [SylphxAI/doctrine](https://github.com/SylphxAI/doctrine)
 - Machine manifest: `.doctrine/project.json`
 - Vendor-neutral GroundAtlas manifest: `project.manifest.json`
+- Generated GroundAtlas reports: `.groundatlas*`, JSON reports, and Markdown
+  scorecards are evidence/read models only
 
 ## Goals
 
@@ -56,6 +58,11 @@ Pull requests use the legacy `Validate Code Quality` context on Sylphx
 self-hosted runners. Package release is Changesets-driven through the repo
 release workflow, which mints a GitHub App token before creating version PRs or
 publishing to npm.
+
+The GroundAtlas package dogfood gate proves the project-control boundary from
+generated JSON and Markdown evidence, but those generated files are not source
+of truth. `project.manifest.json` remains the vendor-neutral control file and
+`.doctrine/project.json` remains the Sylphx Doctrine adapter.
 
 Docs-only boundary changes do not alter runtime behavior, provider dispatch,
 credentials, package output, npm release, or customer data handling. MCP schema,

--- a/docs/adr/0003-groundatlas-013-scorecard-gate.md
+++ b/docs/adr/0003-groundatlas-013-scorecard-gate.md
@@ -1,0 +1,52 @@
+# ADR 0003: Dogfood GroundAtlas 0.1.3 Scorecard Gate
+
+## Status
+
+Accepted.
+
+## Context
+
+PDF Reader MCP already adopted a vendor-neutral `project.manifest.json` and kept
+`.doctrine/project.json` as the Sylphx-specific adapter. The original
+GroundAtlas package gate used `groundatlas@0.1.2`, which emitted machine-readable
+JSON evidence but did not require the Markdown fleet scorecard introduced in
+GroundAtlas 0.1.3.
+
+The repository is a public local-first MCP package. The project-control gate
+must prove package/adoption boundaries without changing runtime PDF behavior,
+provider routing, credentials, package artifacts, npm publication, or customer
+data handling.
+
+## Decision
+
+Use `SylphxAI/groundatlas@v0.1.3` with `groundatlas@0.1.3` in CI and treat the
+Markdown fleet scorecard as first-class delivery evidence.
+
+The CI gate must assert:
+
+- GroundAtlas selects `project.manifest.json` as the vendor-neutral control
+  file.
+- The selected manifest is not an adapter.
+- `.doctrine/project.json` is reported only as an adapter.
+- The strict fleet summary is `1 adopted, 0 warning, 0 blocked, 1 total`.
+- The Markdown scorecard contains the GroundAtlas fleet report title and
+  adopted summary.
+
+The uploaded `groundatlas-package-dogfood` artifact must include:
+
+- `groundatlas-manifest.json`;
+- `groundatlas-fleet.json`;
+- `groundatlas-fleet.md`.
+
+Generated `.groundatlas*` outputs and GroundAtlas JSON/Markdown reports remain
+evidence/read models only. They are not project-control source of truth.
+
+## Consequences
+
+- Human-readable fleet scorecards are available in CI artifacts and GitHub step
+  summaries.
+- Public and internal agents can verify the GroundAtlas/Doctrine SSOT split from
+  generated evidence without treating generated reports as authoritative inputs.
+- Dependabot PR #360 is superseded because it only bumped the action reference;
+  this ADR requires the package spec, assertions, and artifact upload to move
+  together.

--- a/docs/specs/project-control-gate.md
+++ b/docs/specs/project-control-gate.md
@@ -1,0 +1,51 @@
+# Project Control Gate
+
+PDF Reader MCP keeps project-control facts in two source files:
+
+- `project.manifest.json` is the vendor-neutral GroundAtlas project control
+  file.
+- `.doctrine/project.json` is the Sylphx Doctrine adapter and local governance
+  catalog.
+
+Generated `.groundatlas*` outputs plus GroundAtlas JSON and Markdown reports are
+evidence/read models only. They must not be edited or treated as source of
+truth.
+
+## Required CI Behavior
+
+The CI workflow must run a single GroundAtlas dogfood job on pull requests,
+merge-group candidates, and `main` pushes. That job must use:
+
+- `SylphxAI/groundatlas@v0.1.3`;
+- `groundatlas@0.1.3`;
+- `require-atlas: "true"`;
+- `strict: "true"`.
+
+The assertion step must prove:
+
+- selected manifest path is `project.manifest.json`;
+- selected manifest `adapter=false`;
+- `.doctrine/project.json` remains an adapter with `adapter=true`;
+- fleet summary is `1 adopted, 0 warning, 0 blocked, 1 total`;
+- Markdown scorecard includes `# GroundAtlas fleet adoption report`;
+- Markdown scorecard includes
+  `Summary: 1 adopted, 0 warning, 0 blocked, 1 total.`
+
+The `groundatlas-package-dogfood` artifact must include:
+
+- `groundatlas-manifest.json`;
+- `groundatlas-fleet.json`;
+- `groundatlas-fleet.md`.
+
+## Validation
+
+Control-plane-only changes should run:
+
+```bash
+bun test test/project-control.test.ts
+npm exec --yes --package groundatlas@0.1.3 -- ga audit --out .groundatlas-pilot
+npm exec --yes --package groundatlas@0.1.3 -- ga manifest --out .groundatlas-pilot --json
+npm exec --yes --package groundatlas@0.1.3 -- ga fleet . --out .groundatlas-pilot --require-atlas --strict --json
+npm exec --yes --package groundatlas@0.1.3 -- ga fleet . --out .groundatlas-pilot --require-atlas --strict
+git diff --check
+```

--- a/project.manifest.json
+++ b/project.manifest.json
@@ -104,6 +104,6 @@
   ],
   "adoption": {
     "status": "adopted",
-    "notes": "Vendor-neutral GroundAtlas manifest for package/action dogfooding. .doctrine/project.json remains the Sylphx Doctrine adapter and local governance catalog."
+    "notes": "Vendor-neutral GroundAtlas manifest for package/action dogfooding. .doctrine/project.json remains the Sylphx Doctrine adapter and local governance catalog. Generated .groundatlas* outputs plus GroundAtlas JSON and Markdown reports are evidence/read models only."
   }
 }

--- a/test/project-control.test.ts
+++ b/test/project-control.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const readJson = (path: string) => JSON.parse(readFileSync(path, 'utf8'));
+const readText = (path: string) => readFileSync(path, 'utf8');
+
+describe('GroundAtlas project control', () => {
+  it('keeps the vendor-neutral manifest separate from the Doctrine adapter', () => {
+    const manifest = readJson('project.manifest.json');
+    const doctrine = readJson('.doctrine/project.json');
+
+    expect(manifest.project.id).toBe('pdf-reader-mcp');
+    expect(manifest.surfaces).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: '.doctrine/project.json',
+          description: expect.stringContaining('not the vendor-neutral GroundAtlas default'),
+        }),
+      ])
+    );
+    expect(doctrine.boundaries.publicSurfaces).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'Vendor-neutral GroundAtlas project manifest',
+          location: 'project.manifest.json',
+        }),
+      ])
+    );
+    expect(doctrine.delivery.productionProof).toContain('GroundAtlas package dogfood');
+  });
+
+  it('dogfoods GroundAtlas 0.1.3 JSON and Markdown scorecard outputs in CI', () => {
+    const workflow = readText('.github/workflows/ci.yml');
+
+    expect(workflow).toContain('uses: SylphxAI/groundatlas@v0.1.3');
+    expect(workflow).toContain('package-spec: groundatlas@0.1.3');
+    expect(workflow).toContain('fleet-markdown-report-path');
+    expect(workflow).toContain('groundatlas-package-dogfood');
+    expect(workflow).toContain('project.manifest.json');
+    expect(workflow).toContain('.doctrine/project.json');
+    expect(workflow).toContain('# GroundAtlas fleet adoption report');
+    expect(workflow).toContain('Summary: 1 adopted, 0 warning, 0 blocked, 1 total.');
+  });
+});


### PR DESCRIPTION

## Summary
- upgrade the GroundAtlas dogfood action and package spec to 0.1.3
- assert the vendor-neutral manifest / Doctrine adapter split plus the strict fleet summary
- assert and upload the Markdown fleet scorecard as part of `groundatlas-package-dogfood`
- document that generated GroundAtlas JSON/Markdown reports are evidence/read models only

## Mission Control
- Work Item: `mcw_20260707_pdf_reader_mcp_groundatlas_013_scorecard`
- This supersedes Dependabot PR #360, which only bumps the action reference and does not satisfy the v0.1.3 scorecard contract.

## Validation
- `bun install --frozen-lockfile`
- `bun run check`
- `bun run typecheck`
- `bun test test/project-control.test.ts`
- `bun run test`
- `bunx -p groundatlas@0.1.3 ga update --out .groundatlas-pilot`
- `bunx -p groundatlas@0.1.3 ga audit --out .groundatlas-pilot`
- `bunx -p groundatlas@0.1.3 ga manifest --out .groundatlas-pilot --json`
- `bunx -p groundatlas@0.1.3 ga fleet . --out .groundatlas-pilot --require-atlas --strict --json`
- `bunx -p groundatlas@0.1.3 ga fleet . --out .groundatlas-pilot --require-atlas --strict`
- `git diff --check`

## Notes
- Runtime/package behavior is unchanged.
- Local generated `.groundatlas-pilot/` outputs were not committed.
