### PR TITLE
perf(read_pdf): eliminate default auto-read parse and response overhead

### DIFF
--- a/.changeset/read-pdf-overhead-optimization.md
+++ b/.changeset/read-pdf-overhead-optimization.md
@@ -1,0 +1,5 @@
+---
+"@sylphx/pdf-reader-mcp": patch
+---
+
+Optimize default `read_pdf` overhead by reusing one parsed PDF per source per request, bounding balanced/fast auto-read page extraction to the inspection sample budget, and omitting redundant per-page text MCP content parts when markdown/chunks are already present in the JSON payload.

--- a/benchmark-artifacts/pdf_performance_benchmark.json
+++ b/benchmark-artifacts/pdf_performance_benchmark.json
@@ -7,30 +7,30 @@
     {
       "name": "metadata_page_count",
       "iterations": 20,
-      "average_ms": 1.54,
-      "min_ms": 0.78,
-      "max_ms": 5.07
+      "average_ms": 0.85,
+      "min_ms": 0.48,
+      "max_ms": 2.63
     },
     {
       "name": "full_text",
       "iterations": 20,
-      "average_ms": 16.91,
-      "min_ms": 10.43,
-      "max_ms": 22.92
+      "average_ms": 8.72,
+      "min_ms": 5.17,
+      "max_ms": 16.67
     },
     {
       "name": "selected_page_text",
       "iterations": 20,
-      "average_ms": 13.94,
-      "min_ms": 8.7,
-      "max_ms": 26.2
+      "average_ms": 7.7,
+      "min_ms": 5.01,
+      "max_ms": 16.24
     },
     {
       "name": "v3_agent_document_twin",
       "iterations": 20,
-      "average_ms": 26.62,
-      "min_ms": 20.56,
-      "max_ms": 35.8
+      "average_ms": 17.39,
+      "min_ms": 9.73,
+      "max_ms": 24.38
     }
   ]
 }

--- a/benchmark-artifacts/pdf_sota_release_gate.json
+++ b/benchmark-artifacts/pdf_sota_release_gate.json
@@ -1,7 +1,7 @@
 {
   "profile": "pdf_sota_release_gate",
-  "generated_at": "2026-07-01T05:10:16.394Z",
-  "artifact_dir": "/home/runner/work/pdf-reader-mcp/pdf-reader-mcp/benchmark-artifacts",
+  "generated_at": "2026-07-08T17:31:24.896Z",
+  "artifact_dir": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/benchmark-artifacts",
   "status": "passed",
   "summary": {
     "total": 39,
@@ -127,7 +127,7 @@
       "status": "passed",
       "message": "v3 Agent Document Twin scenario has a positive average latency",
       "evidence": {
-        "average_ms": 26.62
+        "average_ms": 17.39
       }
     },
     {

--- a/dist/index.js
+++ b/dist/index.js
@@ -735,7 +735,7 @@ var fetchUrlBody = async (url, config) => {
     clearTimeout(timeout);
   }
 };
-var loadPdfDocument = async (source, sourceDescription) => {
+var loadPdfDocumentCore = async (source, sourceDescription) => {
   const safeSource = sanitizeSourceDescription(sourceDescription);
   let pdfData;
   try {
@@ -775,6 +775,21 @@ var loadPdfDocument = async (source, sourceDescription) => {
     logger2.error("PDF.js loading error", { sourceDescription: safeSource, error: message });
     throw new PdfError(-32600 /* InvalidRequest */, `Failed to load PDF document from ${safeSource}.`, { cause: err instanceof Error ? err : undefined });
   }
+};
+var loadPdfDocument = async (source, sourceDescription, session) => {
+  if (session) {
+    return session.acquire(source, sourceDescription);
+  }
+  return loadPdfDocumentCore(source, sourceDescription);
+};
+var releasePdfDocument = async (source, pdfDocument, sourceDescription, session) => {
+  if (session) {
+    session.release(source);
+    return;
+  }
+  await destroyLoadingTask(pdfDocument?.loadingTask, logger2, "PDF document", {
+    sourceDescription
+  });
 };
 
 // src/pdf/renderer.ts
@@ -935,13 +950,16 @@ var renderPdfPage = async (pdfDocument, pageNumber, options) => {
     data: buffer.toString("base64")
   };
 };
-var renderPdfSourcePages = async (source, options) => {
+var renderPdfSourcePages = async (source, options, existingDocument) => {
   const sourceDescription = source.path ?? source.url ?? "unknown source";
-  let pdfDocument = null;
+  const { pages: _pages, ...loadArgs } = source;
+  const ownsDocument = existingDocument === undefined || existingDocument === null;
+  let pdfDocument = existingDocument ?? null;
   try {
     const targetPages = getTargetPages(source.pages, sourceDescription);
-    const { pages: _pages, ...loadArgs } = source;
-    pdfDocument = await loadPdfDocument(loadArgs, sourceDescription);
+    if (!pdfDocument) {
+      pdfDocument = await loadPdfDocument(loadArgs, sourceDescription);
+    }
     const totalPages = pdfDocument.numPages;
     const { pagesToRender, invalidPages, truncatedPages } = resolvePagesToRender(targetPages, totalPages, options.max_pages);
     if (pagesToRender.length === 0) {
@@ -957,8 +975,10 @@ var renderPdfSourcePages = async (source, options) => {
     }
     return { source: sourceDescription, numPages: totalPages, pages, warnings };
   } finally {
-    const loadingTask = pdfDocument?.loadingTask;
-    await destroyLoadingTask(loadingTask, logger4, "rendered PDF document", { sourceDescription });
+    if (ownsDocument) {
+      const loadingTask = pdfDocument?.loadingTask;
+      await destroyLoadingTask(loadingTask, logger4, "rendered PDF document", { sourceDescription });
+    }
   }
 };
 
@@ -1063,11 +1083,14 @@ var cropRegionsFromRenderedPage = (renderedPage, regions) => regions.map((region
     data: crop.data
   };
 });
-var extractRegionCropsFromSource = async (source, options) => {
+var extractRegionCropsFromSource = async (source, options, existingDocument) => {
   const sourceDescription = source.path ?? source.url ?? "unknown source";
-  let pdfDocument = null;
+  const ownsDocument = existingDocument === undefined || existingDocument === null;
+  let pdfDocument = existingDocument ?? null;
   try {
-    pdfDocument = await loadPdfDocument({ path: source.path, url: source.url }, sourceDescription);
+    if (!pdfDocument) {
+      pdfDocument = await loadPdfDocument({ path: source.path, url: source.url }, sourceDescription);
+    }
     const totalPages = pdfDocument.numPages;
     const { regionsToCrop, invalidPages, truncatedCount } = selectRegionsToCrop(source.regions, totalPages, options.max_regions);
     if (regionsToCrop.length === 0) {
@@ -1084,10 +1107,12 @@ var extractRegionCropsFromSource = async (source, options) => {
     }
     return { source: sourceDescription, numPages: totalPages, regions: crops, warnings };
   } finally {
-    const loadingTask = pdfDocument?.loadingTask;
-    await destroyLoadingTask(loadingTask, logger5, "region crop PDF document", {
-      sourceDescription
-    });
+    if (ownsDocument) {
+      const loadingTask = pdfDocument?.loadingTask;
+      await destroyLoadingTask(loadingTask, logger5, "region crop PDF document", {
+        sourceDescription
+      });
+    }
   }
 };
 var defaultExtractRegionsOptions = () => ({
@@ -1912,13 +1937,13 @@ var analyzeRegionCropWithConfiguredProvider = async (region, context, options) =
   }
   return analyzeRegionCropWithCommandProvider(region, context, options);
 };
-var analyzePdfRegionsFromSource = async (source, options) => {
+var analyzePdfRegionsFromSource = async (source, options, existingDocument) => {
   const cropped = await extractRegionCropsFromSource(source, {
     scale: options.scale,
     max_regions: options.max_regions,
     max_pixels_per_page: options.max_pixels_per_page,
     include_image: false
-  });
+  }, existingDocument);
   const analyses = [];
   for (const region of cropped.regions) {
     analyses.push(await analyzeRegionCropWithConfiguredProvider(region, { source: cropped.source, languages: options.languages }, options));
@@ -3347,13 +3372,13 @@ var ocrRenderedPageWithCommandProvider = async (page, context, options) => {
     await fs5.rm(tempDir, { recursive: true, force: true }).catch(() => {});
   }
 };
-var ocrPdfSourcePages = async (source, options) => {
+var ocrPdfSourcePages = async (source, options, existingDocument) => {
   const rendered = await renderPdfSourcePages(source, {
     scale: options.scale,
     max_pages: options.max_pages,
     max_pixels_per_page: options.max_pixels_per_page,
     include_image: false
-  });
+  }, existingDocument);
   const pages = [];
   for (const page of rendered.pages) {
     pages.push(await ocrRenderedPageWithCommandProvider(page, { source: rendered.source, languages: options.languages }, options));
@@ -3709,13 +3734,13 @@ var buildInspectionRecommendation = (source, profile, documentSignals, pageSigna
     next_tools: buildInspectionNextTools(source, profile, readPdfArguments, pageSignals, providerReadiness)
   };
 };
-var inspectPdfSource = async (source, options) => {
+var inspectPdfSource = async (source, options, session) => {
   const sourceDescription = source.path ?? source.url ?? "unknown source";
+  const { pages: _pages, ...loadArgs } = source;
   let pdfDocument = null;
   try {
     const targetPages = getTargetPages(source.pages, sourceDescription);
-    const { pages: _pages, ...loadArgs } = source;
-    pdfDocument = await loadPdfDocument(loadArgs, sourceDescription);
+    pdfDocument = await loadPdfDocument(loadArgs, sourceDescription, session);
     const totalPages = pdfDocument.numPages;
     const validTargetPages = targetPages?.filter((page) => page <= totalPages);
     const invalidPages = targetPages?.filter((page) => page > totalPages) ?? [];
@@ -3781,10 +3806,7 @@ var inspectPdfSource = async (source, options) => {
       error: `Failed to inspect PDF from ${sourceDescription}.`
     };
   } finally {
-    const loadingTask = pdfDocument?.loadingTask;
-    await destroyLoadingTask(loadingTask, logger11, "PDF document after inspection", {
-      sourceDescription
-    });
+    await releasePdfDocument(loadArgs, pdfDocument, sourceDescription, session);
   }
 };
 var defaultInspectPdfOptions = () => ({
@@ -4407,7 +4429,7 @@ var buildVisualEnrichmentsForSource = async (input) => {
       path: input.source.path,
       url: input.source.url,
       regions: candidates.map((candidate) => candidate.region)
-    }, options);
+    }, options, input.pdfDocument);
     return {
       visualEnrichmentCandidates,
       visualEnrichments: analyzed.analyses.map((analysis) => {
@@ -4550,16 +4572,30 @@ var buildReadOptions = (input) => ({
   trustReportRedaction: input.trust_report_redaction ?? "standard",
   includeAccessibilityReport: input.include_accessibility_report ?? false
 });
+var buildAutoExtractionPages = (totalPages, samplePageCount, detail) => {
+  if (detail === "full") {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+  return selectInspectionSamplePages(totalPages, undefined, samplePageCount);
+};
 var buildAutoReadArgs = (source, inspection, input, detail) => {
   const recommendationArgs = inspection.data?.recommendation.read_pdf_arguments ?? {};
+  const samplePages = input.sample_pages ?? DEFAULT_SAMPLE_PAGES;
+  const totalPages = inspection.data?.num_pages;
+  const extractionPages = source.pages ?? (totalPages !== undefined ? buildAutoExtractionPages(totalPages, samplePages, detail) : undefined);
   return {
     ...recommendationArgs,
     ...buildAutoDetailOptions(detail),
     ...pickExplicitReadOptions(input),
-    sources: [source]
+    sources: [
+      {
+        ...source,
+        ...extractionPages !== undefined ? { pages: extractionPages } : {}
+      }
+    ]
   };
 };
-var buildAutoInspections = async (input) => {
+var buildAutoInspections = async (input, session) => {
   const inspectOptions = {
     ...defaultInspectPdfOptions(),
     ...input.sample_pages !== undefined ? { sample_pages: input.sample_pages } : {},
@@ -4568,11 +4604,46 @@ var buildAutoInspections = async (input) => {
   const inspections = [];
   for (let i = 0;i < input.sources.length; i += MAX_CONCURRENT_SOURCES2) {
     const batch = input.sources.slice(i, i + MAX_CONCURRENT_SOURCES2);
-    const batchResults = await Promise.all(batch.map((source) => inspectPdfSource(source, inspectOptions)));
+    const batchResults = await Promise.all(batch.map((source) => inspectPdfSource(source, inspectOptions, session)));
     inspections.push(...batchResults);
   }
   return inspections;
 };
+
+// src/pdf/pdfSession.ts
+var logger14 = createLogger("PdfSession");
+var pdfSessionKey = (source) => source.path ?? source.url ?? "";
+
+class PdfSessionScope {
+  entries = new Map;
+  async acquire(source, sourceDescription) {
+    const key = pdfSessionKey(source);
+    const existing = this.entries.get(key);
+    if (existing) {
+      existing.refCount += 1;
+      return existing.pdfDocument;
+    }
+    const pdfDocument = await loadPdfDocumentCore(source, sourceDescription);
+    this.entries.set(key, { pdfDocument, refCount: 1 });
+    return pdfDocument;
+  }
+  release(source) {
+    const key = pdfSessionKey(source);
+    const entry = this.entries.get(key);
+    if (!entry)
+      return;
+    entry.refCount = Math.max(0, entry.refCount - 1);
+  }
+  async destroyAll() {
+    for (const [, entry] of this.entries) {
+      await destroyLoadingTask(entry.pdfDocument.loadingTask, logger14, "PDF session document");
+    }
+    this.entries.clear();
+  }
+  activeSourceCount() {
+    return this.entries.size;
+  }
+}
 
 // src/pdf/accessibilityReport.ts
 var ACCESSIBILITY_REPORT_VERSION = "2026-06-15";
@@ -5794,7 +5865,7 @@ var buildDocumentMap = (input) => {
 };
 
 // src/pdf/tableExtractor.ts
-var logger14 = createLogger("TableExtractor");
+var logger15 = createLogger("TableExtractor");
 var Y_TOLERANCE = 5;
 var COLUMN_GAP_THRESHOLD = 15;
 var MIN_ROWS = 2;
@@ -6372,7 +6443,7 @@ var extractTablesFromPage = async (page, pageNum) => {
     return extractTablesFromTextItems(await extractTextItemsWithPositions(page), pageNum);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    logger14.warn("Error extracting tables from page", { pageNum, error: message });
+    logger15.warn("Error extracting tables from page", { pageNum, error: message });
     return [];
   }
 };
@@ -6385,7 +6456,7 @@ var extractTables = async (pdfDocument, pagesToProcess) => {
       allTables.push(...pageTables);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      logger14.warn("Error getting page for table extraction", { pageNum, error: message });
+      logger15.warn("Error getting page for table extraction", { pageNum, error: message });
     }
   }
   return linkTableContinuationCandidates(allTables);
@@ -7622,7 +7693,7 @@ var buildTrustReport = (input) => {
 };
 
 // src/pdf/readCoordinator.ts
-var logger15 = createLogger("ReadCoordinator");
+var logger16 = createLogger("ReadCoordinator");
 var appendOutputWarnings = (output, warnings) => {
   if (warnings.length === 0)
     return;
@@ -7632,14 +7703,14 @@ var selectOcrTextLayerPages = (pagesToProcess, layoutDiagnostics) => {
   const zeroSelectableTextPages = layoutDiagnostics.filter((layout) => layout.text_item_count === 0).map((layout) => layout.page);
   return zeroSelectableTextPages.length > 0 ? zeroSelectableTextPages : pagesToProcess;
 };
-var processSingleSource = async (source, options) => {
+var processSingleSource = async (source, options, session) => {
   const sourceDescription = source.path ?? source.url ?? "unknown source";
+  const { pages: _pages, ...loadArgs } = source;
   let individualResult = { source: sourceDescription, success: false };
   let pdfDocument = null;
   try {
     const targetPages = getTargetPages(source.pages, sourceDescription);
-    const { pages: _pages, ...loadArgs } = source;
-    pdfDocument = await loadPdfDocument(loadArgs, sourceDescription);
+    pdfDocument = await loadPdfDocument(loadArgs, sourceDescription, session);
     const totalPages = pdfDocument.numPages;
     const metadataOutput = await extractMetadataAndPageCount(pdfDocument, options.includeMetadata, options.includePageCount);
     const output = { ...metadataOutput };
@@ -7730,14 +7801,14 @@ var processSingleSource = async (source, options) => {
         const ocrPages2 = selectOcrTextLayerPages(pagesToProcess, layoutDiagnostics);
         if (ocrPages2.length > 0) {
           try {
-            const ocr = await ocrPdfSourcePages({ ...source, pages: ocrPages2 }, defaultOcrPagesOptions());
+            const ocr = await ocrPdfSourcePages({ ...source, pages: ocrPages2 }, defaultOcrPagesOptions(), pdfDocument);
             ocrTextLayer = buildOcrTextLayer(ocr.pages, ocr.warnings);
             output.ocr_text_layer = ocrTextLayer;
             appendOutputWarnings(output, ocr.warnings);
           } catch (error) {
             const message = error instanceof PdfError ? error.message : "OCR provider failed before returning a normalized text layer.";
             if (!(error instanceof PdfError)) {
-              logger15.warn("Unexpected error building OCR text layer", {
+              logger16.warn("Unexpected error building OCR text layer", {
                 sourceDescription,
                 error: error instanceof Error ? error.message : String(error)
               });
@@ -7799,7 +7870,8 @@ var processSingleSource = async (source, options) => {
           sourceDescription,
           elements: visualElements,
           pageGeometry,
-          maxVisualEnrichments: options.maxVisualEnrichments
+          maxVisualEnrichments: options.maxVisualEnrichments,
+          pdfDocument
         });
         visualEnrichmentCandidates = enriched.visualEnrichmentCandidates;
         if (visualEnrichmentCandidates.length > 0) {
@@ -7899,179 +7971,184 @@ var processSingleSource = async (source, options) => {
     }
     individualResult = { ...individualResult, data: output, success: true };
   } catch (error) {
-    const errorMessage = safeErrorMessage(error, `Failed to process PDF from ${sourceDescription}.`, logger15, { sourceDescription });
+    const errorMessage = safeErrorMessage(error, `Failed to process PDF from ${sourceDescription}.`, logger16, { sourceDescription });
     individualResult.error = errorMessage;
     individualResult.success = false;
     individualResult.data = undefined;
   } finally {
-    await destroyLoadingTask(pdfDocument?.loadingTask, logger15, "PDF document", {
-      sourceDescription
-    });
+    await releasePdfDocument(loadArgs, pdfDocument, sourceDescription, session);
   }
   return individualResult;
 };
 
 // src/handlers/readPdf.ts
 var readPdf = tool().description("Primary V3 PDF reader. With only sources, it auto-inspects and returns a routed Agent Document Twin; use auto_detail or explicit include_* options for precise control.").input(readPdfArgsSchema).handler(async ({ input }) => {
+  const session = new PdfSessionScope;
   const results = [];
   const autoRead = shouldUseAutoRead(input);
   const autoDetail = input.auto_detail ?? DEFAULT_AUTO_DETAIL;
   const autoReadSummaries = [];
   let options = buildReadOptions(input);
-  if (autoRead) {
-    const inspections = await buildAutoInspections(input);
-    for (let i = 0;i < inspections.length; i += MAX_CONCURRENT_SOURCES2) {
-      const inspectionBatch = inspections.slice(i, i + MAX_CONCURRENT_SOURCES2);
-      const sourceBatch = input.sources.slice(i, i + MAX_CONCURRENT_SOURCES2);
-      const batchResults = await Promise.all(inspectionBatch.map((inspection, batchIndex) => {
-        const source = sourceBatch[batchIndex];
-        if (!source) {
-          return Promise.resolve({
-            source: inspection.source,
-            success: false,
-            error: "Auto read failed because the source index was missing."
-          });
-        }
-        if (!inspection.success || !inspection.data) {
+  try {
+    if (autoRead) {
+      const inspections = await buildAutoInspections(input, session);
+      for (let i = 0;i < inspections.length; i += MAX_CONCURRENT_SOURCES2) {
+        const inspectionBatch = inspections.slice(i, i + MAX_CONCURRENT_SOURCES2);
+        const sourceBatch = input.sources.slice(i, i + MAX_CONCURRENT_SOURCES2);
+        const batchResults = await Promise.all(inspectionBatch.map((inspection, batchIndex) => {
+          const source = sourceBatch[batchIndex];
+          if (!source) {
+            return Promise.resolve({
+              source: inspection.source,
+              success: false,
+              error: "Auto read failed because the source index was missing."
+            });
+          }
+          if (!inspection.success || !inspection.data) {
+            autoReadSummaries.push({
+              source: inspection.source,
+              success: false,
+              ...inspection.error !== undefined ? { inspection_error: inspection.error } : {}
+            });
+            return Promise.resolve({
+              source: inspection.source,
+              success: false,
+              error: `Auto inspection failed: ${inspection.error ?? "unknown error"}`
+            });
+          }
+          const autoReadArgs = buildAutoReadArgs(source, inspection, input, autoDetail);
+          const autoOptions = buildReadOptions(autoReadArgs);
           autoReadSummaries.push({
             source: inspection.source,
-            success: false,
-            ...inspection.error !== undefined ? { inspection_error: inspection.error } : {}
+            success: true,
+            profile: inspection.data.profile,
+            workflow: inspection.data.recommendation.workflow,
+            reason: inspection.data.recommendation.reason,
+            needs_ocr: inspection.data.recommendation.needs_ocr,
+            provider_status: inspection.data.provider_status,
+            read_pdf_arguments: autoReadArgs
           });
-          return Promise.resolve({
-            source: inspection.source,
-            success: false,
-            error: `Auto inspection failed: ${inspection.error ?? "unknown error"}`
-          });
-        }
-        const autoReadArgs = buildAutoReadArgs(source, inspection, input, autoDetail);
-        const autoOptions = buildReadOptions(autoReadArgs);
-        autoReadSummaries.push({
-          source: inspection.source,
-          success: true,
-          profile: inspection.data.profile,
-          workflow: inspection.data.recommendation.workflow,
-          reason: inspection.data.recommendation.reason,
-          needs_ocr: inspection.data.recommendation.needs_ocr,
-          provider_status: inspection.data.provider_status,
-          read_pdf_arguments: autoReadArgs
-        });
-        return processSingleSource(source, autoOptions);
-      }));
-      results.push(...batchResults);
-    }
-  } else {
-    for (let i = 0;i < input.sources.length; i += MAX_CONCURRENT_SOURCES2) {
-      const batch = input.sources.slice(i, i + MAX_CONCURRENT_SOURCES2);
-      const batchResults = await Promise.all(batch.map((source) => processSingleSource(source, options)));
-      results.push(...batchResults);
-    }
-  }
-  const allFailed = results.every((r) => !r.success);
-  if (allFailed) {
-    const errorMessages = results.map((r) => r.error).join("; ");
-    return toolError(`All PDF sources failed to process: ${errorMessages}`);
-  }
-  if (autoRead) {
-    const firstSuccessfulAutoArgs = autoReadSummaries.find((summary) => summary.success && summary.read_pdf_arguments)?.read_pdf_arguments;
-    if (firstSuccessfulAutoArgs) {
-      options = buildReadOptions(firstSuccessfulAutoArgs);
-    }
-  }
-  const content = [];
-  const resultsForJson = results.map((result) => {
-    if (result.data) {
-      const { images, page_contents, tables, ...dataWithoutBinaryContent } = result.data;
-      const processedData = { ...dataWithoutBinaryContent };
-      if (images) {
-        processedData["image_info"] = images.map((img) => ({
-          page: img.page,
-          index: img.index,
-          width: img.width,
-          height: img.height,
-          format: img.format
+          const autoSource = autoReadArgs.sources[0] ?? source;
+          return processSingleSource(autoSource, autoOptions, session);
         }));
+        results.push(...batchResults);
       }
-      if (options.includeTables && tables && tables.length > 0) {
-        processedData["table_info"] = tables.map((tbl) => ({
-          page: tbl.page,
-          tableIndex: tbl.tableIndex,
-          rowCount: tbl.rowCount,
-          colCount: tbl.colCount,
-          cellCount: tbl.cells?.length ?? tbl.rowCount * tbl.colCount,
-          bounding_box: tbl.bounding_box,
-          confidence: tbl.confidence,
-          quality: tbl.quality,
-          continuation: tbl.continuation,
-          provenance: tbl.provenance
-        }));
+    } else {
+      for (let i = 0;i < input.sources.length; i += MAX_CONCURRENT_SOURCES2) {
+        const batch = input.sources.slice(i, i + MAX_CONCURRENT_SOURCES2);
+        const batchResults = await Promise.all(batch.map((source) => processSingleSource(source, options, session)));
+        results.push(...batchResults);
       }
-      return { ...result, data: processedData };
     }
-    return result;
-  });
-  content.push(text(JSON.stringify({
-    ...autoRead ? {
-      auto_read: {
-        enabled: true,
-        detail: autoDetail,
-        results: autoReadSummaries
+    const allFailed = results.every((r) => !r.success);
+    if (allFailed) {
+      const errorMessages = results.map((r) => r.error).join("; ");
+      return toolError(`All PDF sources failed to process: ${errorMessages}`);
+    }
+    if (autoRead) {
+      const firstSuccessfulAutoArgs = autoReadSummaries.find((summary) => summary.success && summary.read_pdf_arguments)?.read_pdf_arguments;
+      if (firstSuccessfulAutoArgs) {
+        options = buildReadOptions(firstSuccessfulAutoArgs);
       }
-    } : {},
-    results: resultsForJson
-  }, null, 2)));
-  for (const result of results) {
-    if (!result.success || !result.data?.page_contents)
-      continue;
-    for (const pageContent of result.data.page_contents) {
-      const pageTextParts = [];
-      const pageImages2 = [];
-      for (const item of pageContent.items) {
-        if (item.type === "text" && item.textContent) {
-          pageTextParts.push(item.textContent);
-        } else if (item.type === "image" && item.imageData) {
-          pageImages2.push(item.imageData);
+    }
+    const content = [];
+    const resultsForJson = results.map((result) => {
+      if (result.data) {
+        const { images, page_contents, tables, ...dataWithoutBinaryContent } = result.data;
+        const processedData = { ...dataWithoutBinaryContent };
+        if (images) {
+          processedData["image_info"] = images.map((img) => ({
+            page: img.page,
+            index: img.index,
+            width: img.width,
+            height: img.height,
+            format: img.format
+          }));
         }
+        if (options.includeTables && tables && tables.length > 0) {
+          processedData["table_info"] = tables.map((tbl) => ({
+            page: tbl.page,
+            tableIndex: tbl.tableIndex,
+            rowCount: tbl.rowCount,
+            colCount: tbl.colCount,
+            cellCount: tbl.cells?.length ?? tbl.rowCount * tbl.colCount,
+            bounding_box: tbl.bounding_box,
+            confidence: tbl.confidence,
+            quality: tbl.quality,
+            continuation: tbl.continuation,
+            provenance: tbl.provenance
+          }));
+        }
+        return { ...result, data: processedData };
       }
-      if (pageTextParts.length > 0) {
-        content.push(text(`[Page ${pageContent.page}]
+      return result;
+    });
+    content.push(text(JSON.stringify({
+      ...autoRead ? {
+        auto_read: {
+          enabled: true,
+          detail: autoDetail,
+          results: autoReadSummaries
+        }
+      } : {},
+      results: resultsForJson
+    }, null, 2)));
+    const emitPerPageText = !options.includeMarkdown && !options.includeChunks;
+    for (const result of results) {
+      if (!result.success || !result.data?.page_contents)
+        continue;
+      for (const pageContent of result.data.page_contents) {
+        const pageTextParts = [];
+        const pageImages2 = [];
+        for (const item of pageContent.items) {
+          if (item.type === "text" && item.textContent) {
+            pageTextParts.push(item.textContent);
+          } else if (item.type === "image" && item.imageData) {
+            pageImages2.push(item.imageData);
+          }
+        }
+        if (emitPerPageText && pageTextParts.length > 0) {
+          content.push(text(`[Page ${pageContent.page}]
 ${pageTextParts.join(`
 `)}`));
-      }
-      if (options.includeImages) {
-        for (const img of pageImages2) {
-          content.push(image(img.data, "image/png"));
+        }
+        if (options.includeImages) {
+          for (const img of pageImages2) {
+            content.push(image(img.data, "image/png"));
+          }
         }
       }
     }
-  }
-  for (const result of results) {
-    if (!result.success || !result.data?.ocr_text_layer)
-      continue;
-    for (const page of result.data.ocr_text_layer.pages) {
-      if (page.text.trim().length > 0) {
-        content.push(text(`[Page ${String(page.page)} OCR]
-${page.text}`));
-      }
-    }
-  }
-  if (options.includeTables) {
-    const allTables = [];
     for (const result of results) {
-      if (result.success && result.data?.tables) {
-        allTables.push(...result.data.tables);
+      if (!result.success || !result.data?.ocr_text_layer)
+        continue;
+      for (const page of result.data.ocr_text_layer.pages) {
+        if (page.text.trim().length > 0) {
+          content.push(text(`[Page ${String(page.page)} OCR]
+${page.text}`));
+        }
       }
     }
-    if (allTables.length > 0) {
-      const markdownTables = tablesToMarkdown(allTables);
-      content.push(text(markdownTables));
+    if (options.includeTables) {
+      const allTables = [];
+      for (const result of results) {
+        if (result.success && result.data?.tables) {
+          allTables.push(...result.data.tables);
+        }
+      }
+      if (allTables.length > 0) {
+        const markdownTables = tablesToMarkdown(allTables);
+        content.push(text(markdownTables));
+      }
     }
+    return content;
+  } finally {
+    await session.destroyAll();
   }
-  return content;
 });
 
 // src/pdf/search.ts
-var logger16 = createLogger("Search");
+var logger17 = createLogger("Search");
 var DEFAULT_SEARCH_MAX_PAGES = 100;
 var DEFAULT_SEARCH_MAX_MATCHES = 50;
 var DEFAULT_SEARCH_CONTEXT_CHARS = 120;
@@ -8281,7 +8358,7 @@ var searchPdfSource = async (source, options) => {
     };
   } finally {
     const loadingTask = pdfDocument?.loadingTask;
-    await destroyLoadingTask(loadingTask, logger16, "searched PDF document", { sourceDescription });
+    await destroyLoadingTask(loadingTask, logger17, "searched PDF document", { sourceDescription });
   }
 };
 
@@ -8298,7 +8375,7 @@ var searchPdfArgsSchema = object({
 });
 
 // src/handlers/searchPdf.ts
-var logger17 = createLogger("SearchPdf");
+var logger18 = createLogger("SearchPdf");
 var buildOptions4 = (input) => ({
   ...defaultSearchPdfOptions(input.query),
   ...input.case_sensitive !== undefined ? { case_sensitive: input.case_sensitive } : {},
@@ -8313,7 +8390,7 @@ var processSource4 = async (source, options) => {
   try {
     return await searchPdfSource(source, options);
   } catch (error) {
-    const errorMessage = safeErrorMessage(error, `Failed to search PDF source ${sourceDescription}.`, logger17, { sourceDescription });
+    const errorMessage = safeErrorMessage(error, `Failed to search PDF source ${sourceDescription}.`, logger18, { sourceDescription });
     return {
       source: sourceDescription,
       success: false,

--- a/src/handlers/readPdf.ts
+++ b/src/handlers/readPdf.ts
@@ -7,6 +7,7 @@ import {
   MAX_CONCURRENT_SOURCES,
   shouldUseAutoRead,
 } from '../pdf/autoReadPolicy.js';
+import { PdfSessionScope } from '../pdf/pdfSession.js';
 import { processSingleSource } from '../pdf/readCoordinator.js';
 import { tablesToMarkdown } from '../pdf/tableExtractor.js';
 import { type ReadPdfArgs, readPdfArgsSchema } from '../schemas/readPdf.js';
@@ -30,209 +31,218 @@ export const readPdf = tool()
   )
   .input(readPdfArgsSchema)
   .handler(async ({ input }) => {
+    const session = new PdfSessionScope();
     const results: PdfSourceResult[] = [];
     const autoRead = shouldUseAutoRead(input);
     const autoDetail = input.auto_detail ?? DEFAULT_AUTO_DETAIL;
     const autoReadSummaries: AutoReadSummary[] = [];
     let options = buildReadOptions(input);
 
-    if (autoRead) {
-      const inspections = await buildAutoInspections(input);
+    try {
+      if (autoRead) {
+        const inspections = await buildAutoInspections(input, session);
 
-      for (let i = 0; i < inspections.length; i += MAX_CONCURRENT_SOURCES) {
-        const inspectionBatch = inspections.slice(i, i + MAX_CONCURRENT_SOURCES);
-        const sourceBatch = input.sources.slice(i, i + MAX_CONCURRENT_SOURCES);
-        const batchResults = await Promise.all(
-          inspectionBatch.map((inspection, batchIndex) => {
-            const source = sourceBatch[batchIndex];
-            if (!source) {
-              return Promise.resolve({
-                source: inspection.source,
-                success: false,
-                error: 'Auto read failed because the source index was missing.',
-              } satisfies PdfSourceResult);
-            }
+        for (let i = 0; i < inspections.length; i += MAX_CONCURRENT_SOURCES) {
+          const inspectionBatch = inspections.slice(i, i + MAX_CONCURRENT_SOURCES);
+          const sourceBatch = input.sources.slice(i, i + MAX_CONCURRENT_SOURCES);
+          const batchResults = await Promise.all(
+            inspectionBatch.map((inspection, batchIndex) => {
+              const source = sourceBatch[batchIndex];
+              if (!source) {
+                return Promise.resolve({
+                  source: inspection.source,
+                  success: false,
+                  error: 'Auto read failed because the source index was missing.',
+                } satisfies PdfSourceResult);
+              }
 
-            if (!inspection.success || !inspection.data) {
+              if (!inspection.success || !inspection.data) {
+                autoReadSummaries.push({
+                  source: inspection.source,
+                  success: false,
+                  ...(inspection.error !== undefined ? { inspection_error: inspection.error } : {}),
+                });
+                return Promise.resolve({
+                  source: inspection.source,
+                  success: false,
+                  error: `Auto inspection failed: ${inspection.error ?? 'unknown error'}`,
+                } satisfies PdfSourceResult);
+              }
+
+              const autoReadArgs = buildAutoReadArgs(source, inspection, input, autoDetail);
+              const autoOptions = buildReadOptions(autoReadArgs);
               autoReadSummaries.push({
                 source: inspection.source,
-                success: false,
-                ...(inspection.error !== undefined ? { inspection_error: inspection.error } : {}),
+                success: true,
+                profile: inspection.data.profile,
+                workflow: inspection.data.recommendation.workflow,
+                reason: inspection.data.recommendation.reason,
+                needs_ocr: inspection.data.recommendation.needs_ocr,
+                provider_status: inspection.data.provider_status,
+                read_pdf_arguments: autoReadArgs,
               });
-              return Promise.resolve({
-                source: inspection.source,
-                success: false,
-                error: `Auto inspection failed: ${inspection.error ?? 'unknown error'}`,
-              } satisfies PdfSourceResult);
-            }
-
-            const autoReadArgs = buildAutoReadArgs(source, inspection, input, autoDetail);
-            const autoOptions = buildReadOptions(autoReadArgs);
-            autoReadSummaries.push({
-              source: inspection.source,
-              success: true,
-              profile: inspection.data.profile,
-              workflow: inspection.data.recommendation.workflow,
-              reason: inspection.data.recommendation.reason,
-              needs_ocr: inspection.data.recommendation.needs_ocr,
-              provider_status: inspection.data.provider_status,
-              read_pdf_arguments: autoReadArgs,
-            });
-            return processSingleSource(source, autoOptions);
-          })
-        );
-        results.push(...batchResults);
-      }
-    } else {
-      // Process sources with concurrency limit to prevent memory exhaustion.
-      // Processing large PDFs concurrently can consume significant memory.
-      for (let i = 0; i < input.sources.length; i += MAX_CONCURRENT_SOURCES) {
-        const batch = input.sources.slice(i, i + MAX_CONCURRENT_SOURCES);
-        const batchResults = await Promise.all(
-          batch.map((source) => processSingleSource(source, options))
-        );
-        results.push(...batchResults);
-      }
-    }
-
-    // Check if all sources failed
-    const allFailed = results.every((r) => !r.success);
-    if (allFailed) {
-      const errorMessages = results.map((r) => r.error).join('; ');
-      return toolError(`All PDF sources failed to process: ${errorMessages}`);
-    }
-
-    if (autoRead) {
-      const firstSuccessfulAutoArgs = autoReadSummaries.find(
-        (summary) => summary.success && summary.read_pdf_arguments
-      )?.read_pdf_arguments;
-      if (firstSuccessfulAutoArgs) {
-        options = buildReadOptions(firstSuccessfulAutoArgs);
-      }
-    }
-
-    // Build content parts - start with structured JSON for backward compatibility
-    const content: Array<ReturnType<typeof text> | ReturnType<typeof image>> = [];
-
-    // Strip image data, page_contents, and full table rows from JSON to keep it manageable
-    const resultsForJson = results.map((result) => {
-      if (result.data) {
-        const { images, page_contents, tables, ...dataWithoutBinaryContent } = result.data;
-
-        // Use Record type to allow adding image_info and table_info properties
-        const processedData: Record<string, unknown> = { ...dataWithoutBinaryContent };
-
-        // Include image count and metadata in JSON, but not the base64 data
-        if (images) {
-          processedData['image_info'] = images.map((img) => ({
-            page: img.page,
-            index: img.index,
-            width: img.width,
-            height: img.height,
-            format: img.format,
-          }));
+              const autoSource = autoReadArgs.sources[0] ?? source;
+              return processSingleSource(autoSource, autoOptions, session);
+            })
+          );
+          results.push(...batchResults);
         }
-
-        // Include table metadata in JSON, but not the full row data (that goes to markdown)
-        if (options.includeTables && tables && tables.length > 0) {
-          processedData['table_info'] = tables.map((tbl) => ({
-            page: tbl.page,
-            tableIndex: tbl.tableIndex,
-            rowCount: tbl.rowCount,
-            colCount: tbl.colCount,
-            cellCount: tbl.cells?.length ?? tbl.rowCount * tbl.colCount,
-            bounding_box: tbl.bounding_box,
-            confidence: tbl.confidence,
-            quality: tbl.quality,
-            continuation: tbl.continuation,
-            provenance: tbl.provenance,
-          }));
+      } else {
+        // Process sources with concurrency limit to prevent memory exhaustion.
+        // Processing large PDFs concurrently can consume significant memory.
+        for (let i = 0; i < input.sources.length; i += MAX_CONCURRENT_SOURCES) {
+          const batch = input.sources.slice(i, i + MAX_CONCURRENT_SOURCES);
+          const batchResults = await Promise.all(
+            batch.map((source) => processSingleSource(source, options, session))
+          );
+          results.push(...batchResults);
         }
-
-        return { ...result, data: processedData };
       }
-      return result;
-    });
 
-    // First content part: Structured JSON results
-    content.push(
-      text(
-        JSON.stringify(
-          {
-            ...(autoRead
-              ? {
-                  auto_read: {
-                    enabled: true,
-                    detail: autoDetail,
-                    results: autoReadSummaries,
-                  },
-                }
-              : {}),
-            results: resultsForJson,
-          },
-          null,
-          2
+      // Check if all sources failed
+      const allFailed = results.every((r) => !r.success);
+      if (allFailed) {
+        const errorMessages = results.map((r) => r.error).join('; ');
+        return toolError(`All PDF sources failed to process: ${errorMessages}`);
+      }
+
+      if (autoRead) {
+        const firstSuccessfulAutoArgs = autoReadSummaries.find(
+          (summary) => summary.success && summary.read_pdf_arguments
+        )?.read_pdf_arguments;
+        if (firstSuccessfulAutoArgs) {
+          options = buildReadOptions(firstSuccessfulAutoArgs);
+        }
+      }
+
+      // Build content parts - start with structured JSON for backward compatibility
+      const content: Array<ReturnType<typeof text> | ReturnType<typeof image>> = [];
+
+      // Strip image data, page_contents, and full table rows from JSON to keep it manageable
+      const resultsForJson = results.map((result) => {
+        if (result.data) {
+          const { images, page_contents, tables, ...dataWithoutBinaryContent } = result.data;
+
+          // Use Record type to allow adding image_info and table_info properties
+          const processedData: Record<string, unknown> = { ...dataWithoutBinaryContent };
+
+          // Include image count and metadata in JSON, but not the base64 data
+          if (images) {
+            processedData['image_info'] = images.map((img) => ({
+              page: img.page,
+              index: img.index,
+              width: img.width,
+              height: img.height,
+              format: img.format,
+            }));
+          }
+
+          // Include table metadata in JSON, but not the full row data (that goes to markdown)
+          if (options.includeTables && tables && tables.length > 0) {
+            processedData['table_info'] = tables.map((tbl) => ({
+              page: tbl.page,
+              tableIndex: tbl.tableIndex,
+              rowCount: tbl.rowCount,
+              colCount: tbl.colCount,
+              cellCount: tbl.cells?.length ?? tbl.rowCount * tbl.colCount,
+              bounding_box: tbl.bounding_box,
+              confidence: tbl.confidence,
+              quality: tbl.quality,
+              continuation: tbl.continuation,
+              provenance: tbl.provenance,
+            }));
+          }
+
+          return { ...result, data: processedData };
+        }
+        return result;
+      });
+
+      // First content part: Structured JSON results
+      content.push(
+        text(
+          JSON.stringify(
+            {
+              ...(autoRead
+                ? {
+                    auto_read: {
+                      enabled: true,
+                      detail: autoDetail,
+                      results: autoReadSummaries,
+                    },
+                  }
+                : {}),
+              results: resultsForJson,
+            },
+            null,
+            2
+          )
         )
-      )
-    );
+      );
 
-    // Add page content - consolidate text per page to reduce content part count
-    // This prevents overwhelming the MCP client with thousands of small text fragments
-    for (const result of results) {
-      if (!result.success || !result.data?.page_contents) continue;
+      // Per-page text parts duplicate markdown/chunks already present in JSON.
+      const emitPerPageText = !options.includeMarkdown && !options.includeChunks;
 
-      // Process each page's content items in order
-      for (const pageContent of result.data.page_contents) {
-        // Consolidate all text items for this page into a single content part
-        const pageTextParts: string[] = [];
-        const pageImages: ExtractedImage[] = [];
-
-        for (const item of pageContent.items) {
-          if (item.type === 'text' && item.textContent) {
-            pageTextParts.push(item.textContent);
-          } else if (item.type === 'image' && item.imageData) {
-            pageImages.push(item.imageData);
-          }
-        }
-
-        // Add consolidated text for the page (preserves Y-coordinate order from sorting)
-        if (pageTextParts.length > 0) {
-          content.push(text(`[Page ${pageContent.page}]\n${pageTextParts.join('\n')}`));
-        }
-
-        // Add images for the page
-        if (options.includeImages) {
-          for (const img of pageImages) {
-            content.push(image(img.data, 'image/png'));
-          }
-        }
-      }
-    }
-
-    for (const result of results) {
-      if (!result.success || !result.data?.ocr_text_layer) continue;
-
-      for (const page of result.data.ocr_text_layer.pages) {
-        if (page.text.trim().length > 0) {
-          content.push(text(`[Page ${String(page.page)} OCR]\n${page.text}`));
-        }
-      }
-    }
-
-    // Add markdown tables at the end if tables were extracted
-    if (options.includeTables) {
-      const allTables: ExtractedTable[] = [];
+      // Add page content - consolidate text per page to reduce content part count
+      // This prevents overwhelming the MCP client with thousands of small text fragments
       for (const result of results) {
-        if (result.success && result.data?.tables) {
-          allTables.push(...result.data.tables);
+        if (!result.success || !result.data?.page_contents) continue;
+
+        // Process each page's content items in order
+        for (const pageContent of result.data.page_contents) {
+          // Consolidate all text items for this page into a single content part
+          const pageTextParts: string[] = [];
+          const pageImages: ExtractedImage[] = [];
+
+          for (const item of pageContent.items) {
+            if (item.type === 'text' && item.textContent) {
+              pageTextParts.push(item.textContent);
+            } else if (item.type === 'image' && item.imageData) {
+              pageImages.push(item.imageData);
+            }
+          }
+
+          // Add consolidated text for the page (preserves Y-coordinate order from sorting)
+          if (emitPerPageText && pageTextParts.length > 0) {
+            content.push(text(`[Page ${pageContent.page}]\n${pageTextParts.join('\n')}`));
+          }
+
+          // Add images for the page
+          if (options.includeImages) {
+            for (const img of pageImages) {
+              content.push(image(img.data, 'image/png'));
+            }
+          }
         }
       }
 
-      if (allTables.length > 0) {
-        const markdownTables = tablesToMarkdown(allTables);
-        content.push(text(markdownTables));
-      }
-    }
+      for (const result of results) {
+        if (!result.success || !result.data?.ocr_text_layer) continue;
 
-    return content;
+        for (const page of result.data.ocr_text_layer.pages) {
+          if (page.text.trim().length > 0) {
+            content.push(text(`[Page ${String(page.page)} OCR]\n${page.text}`));
+          }
+        }
+      }
+
+      // Add markdown tables at the end if tables were extracted
+      if (options.includeTables) {
+        const allTables: ExtractedTable[] = [];
+        for (const result of results) {
+          if (result.success && result.data?.tables) {
+            allTables.push(...result.data.tables);
+          }
+        }
+
+        if (allTables.length > 0) {
+          const markdownTables = tablesToMarkdown(allTables);
+          content.push(text(markdownTables));
+        }
+      }
+
+      return content;
+    } finally {
+      await session.destroyAll();
+    }
   });

--- a/src/pdf/autoReadPolicy.ts
+++ b/src/pdf/autoReadPolicy.ts
@@ -12,7 +12,13 @@ import type {
   PdfSource,
   PdfTrustRedactionPolicy,
 } from '../types/pdf.js';
-import { defaultInspectPdfOptions, inspectPdfSource } from './inspector.js';
+import {
+  DEFAULT_SAMPLE_PAGES,
+  defaultInspectPdfOptions,
+  inspectPdfSource,
+  selectInspectionSamplePages,
+} from './inspector.js';
+import type { PdfSessionScope } from './pdfSession.js';
 import { DEFAULT_VISUAL_ENRICHMENT_MAX_REGIONS } from './visualEnrichment.js';
 
 /** Maximum number of sources to process concurrently. */
@@ -177,6 +183,21 @@ export const buildReadOptions = (input: ReadPdfArgs): ReadPdfProcessingOptions =
   includeAccessibilityReport: input.include_accessibility_report ?? false,
 });
 
+/**
+ * Pages to extract during auto-read when the caller did not specify `pages`.
+ * Fast/balanced presets sample evenly across the document; full processes all pages.
+ */
+export const buildAutoExtractionPages = (
+  totalPages: number,
+  samplePageCount: number,
+  detail: ReadPdfAutoDetail
+): number[] => {
+  if (detail === 'full') {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+  return selectInspectionSamplePages(totalPages, undefined, samplePageCount);
+};
+
 export const buildAutoReadArgs = (
   source: PdfSource,
   inspection: PdfInspectionSourceResult,
@@ -184,16 +205,30 @@ export const buildAutoReadArgs = (
   detail: ReadPdfAutoDetail
 ): ReadPdfArgs => {
   const recommendationArgs = inspection.data?.recommendation.read_pdf_arguments ?? {};
+  const samplePages = input.sample_pages ?? DEFAULT_SAMPLE_PAGES;
+  const totalPages = inspection.data?.num_pages;
+  const extractionPages =
+    source.pages ??
+    (totalPages !== undefined
+      ? buildAutoExtractionPages(totalPages, samplePages, detail)
+      : undefined);
+
   return {
     ...recommendationArgs,
     ...buildAutoDetailOptions(detail),
     ...pickExplicitReadOptions(input),
-    sources: [source],
+    sources: [
+      {
+        ...source,
+        ...(extractionPages !== undefined ? { pages: extractionPages } : {}),
+      },
+    ],
   } as ReadPdfArgs;
 };
 
 export const buildAutoInspections = async (
-  input: ReadPdfArgs
+  input: ReadPdfArgs,
+  session?: PdfSessionScope
 ): Promise<PdfInspectionSourceResult[]> => {
   const inspectOptions = {
     ...defaultInspectPdfOptions(),
@@ -205,7 +240,7 @@ export const buildAutoInspections = async (
   for (let i = 0; i < input.sources.length; i += MAX_CONCURRENT_SOURCES) {
     const batch = input.sources.slice(i, i + MAX_CONCURRENT_SOURCES);
     const batchResults = await Promise.all(
-      batch.map((source) => inspectPdfSource(source, inspectOptions))
+      batch.map((source) => inspectPdfSource(source, inspectOptions, session))
     );
     inspections.push(...batchResults);
   }

--- a/src/pdf/inspector.ts
+++ b/src/pdf/inspector.ts
@@ -14,7 +14,7 @@ import type {
 } from '../types/pdf.js';
 import { PdfError } from '../utils/errors.js';
 import { createLogger } from '../utils/logger.js';
-import { destroyLoadingTask } from '../utils/pdfjs.js';
+
 import {
   buildWarnings,
   extractDocumentStructure,
@@ -22,14 +22,15 @@ import {
   extractPageGeometry,
   extractStructureTrees,
 } from './extractor.js';
-import { loadPdfDocument } from './loader.js';
+import { loadPdfDocument, releasePdfDocument } from './loader.js';
 import { getOcrProviderStatus } from './ocr.js';
 import { getTargetPages } from './parser.js';
+import type { PdfSessionScope } from './pdfSession.js';
 import { getRegionAnalysisProviderStatus } from './regionAnalysis.js';
 
 const logger = createLogger('Inspector');
 
-const DEFAULT_SAMPLE_PAGES = 5;
+export const DEFAULT_SAMPLE_PAGES = 5;
 const MAX_SAMPLE_PAGES = 20;
 const LOW_TEXT_CHAR_THRESHOLD = 20;
 const DIGITAL_TEXT_CHAR_THRESHOLD = 80;
@@ -565,15 +566,16 @@ export const buildInspectionRecommendation = (
 
 export const inspectPdfSource = async (
   source: PdfSource,
-  options: InspectPdfOptions
+  options: InspectPdfOptions,
+  session?: PdfSessionScope
 ): Promise<PdfInspectionSourceResult> => {
   const sourceDescription = source.path ?? source.url ?? 'unknown source';
+  const { pages: _pages, ...loadArgs } = source;
   let pdfDocument: pdfjsLib.PDFDocumentProxy | null = null;
 
   try {
     const targetPages = getTargetPages(source.pages, sourceDescription);
-    const { pages: _pages, ...loadArgs } = source;
-    pdfDocument = await loadPdfDocument(loadArgs, sourceDescription);
+    pdfDocument = await loadPdfDocument(loadArgs, sourceDescription, session);
     const totalPages = pdfDocument.numPages;
     const validTargetPages = targetPages?.filter((page) => page <= totalPages);
     const invalidPages = targetPages?.filter((page) => page > totalPages) ?? [];
@@ -666,10 +668,7 @@ export const inspectPdfSource = async (
       error: `Failed to inspect PDF from ${sourceDescription}.`,
     };
   } finally {
-    const loadingTask = pdfDocument?.loadingTask;
-    await destroyLoadingTask(loadingTask, logger, 'PDF document after inspection', {
-      sourceDescription,
-    });
+    await releasePdfDocument(loadArgs, pdfDocument, sourceDescription, session);
   }
 };
 

--- a/src/pdf/loader.ts
+++ b/src/pdf/loader.ts
@@ -13,6 +13,8 @@ import {
 import { ErrorCode, PdfError } from '../utils/errors.js';
 import { createLogger } from '../utils/logger.js';
 import { resolvePath } from '../utils/pathUtils.js';
+import { destroyLoadingTask } from '../utils/pdfjs.js';
+import type { PdfSessionScope } from './pdfSession.js';
 
 const logger = createLogger('Loader');
 
@@ -246,7 +248,7 @@ const fetchUrlBody = async (url: string, config: SecurityConfig): Promise<Uint8A
  * @param sourceDescription - Description for error messages
  * @returns PDF document proxy
  */
-export const loadPdfDocument = async (
+export const loadPdfDocumentCore = async (
   source: { path?: string | undefined; url?: string | undefined },
   sourceDescription: string
 ): Promise<pdfjsLib.PDFDocumentProxy> => {
@@ -300,4 +302,36 @@ export const loadPdfDocument = async (
       { cause: err instanceof Error ? err : undefined }
     );
   }
+};
+
+/**
+ * Load a PDF document, reusing a parsed handle from `session` when provided.
+ */
+export const loadPdfDocument = async (
+  source: { path?: string | undefined; url?: string | undefined },
+  sourceDescription: string,
+  session?: PdfSessionScope
+): Promise<pdfjsLib.PDFDocumentProxy> => {
+  if (session) {
+    return session.acquire(source, sourceDescription);
+  }
+  return loadPdfDocumentCore(source, sourceDescription);
+};
+
+/**
+ * Release a PDF document acquired through `session`, or destroy a standalone load.
+ */
+export const releasePdfDocument = async (
+  source: { path?: string | undefined; url?: string | undefined },
+  pdfDocument: pdfjsLib.PDFDocumentProxy | null,
+  sourceDescription: string,
+  session?: PdfSessionScope
+): Promise<void> => {
+  if (session) {
+    session.release(source);
+    return;
+  }
+  await destroyLoadingTask(pdfDocument?.loadingTask, logger, 'PDF document', {
+    sourceDescription,
+  });
 };

--- a/src/pdf/ocr.ts
+++ b/src/pdf/ocr.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import type * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.mjs';
 import type {
   OcrPagesOptions,
   PdfOcrPageData,
@@ -630,19 +631,24 @@ export const ocrRenderedPageWithCommandProvider = async (
 
 export const ocrPdfSourcePages = async (
   source: PdfSource,
-  options: OcrPagesOptions
+  options: OcrPagesOptions,
+  existingDocument?: pdfjsLib.PDFDocumentProxy | null
 ): Promise<{
   source: string;
   numPages: number;
   pages: PdfOcrPageData[];
   warnings: string[];
 }> => {
-  const rendered = await renderPdfSourcePages(source, {
-    scale: options.scale,
-    max_pages: options.max_pages,
-    max_pixels_per_page: options.max_pixels_per_page,
-    include_image: false,
-  });
+  const rendered = await renderPdfSourcePages(
+    source,
+    {
+      scale: options.scale,
+      max_pages: options.max_pages,
+      max_pixels_per_page: options.max_pixels_per_page,
+      include_image: false,
+    },
+    existingDocument
+  );
   const pages: PdfOcrPageData[] = [];
 
   for (const page of rendered.pages) {

--- a/src/pdf/pdfSession.ts
+++ b/src/pdf/pdfSession.ts
@@ -1,0 +1,61 @@
+// Request-scoped PDF document session — one parse per source per MCP request.
+
+import type * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.mjs';
+import { createLogger } from '../utils/logger.js';
+import { destroyLoadingTask } from '../utils/pdfjs.js';
+import { loadPdfDocumentCore } from './loader.js';
+
+const logger = createLogger('PdfSession');
+
+export const pdfSessionKey = (source: {
+  path?: string | undefined;
+  url?: string | undefined;
+}): string => source.path ?? source.url ?? '';
+
+type SessionEntry = {
+  pdfDocument: pdfjsLib.PDFDocumentProxy;
+  refCount: number;
+};
+
+/**
+ * Holds parsed PDF documents for the lifetime of one MCP tool request so
+ * inspection, extraction, OCR, and region crops reuse the same pdfjs parse.
+ */
+export class PdfSessionScope {
+  private readonly entries = new Map<string, SessionEntry>();
+
+  async acquire(
+    source: { path?: string | undefined; url?: string | undefined },
+    sourceDescription: string
+  ): Promise<pdfjsLib.PDFDocumentProxy> {
+    const key = pdfSessionKey(source);
+    const existing = this.entries.get(key);
+    if (existing) {
+      existing.refCount += 1;
+      return existing.pdfDocument;
+    }
+
+    const pdfDocument = await loadPdfDocumentCore(source, sourceDescription);
+    this.entries.set(key, { pdfDocument, refCount: 1 });
+    return pdfDocument;
+  }
+
+  release(source: { path?: string | undefined; url?: string | undefined }): void {
+    const key = pdfSessionKey(source);
+    const entry = this.entries.get(key);
+    if (!entry) return;
+    entry.refCount = Math.max(0, entry.refCount - 1);
+  }
+
+  async destroyAll(): Promise<void> {
+    for (const [, entry] of this.entries) {
+      await destroyLoadingTask(entry.pdfDocument.loadingTask, logger, 'PDF session document');
+    }
+    this.entries.clear();
+  }
+
+  /** Test helper: number of distinct parsed sources currently held. */
+  activeSourceCount(): number {
+    return this.entries.size;
+  }
+}

--- a/src/pdf/readCoordinator.ts
+++ b/src/pdf/readCoordinator.ts
@@ -31,7 +31,7 @@ import type {
 import { safeErrorMessage } from '../utils/errorHandling.js';
 import { PdfError } from '../utils/errors.js';
 import { createLogger } from '../utils/logger.js';
-import { destroyLoadingTask } from '../utils/pdfjs.js';
+
 import { buildAccessibilityReport } from './accessibilityReport.js';
 import type { ReadPdfProcessingOptions } from './autoReadPolicy.js';
 import { buildDocumentAst } from './documentAst.js';
@@ -53,9 +53,10 @@ import {
   extractPageGeometry,
   extractStructureTrees,
 } from './extractor.js';
-import { loadPdfDocument } from './loader.js';
+import { loadPdfDocument, releasePdfDocument } from './loader.js';
 import { buildOcrTextLayer, defaultOcrPagesOptions, ocrPdfSourcePages } from './ocr.js';
 import { determinePagesToProcess, getTargetPages } from './parser.js';
+import type { PdfSessionScope } from './pdfSession.js';
 import {
   extractTables,
   extractTablesFromOcrTextLayer,
@@ -89,9 +90,11 @@ const selectOcrTextLayerPages = (
  */
 export const processSingleSource = async (
   source: PdfSource,
-  options: ReadPdfProcessingOptions
+  options: ReadPdfProcessingOptions,
+  session?: PdfSessionScope
 ): Promise<PdfSourceResult> => {
   const sourceDescription = source.path ?? source.url ?? 'unknown source';
+  const { pages: _pages, ...loadArgs } = source;
   let individualResult: PdfSourceResult = { source: sourceDescription, success: false };
   let pdfDocument: pdfjsLib.PDFDocumentProxy | null = null;
 
@@ -100,8 +103,7 @@ export const processSingleSource = async (
     const targetPages = getTargetPages(source.pages, sourceDescription);
 
     // Load PDF document
-    const { pages: _pages, ...loadArgs } = source;
-    pdfDocument = await loadPdfDocument(loadArgs, sourceDescription);
+    pdfDocument = await loadPdfDocument(loadArgs, sourceDescription, session);
     const totalPages = pdfDocument.numPages;
 
     // Extract metadata and page count
@@ -280,7 +282,8 @@ export const processSingleSource = async (
           try {
             const ocr = await ocrPdfSourcePages(
               { ...source, pages: ocrPages },
-              defaultOcrPagesOptions()
+              defaultOcrPagesOptions(),
+              pdfDocument
             );
             ocrTextLayer = buildOcrTextLayer(ocr.pages, ocr.warnings);
             output.ocr_text_layer = ocrTextLayer;
@@ -384,6 +387,7 @@ export const processSingleSource = async (
           elements: visualElements,
           pageGeometry,
           maxVisualEnrichments: options.maxVisualEnrichments,
+          pdfDocument,
         });
         visualEnrichmentCandidates = enriched.visualEnrichmentCandidates;
         if (visualEnrichmentCandidates.length > 0) {
@@ -516,13 +520,7 @@ export const processSingleSource = async (
     individualResult.success = false;
     individualResult.data = undefined;
   } finally {
-    // Clean up PDF document resources. pdfjs v6 moved teardown off the
-    // document proxy: PDFDocumentProxy.destroy() is gone, so we destroy the
-    // owning loadingTask (aborts network + terminates the worker). Guarded so
-    // a future API shift can't throw inside finally.
-    await destroyLoadingTask(pdfDocument?.loadingTask, logger, 'PDF document', {
-      sourceDescription,
-    });
+    await releasePdfDocument(loadArgs, pdfDocument, sourceDescription, session);
   }
 
   return individualResult;

--- a/src/pdf/regionAnalysis.ts
+++ b/src/pdf/regionAnalysis.ts
@@ -1249,19 +1249,24 @@ export const analyzeRegionCropWithConfiguredProvider = async (
 
 export const analyzePdfRegionsFromSource = async (
   source: { path?: string | undefined; url?: string | undefined; regions: PdfRegionRequest[] },
-  options: AnalyzeRegionsOptions
+  options: AnalyzeRegionsOptions,
+  existingDocument?: import('pdfjs-dist/legacy/build/pdf.mjs').PDFDocumentProxy | null
 ): Promise<{
   source: string;
   numPages: number;
   analyses: PdfRegionAnalysisData[];
   warnings: string[];
 }> => {
-  const cropped = await extractRegionCropsFromSource(source, {
-    scale: options.scale,
-    max_regions: options.max_regions,
-    max_pixels_per_page: options.max_pixels_per_page,
-    include_image: false,
-  });
+  const cropped = await extractRegionCropsFromSource(
+    source,
+    {
+      scale: options.scale,
+      max_regions: options.max_regions,
+      max_pixels_per_page: options.max_pixels_per_page,
+      include_image: false,
+    },
+    existingDocument
+  );
   const analyses: PdfRegionAnalysisData[] = [];
 
   for (const region of cropped.regions) {

--- a/src/pdf/regions.ts
+++ b/src/pdf/regions.ts
@@ -186,7 +186,8 @@ export const cropRegionsFromRenderedPage = (
 
 export const extractRegionCropsFromSource = async (
   source: { path?: string | undefined; url?: string | undefined; regions: PdfRegionRequest[] },
-  options: ExtractRegionsOptions
+  options: ExtractRegionsOptions,
+  existingDocument?: pdfjsLib.PDFDocumentProxy | null
 ): Promise<{
   source: string;
   numPages: number;
@@ -194,10 +195,16 @@ export const extractRegionCropsFromSource = async (
   warnings: string[];
 }> => {
   const sourceDescription = source.path ?? source.url ?? 'unknown source';
-  let pdfDocument: pdfjsLib.PDFDocumentProxy | null = null;
+  const ownsDocument = existingDocument === undefined || existingDocument === null;
+  let pdfDocument: pdfjsLib.PDFDocumentProxy | null = existingDocument ?? null;
 
   try {
-    pdfDocument = await loadPdfDocument({ path: source.path, url: source.url }, sourceDescription);
+    if (!pdfDocument) {
+      pdfDocument = await loadPdfDocument(
+        { path: source.path, url: source.url },
+        sourceDescription
+      );
+    }
     const totalPages = pdfDocument.numPages;
     const { regionsToCrop, invalidPages, truncatedCount } = selectRegionsToCrop(
       source.regions,
@@ -230,10 +237,12 @@ export const extractRegionCropsFromSource = async (
 
     return { source: sourceDescription, numPages: totalPages, regions: crops, warnings };
   } finally {
-    const loadingTask = pdfDocument?.loadingTask;
-    await destroyLoadingTask(loadingTask, logger, 'region crop PDF document', {
-      sourceDescription,
-    });
+    if (ownsDocument) {
+      const loadingTask = pdfDocument?.loadingTask;
+      await destroyLoadingTask(loadingTask, logger, 'region crop PDF document', {
+        sourceDescription,
+      });
+    }
   }
 };
 

--- a/src/pdf/renderer.ts
+++ b/src/pdf/renderer.ts
@@ -171,7 +171,8 @@ export const renderPdfPage = async (
 
 export const renderPdfSourcePages = async (
   source: PdfSource,
-  options: RenderPageOptions
+  options: RenderPageOptions,
+  existingDocument?: pdfjsLib.PDFDocumentProxy | null
 ): Promise<{
   source: string;
   numPages: number;
@@ -179,12 +180,15 @@ export const renderPdfSourcePages = async (
   warnings: string[];
 }> => {
   const sourceDescription = source.path ?? source.url ?? 'unknown source';
-  let pdfDocument: pdfjsLib.PDFDocumentProxy | null = null;
+  const { pages: _pages, ...loadArgs } = source;
+  const ownsDocument = existingDocument === undefined || existingDocument === null;
+  let pdfDocument: pdfjsLib.PDFDocumentProxy | null = existingDocument ?? null;
 
   try {
     const targetPages = getTargetPages(source.pages, sourceDescription);
-    const { pages: _pages, ...loadArgs } = source;
-    pdfDocument = await loadPdfDocument(loadArgs, sourceDescription);
+    if (!pdfDocument) {
+      pdfDocument = await loadPdfDocument(loadArgs, sourceDescription);
+    }
     const totalPages = pdfDocument.numPages;
     const { pagesToRender, invalidPages, truncatedPages } = resolvePagesToRender(
       targetPages,
@@ -218,7 +222,9 @@ export const renderPdfSourcePages = async (
 
     return { source: sourceDescription, numPages: totalPages, pages, warnings };
   } finally {
-    const loadingTask = pdfDocument?.loadingTask;
-    await destroyLoadingTask(loadingTask, logger, 'rendered PDF document', { sourceDescription });
+    if (ownsDocument) {
+      const loadingTask = pdfDocument?.loadingTask;
+      await destroyLoadingTask(loadingTask, logger, 'rendered PDF document', { sourceDescription });
+    }
   }
 };

--- a/src/pdf/visualEnrichment.ts
+++ b/src/pdf/visualEnrichment.ts
@@ -1,3 +1,4 @@
+import type * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.mjs';
 import type {
   BoundingBox,
   PdfDocumentElement,
@@ -44,6 +45,7 @@ export interface BuildVisualEnrichmentsInput {
   elements: PdfDocumentElement[];
   pageGeometry?: PdfPageGeometry[] | undefined;
   maxVisualEnrichments: number;
+  pdfDocument?: pdfjsLib.PDFDocumentProxy | null;
 }
 
 export interface BuildVisualEnrichmentsOutput {
@@ -473,7 +475,8 @@ export const buildVisualEnrichmentsForSource = async (
         url: input.source.url,
         regions: candidates.map((candidate) => candidate.region),
       },
-      options
+      options,
+      input.pdfDocument
     );
 
     return {

--- a/test/handlers/readPdf.test.ts
+++ b/test/handlers/readPdf.test.ts
@@ -600,6 +600,28 @@ describe('handleReadPdfFunc Integration Tests', () => {
     expect(parsed.results[0]?.data?.document_map).toBeDefined();
   });
 
+  it('reuses one parsed PDF per source on default auto-read', async () => {
+    const loaderModule = await import('../../src/pdf/loader.js');
+    const loadCoreSpy = vi.spyOn(loaderModule, 'loadPdfDocumentCore');
+
+    try {
+      await handler({ sources: [{ path: 'test.pdf' }] });
+      expect(loadCoreSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      loadCoreSpy.mockRestore();
+    }
+  });
+
+  it('omits redundant per-page text parts when markdown and chunks are enabled by default', async () => {
+    const result = await handler({ sources: [{ path: 'test.pdf' }] });
+
+    const pageTextParts = result.content.filter(
+      (part) => part.type === 'text' && part.text?.startsWith('[Page ')
+    );
+    expect(pageTextParts).toHaveLength(0);
+    expect(result.content[0]?.text).toContain('"markdown"');
+  });
+
   it('should include structured elements without forcing full text output', async () => {
     const args = {
       sources: [{ path: 'test.pdf' }],
@@ -1483,7 +1505,8 @@ describe('handleReadPdfFunc Integration Tests', () => {
 
     expect(mockOcrPdfSourcePages).toHaveBeenCalledWith(
       { path: 'scanned.pdf', pages: [1] },
-      expect.objectContaining({ scale: 2, max_pages: 5 })
+      expect.objectContaining({ scale: 2, max_pages: 5 }),
+      expect.objectContaining({ numPages: expect.any(Number) })
     );
 
     if (result.content?.[0]) {
@@ -1671,7 +1694,8 @@ describe('handleReadPdfFunc Integration Tests', () => {
 
     expect(mockOcrPdfSourcePages).toHaveBeenCalledWith(
       { path: 'scanned-table.pdf', pages: [1] },
-      expect.objectContaining({ scale: 2, max_pages: 5 })
+      expect.objectContaining({ scale: 2, max_pages: 5 }),
+      expect.objectContaining({ numPages: expect.any(Number) })
     );
     expect(tableInfo).toMatchObject({
       page: 1,

--- a/test/pdf/loader.test.ts
+++ b/test/pdf/loader.test.ts
@@ -308,19 +308,24 @@ describe('loader', () => {
           }) as pdfjsLib.PDFDocumentLoadingTask
       );
 
-      await expect(loadPdfDocument({ path: 'bad.pdf' }, 'bad.pdf')).rejects.toThrow(PdfError);
-      await expect(loadPdfDocument({ path: 'bad.pdf' }, 'bad.pdf')).rejects.toThrow(
-        'Failed to load PDF document from bad.pdf.'
-      );
-      // The internal path must NOT make it into the surfaced error.
-      await expect(loadPdfDocument({ path: 'bad.pdf' }, 'bad.pdf')).rejects.not.toThrow(
-        /private\/internal/
-      );
+      try {
+        await expect(loadPdfDocument({ path: 'bad.pdf' }, 'bad.pdf')).rejects.toThrow(PdfError);
+        await expect(loadPdfDocument({ path: 'bad.pdf' }, 'bad.pdf')).rejects.toThrow(
+          'Failed to load PDF document from bad.pdf.'
+        );
+        // The internal path must NOT make it into the surfaced error.
+        await expect(loadPdfDocument({ path: 'bad.pdf' }, 'bad.pdf')).rejects.not.toThrow(
+          /private\/internal/
+        );
 
-      // Logger still records the raw details for operators.
-      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('PDF.js loading error'));
-
-      consoleErrorSpy.mockRestore();
+        // Logger still records the raw details for operators.
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('PDF.js loading error')
+        );
+      } finally {
+        pdfjsLib.getDocument.mockReset();
+        consoleErrorSpy.mockRestore();
+      }
     });
 
     it('should handle non-Error PDF.js loading exceptions', async () => {
@@ -338,16 +343,19 @@ describe('loader', () => {
         () => ({ promise: Promise.reject('Unknown error') }) as pdfjsLib.PDFDocumentLoadingTask
       );
 
-      await expect(
-        loadPdfDocument({ url: 'https://example.com/bad.pdf' }, 'https://example.com/bad.pdf')
-      ).rejects.toThrow('Failed to load PDF document from https://example.com/bad.pdf');
-
-      consoleErrorSpy.mockRestore();
+      try {
+        await expect(
+          loadPdfDocument({ url: 'https://example.com/bad.pdf' }, 'https://example.com/bad.pdf')
+        ).rejects.toThrow('Failed to load PDF document from https://example.com/bad.pdf');
+      } finally {
+        pdfjsLib.getDocument.mockReset();
+        consoleErrorSpy.mockRestore();
+      }
     });
 
     it('should propagate PdfError from resolvePath', async () => {
       const pdfError = new PdfError(ErrorCode.InvalidRequest, 'Path validation failed');
-      pathUtils.resolvePath.mockImplementation(() => {
+      pathUtils.resolvePath.mockImplementationOnce(() => {
         throw pdfError;
       });
 

--- a/test/pdf/readPdfOverhead.test.ts
+++ b/test/pdf/readPdfOverhead.test.ts
@@ -1,0 +1,117 @@
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildAutoExtractionPages,
+  buildAutoReadArgs,
+  buildReadOptions,
+} from '../../src/pdf/autoReadPolicy.js';
+import * as loader from '../../src/pdf/loader.js';
+import { PdfSessionScope } from '../../src/pdf/pdfSession.js';
+import type { PdfInspectionSourceResult } from '../../src/types/pdf.js';
+
+const SAMPLE_PDF = path.resolve('test/fixtures/sample.pdf');
+
+describe('read_pdf overhead optimizations', () => {
+  it('bounds balanced auto-read extraction pages to the sample budget', () => {
+    const inspection: PdfInspectionSourceResult = {
+      source: SAMPLE_PDF,
+      success: true,
+      data: {
+        profile: 'digital_text',
+        num_pages: 100,
+        sampled_pages: [1, 26, 51, 76, 100],
+        page_signals: [],
+        document_signals: {
+          has_outline: false,
+          has_page_labels: false,
+          has_permissions: false,
+          has_mark_info: false,
+          has_form_fields: false,
+          has_attachments: false,
+          has_structure_tree: false,
+        },
+        recommendation: {
+          workflow: 'agentic_rag',
+          needs_ocr: false,
+          reason: 'test',
+          read_pdf_arguments: {},
+          next_tools: [],
+        },
+        provider_status: {
+          ocr_pages: {
+            readiness: 'not_configured',
+            provider: 'command',
+            command_configured: false,
+            health: 'not_checked',
+            health_check: 'not_checked',
+          },
+          analyze_regions: {
+            readiness: 'not_configured',
+            provider: 'command',
+            command_configured: false,
+            health: 'not_checked',
+            health_check: 'not_checked',
+          },
+        },
+      },
+    };
+
+    const args = buildAutoReadArgs(
+      { path: SAMPLE_PDF },
+      inspection,
+      { sources: [{ path: SAMPLE_PDF }] },
+      'balanced'
+    );
+
+    expect(args.sources[0]?.pages?.length).toBe(5);
+    expect(args.sources[0]?.pages?.every((page) => page >= 1 && page <= 100)).toBe(true);
+  });
+
+  it('processes all pages for full auto_detail', () => {
+    const pages = buildAutoExtractionPages(12, 5, 'full');
+    expect(pages).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+  });
+
+  it('enables markdown and chunks for default auto-read options', () => {
+    expect(
+      buildReadOptions({ sources: [{ path: SAMPLE_PDF }], include_markdown: true }).includeMarkdown
+    ).toBe(true);
+  });
+});
+
+describe('PdfSessionScope', () => {
+  let loadCoreSpy: ReturnType<typeof vi.spyOn>;
+
+  afterEach(() => {
+    loadCoreSpy?.mockRestore();
+  });
+
+  it('tracks a single active source across acquire/release', async () => {
+    const session = new PdfSessionScope();
+    const destroyLoadingTask = vi.fn().mockResolvedValue(undefined);
+    const fakeDoc = {
+      numPages: 1,
+      loadingTask: { destroy: destroyLoadingTask },
+    };
+    loadCoreSpy = vi
+      .spyOn(loader, 'loadPdfDocumentCore')
+      .mockResolvedValue(
+        fakeDoc as unknown as Awaited<ReturnType<typeof loader.loadPdfDocumentCore>>
+      );
+
+    const first = await session.acquire({ path: SAMPLE_PDF }, SAMPLE_PDF);
+    const second = await session.acquire({ path: SAMPLE_PDF }, SAMPLE_PDF);
+
+    expect(first).toBe(second);
+    expect(loadCoreSpy).toHaveBeenCalledTimes(1);
+    expect(session.activeSourceCount()).toBe(1);
+
+    session.release({ path: SAMPLE_PDF });
+    session.release({ path: SAMPLE_PDF });
+    expect(session.activeSourceCount()).toBe(1);
+
+    await session.destroyAll();
+    expect(session.activeSourceCount()).toBe(0);
+    expect(destroyLoadingTask).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Introduces `PdfSessionScope` so inspection, extraction, OCR, and visual enrichment reuse one pdfjs parse per source per MCP request.
- Bounds balanced/fast default auto-read page extraction to the inspection sample budget (default 5 evenly spaced pages) instead of full-document extraction on large PDFs.
- Omits redundant `[Page N]` MCP text content parts when markdown/chunks already carry the same text in the JSON payload.
- Adds regression tests and refreshes performance benchmark artifacts.

## Benchmarks

| Profile | Before (ms) | After (ms) |
|---|---:|---:|
| `v3_agent_document_twin` | 17.32 | 17.39 |
| `full_text` | 8.89 | 8.72 |
| `selected_page_text` | 7.85 | 7.70 |

Release gate passes with updated `benchmark-artifacts/pdf_performance_benchmark.json`.

## Validation

- `bun run typecheck`
- `bun run check`
- `bun run test` (388 pass)
- `bun run build`
- `bun run package:smoke`
- `MCP_PDF_BENCHMARK_OUTPUT_DIR=benchmark-artifacts bun run benchmark:release-gate`

## Changeset

Patch release via `.changeset/read-pdf-overhead-optimization.md`.