### PR TITLE
test(security): close #368 with SSRF/file:// regression tests

### DIFF
--- a/test/pdf/loader.test.ts
+++ b/test/pdf/loader.test.ts
@@ -131,6 +131,55 @@ describe('loader', () => {
       expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 
+    // Regression tests for https://github.com/SylphxAI/pdf-reader-mcp/issues/368
+    // (GHSA-34gp-w56h-r2mv): the url branch must not bypass path confinement via
+    // SSRF or file:// local-file reads.
+    it('should reject loopback URLs before any network fetch (issue #368)', async () => {
+      globalThis.fetch = vi.fn() as typeof globalThis.fetch;
+
+      await expect(
+        loadPdfDocument(
+          { url: 'http://127.0.0.1:8080/internal.pdf' },
+          'http://127.0.0.1:8080/internal.pdf'
+        )
+      ).rejects.toThrow(/non-public address|SSRF/);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should reject file:// URLs instead of reading arbitrary local files (issue #368)', async () => {
+      globalThis.fetch = vi.fn() as typeof globalThis.fetch;
+
+      await expect(
+        loadPdfDocument(
+          { url: 'file:///tmp/word_outside/anywhere.pdf' },
+          'file:///tmp/word_outside/anywhere.pdf'
+        )
+      ).rejects.toThrow(/Access denied|rejected/);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(fs.readFile).not.toHaveBeenCalled();
+      expect(pathUtils.resolvePath).not.toHaveBeenCalled();
+    });
+
+    it('should re-validate redirect targets and reject private-IP hops (issue #368)', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(null, {
+            status: 302,
+            headers: { location: 'http://169.254.169.254/latest/meta-data/' },
+          })
+        );
+      globalThis.fetch = fetchMock as typeof globalThis.fetch;
+
+      await expect(
+        loadPdfDocument(
+          { url: 'https://example.com/redirect.pdf' },
+          'https://example.com/redirect.pdf'
+        )
+      ).rejects.toThrow(/non-public address|SSRF/);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
     it('should reject URL responses whose Content-Length exceeds the cap (SSS-08)', async () => {
       const fetchMock = vi.fn().mockResolvedValue(
         new Response(new Uint8Array(0), {

--- a/test/pdf/loader.test.ts
+++ b/test/pdf/loader.test.ts
@@ -161,14 +161,12 @@ describe('loader', () => {
     });
 
     it('should re-validate redirect targets and reject private-IP hops (issue #368)', async () => {
-      const fetchMock = vi
-        .fn()
-        .mockResolvedValueOnce(
-          new Response(null, {
-            status: 302,
-            headers: { location: 'http://169.254.169.254/latest/meta-data/' },
-          })
-        );
+      const fetchMock = vi.fn().mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { location: 'http://169.254.169.254/latest/meta-data/' },
+        })
+      );
       globalThis.fetch = fetchMock as typeof globalThis.fetch;
 
       await expect(


### PR DESCRIPTION
## Summary

Closes #368.

The SSRF and `file://` local-file read bypass reported in [GHSA-34gp-w56h-r2mv](https://github.com/SylphxAI/pdf-reader-mcp/security/advisories/GHSA-34gp-w56h-r2mv) was already remediated in #280 (`fix(security): patch SSS-02/03/07/08 findings`):

- URL sources no longer pass through to PDF.js's network loader; `src/pdf/loader.ts` fetches via `fetch()` with manual redirect handling and hands the body to PDF.js as `data`.
- Non-`http(s)` schemes (including `file://`) are rejected by `isUrlAllowed()`.
- Private/loopback/link-local/metadata IPs are blocked via `assertUrlNotPrivate()` before any network call.
- Redirect targets are re-validated on each hop.

This PR adds explicit regression tests for the three attack vectors described in #368:

1. Loopback SSRF (`http://127.0.0.1:...`) — rejected before fetch
2. `file://` local-file read bypass — rejected without touching `resolvePath` or `fs.readFile`
3. Redirect to cloud metadata (`169.254.169.254`) — second hop rejected after manual redirect

## Validation

- `bun test test/pdf/loader.test.ts`

## Residual risk

None for runtime behavior — tests only. Operators who explicitly opt into private-IP fetches via `--allow-private-ips` / `MCP_PDF_ALLOW_PRIVATE_IPS=true` can still reach loopback/metadata endpoints by design.