### PR TITLE
fix(read_pdf): harden session reuse and auto-read overhead paths

### DIFF
--- a/.changeset/read-pdf-overhead-hardening.md
+++ b/.changeset/read-pdf-overhead-hardening.md
@@ -1,0 +1,5 @@
+---
+"@sylphx/pdf-reader-mcp": patch
+---
+
+Harden read_pdf overhead optimizations: serialize concurrent PdfSession acquires, skip auto-read when callers only specify source pages, add default balanced auto-read benchmark coverage, and expand regression tests for page budgets and session document reuse.

--- a/benchmark-artifacts/pdf_performance_benchmark.json
+++ b/benchmark-artifacts/pdf_performance_benchmark.json
@@ -7,30 +7,37 @@
     {
       "name": "metadata_page_count",
       "iterations": 20,
-      "average_ms": 1.13,
-      "min_ms": 0.66,
-      "max_ms": 2.49
+      "average_ms": 0.83,
+      "min_ms": 0.5,
+      "max_ms": 2.56
     },
     {
       "name": "full_text",
       "iterations": 20,
-      "average_ms": 13.1,
-      "min_ms": 8.69,
-      "max_ms": 17.55
+      "average_ms": 10.53,
+      "min_ms": 6.05,
+      "max_ms": 15.46
     },
     {
       "name": "selected_page_text",
       "iterations": 20,
-      "average_ms": 10.86,
-      "min_ms": 6.85,
-      "max_ms": 20.99
+      "average_ms": 7.76,
+      "min_ms": 5.33,
+      "max_ms": 10.92
+    },
+    {
+      "name": "default_auto_read_balanced",
+      "iterations": 20,
+      "average_ms": 19.73,
+      "min_ms": 16.99,
+      "max_ms": 28.68
     },
     {
       "name": "v3_agent_document_twin",
       "iterations": 20,
-      "average_ms": 25.67,
-      "min_ms": 19.77,
-      "max_ms": 32.75
+      "average_ms": 21.45,
+      "min_ms": 17.35,
+      "max_ms": 28.69
     }
   ]
 }

--- a/benchmark-artifacts/pdf_sota_release_gate.json
+++ b/benchmark-artifacts/pdf_sota_release_gate.json
@@ -1,11 +1,11 @@
 {
   "profile": "pdf_sota_release_gate",
-  "generated_at": "2026-07-08T17:42:09.326Z",
-  "artifact_dir": "/home/runner/work/pdf-reader-mcp/pdf-reader-mcp/benchmark-artifacts",
+  "generated_at": "2026-07-08T17:55:08.788Z",
+  "artifact_dir": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/benchmark-artifacts",
   "status": "passed",
   "summary": {
-    "total": 39,
-    "passed": 39,
+    "total": 41,
+    "passed": 41,
     "failed": 0
   },
   "checks": [
@@ -127,7 +127,20 @@
       "status": "passed",
       "message": "v3 Agent Document Twin scenario has a positive average latency",
       "evidence": {
-        "average_ms": 25.67
+        "average_ms": 21.45
+      }
+    },
+    {
+      "id": "performance:default-auto-read-present",
+      "status": "passed",
+      "message": "performance artifact includes the default balanced auto-read scenario"
+    },
+    {
+      "id": "performance:default-auto-read-timed",
+      "status": "passed",
+      "message": "default balanced auto-read scenario has a positive average latency",
+      "evidence": {
+        "average_ms": 19.73
       }
     },
     {

--- a/dist/index.js
+++ b/dist/index.js
@@ -4502,7 +4502,14 @@ var pickExplicitReadOptions = (input) => {
   return options;
 };
 var hasExplicitReadOptions = (input) => explicitReadOptionKeys.some((key) => input[key] !== undefined);
-var shouldUseAutoRead = (input) => input.auto ?? !hasExplicitReadOptions(input);
+var hasExplicitSourcePageSelection = (input) => input.sources.some((source) => source.pages !== undefined);
+var shouldUseAutoRead = (input) => {
+  if (input.auto === false)
+    return false;
+  if (input.auto === true)
+    return true;
+  return !hasExplicitReadOptions(input) && !hasExplicitSourcePageSelection(input);
+};
 var buildAutoDetailOptions = (detail) => {
   const fast = {
     include_metadata: true,
@@ -4616,6 +4623,7 @@ var pdfSessionKey = (source) => source.path ?? source.url ?? "";
 
 class PdfSessionScope {
   entries = new Map;
+  pending = new Map;
   async acquire(source, sourceDescription) {
     const key = pdfSessionKey(source);
     const existing = this.entries.get(key);
@@ -4623,9 +4631,28 @@ class PdfSessionScope {
       existing.refCount += 1;
       return existing.pdfDocument;
     }
-    const pdfDocument = await loadPdfDocumentCore(source, sourceDescription);
-    this.entries.set(key, { pdfDocument, refCount: 1 });
-    return pdfDocument;
+    let pending = this.pending.get(key);
+    if (!pending) {
+      pending = loadPdfDocumentCore(source, sourceDescription).then(async (pdfDocument) => {
+        const raced = this.entries.get(key);
+        if (raced) {
+          await destroyLoadingTask(pdfDocument.loadingTask, logger14, "PDF session duplicate");
+          return raced.pdfDocument;
+        }
+        this.entries.set(key, { pdfDocument, refCount: 0 });
+        return pdfDocument;
+      }).finally(() => {
+        this.pending.delete(key);
+      });
+      this.pending.set(key, pending);
+    }
+    await pending;
+    const entry = this.entries.get(key);
+    if (!entry) {
+      throw new Error(`PDF session entry missing after acquire for ${key}`);
+    }
+    entry.refCount += 1;
+    return entry.pdfDocument;
   }
   release(source) {
     const key = pdfSessionKey(source);
@@ -4635,10 +4662,10 @@ class PdfSessionScope {
     entry.refCount = Math.max(0, entry.refCount - 1);
   }
   async destroyAll() {
-    for (const [, entry] of this.entries) {
-      await destroyLoadingTask(entry.pdfDocument.loadingTask, logger14, "PDF session document");
-    }
+    this.pending.clear();
+    const entries = [...this.entries.values()];
     this.entries.clear();
+    await Promise.all(entries.map((entry) => destroyLoadingTask(entry.pdfDocument.loadingTask, logger14, "PDF session document")));
   }
   activeSourceCount() {
     return this.entries.size;

--- a/scripts/benchmark-pdf-intelligence.ts
+++ b/scripts/benchmark-pdf-intelligence.ts
@@ -94,6 +94,12 @@ const main = async () => {
       },
     },
     {
+      name: 'default_auto_read_balanced',
+      input: {
+        sources: [{ path: SAMPLE_PDF_PATH }],
+      },
+    },
+    {
       name: 'v3_agent_document_twin',
       input: {
         sources: [{ path: SAMPLE_PDF_PATH, pages: [1] }],

--- a/scripts/sota-release-gate.ts
+++ b/scripts/sota-release-gate.ts
@@ -211,6 +211,9 @@ export const buildSotaReleaseGateReport = async (
   const documentTwinPerformance = performanceResults.find(
     (result) => result.name === 'v3_agent_document_twin'
   );
+  const defaultAutoReadPerformance = performanceResults.find(
+    (result) => result.name === 'default_auto_read_balanced'
+  );
   addCheck(
     checks,
     'performance:document-twin-present',
@@ -223,6 +226,19 @@ export const buildSotaReleaseGateReport = async (
     (getNumber(documentTwinPerformance, 'average_ms') ?? 0) > 0,
     'v3 Agent Document Twin scenario has a positive average latency',
     { average_ms: documentTwinPerformance?.average_ms }
+  );
+  addCheck(
+    checks,
+    'performance:default-auto-read-present',
+    defaultAutoReadPerformance !== undefined,
+    'performance artifact includes the default balanced auto-read scenario'
+  );
+  addCheck(
+    checks,
+    'performance:default-auto-read-timed',
+    (getNumber(defaultAutoReadPerformance, 'average_ms') ?? 0) > 0,
+    'default balanced auto-read scenario has a positive average latency',
+    { average_ms: defaultAutoReadPerformance?.average_ms }
   );
 
   const qualityPassed = getNumber(artifacts.quality, 'passed');

--- a/src/pdf/autoReadPolicy.ts
+++ b/src/pdf/autoReadPolicy.ts
@@ -106,8 +106,15 @@ const pickExplicitReadOptions = (input: ReadPdfArgs): Partial<ReadPdfArgs> => {
 export const hasExplicitReadOptions = (input: ReadPdfArgs): boolean =>
   explicitReadOptionKeys.some((key) => input[key] !== undefined);
 
-export const shouldUseAutoRead = (input: ReadPdfArgs): boolean =>
-  input.auto ?? !hasExplicitReadOptions(input);
+/** True when any source already pins explicit page selection. */
+export const hasExplicitSourcePageSelection = (input: ReadPdfArgs): boolean =>
+  input.sources.some((source) => source.pages !== undefined);
+
+export const shouldUseAutoRead = (input: ReadPdfArgs): boolean => {
+  if (input.auto === false) return false;
+  if (input.auto === true) return true;
+  return !hasExplicitReadOptions(input) && !hasExplicitSourcePageSelection(input);
+};
 
 /** Preset include_* options for each auto_detail level. */
 export const buildAutoDetailOptions = (detail: ReadPdfAutoDetail): Partial<ReadPdfArgs> => {

--- a/src/pdf/pdfSession.ts
+++ b/src/pdf/pdfSession.ts
@@ -23,6 +23,7 @@ type SessionEntry = {
  */
 export class PdfSessionScope {
   private readonly entries = new Map<string, SessionEntry>();
+  private readonly pending = new Map<string, Promise<pdfjsLib.PDFDocumentProxy>>();
 
   async acquire(
     source: { path?: string | undefined; url?: string | undefined },
@@ -35,9 +36,31 @@ export class PdfSessionScope {
       return existing.pdfDocument;
     }
 
-    const pdfDocument = await loadPdfDocumentCore(source, sourceDescription);
-    this.entries.set(key, { pdfDocument, refCount: 1 });
-    return pdfDocument;
+    let pending = this.pending.get(key);
+    if (!pending) {
+      pending = loadPdfDocumentCore(source, sourceDescription)
+        .then(async (pdfDocument) => {
+          const raced = this.entries.get(key);
+          if (raced) {
+            await destroyLoadingTask(pdfDocument.loadingTask, logger, 'PDF session duplicate');
+            return raced.pdfDocument;
+          }
+          this.entries.set(key, { pdfDocument, refCount: 0 });
+          return pdfDocument;
+        })
+        .finally(() => {
+          this.pending.delete(key);
+        });
+      this.pending.set(key, pending);
+    }
+
+    await pending;
+    const entry = this.entries.get(key);
+    if (!entry) {
+      throw new Error(`PDF session entry missing after acquire for ${key}`);
+    }
+    entry.refCount += 1;
+    return entry.pdfDocument;
   }
 
   release(source: { path?: string | undefined; url?: string | undefined }): void {
@@ -45,13 +68,20 @@ export class PdfSessionScope {
     const entry = this.entries.get(key);
     if (!entry) return;
     entry.refCount = Math.max(0, entry.refCount - 1);
+    // Keep the parsed document at refCount 0 so later stages in the same MCP
+    // request (inspection → extraction → OCR/visual) can re-acquire without
+    // reparsing. destroyAll() tears everything down at request end.
   }
 
   async destroyAll(): Promise<void> {
-    for (const [, entry] of this.entries) {
-      await destroyLoadingTask(entry.pdfDocument.loadingTask, logger, 'PDF session document');
-    }
+    this.pending.clear();
+    const entries = [...this.entries.values()];
     this.entries.clear();
+    await Promise.all(
+      entries.map((entry) =>
+        destroyLoadingTask(entry.pdfDocument.loadingTask, logger, 'PDF session document')
+      )
+    );
   }
 
   /** Test helper: number of distinct parsed sources currently held. */

--- a/test/handlers/readPdf.test.ts
+++ b/test/handlers/readPdf.test.ts
@@ -607,9 +607,142 @@ describe('handleReadPdfFunc Integration Tests', () => {
     try {
       await handler({ sources: [{ path: 'test.pdf' }] });
       expect(loadCoreSpy).toHaveBeenCalledTimes(1);
+      expect(mockGetDocument).toHaveBeenCalledTimes(1);
     } finally {
       loadCoreSpy.mockRestore();
     }
+  });
+
+  it('bounds default auto-read extraction to the sample budget on large PDFs', async () => {
+    const largeDocument = {
+      numPages: 100,
+      getMetadata: mockGetMetadata,
+      getPage: mockGetPage,
+      getOutline: mockGetOutline,
+      getPageLabels: mockGetPageLabels,
+      getPermissions: mockGetPermissions,
+      getMarkInfo: mockGetMarkInfo,
+      getFieldObjects: mockGetFieldObjects,
+      getAttachments: mockGetAttachments,
+    };
+    mockGetDocument.mockReturnValue({ promise: Promise.resolve(largeDocument) });
+    mockGetPage.mockImplementation((pageNum: number) => {
+      if (pageNum > 0 && pageNum <= largeDocument.numPages) {
+        return {
+          getTextContent: vi.fn().mockResolvedValueOnce({
+            items: [
+              {
+                str: `Mock page text ${String(pageNum)}`,
+                transform: [1, 0, 0, 1, 0, 100 + pageNum * 10],
+                fontName: 'g_d0_f1',
+                dir: 'ltr',
+                hasEOL: false,
+              },
+            ],
+          }),
+          getViewport: vi.fn().mockReturnValue({ width: 612, height: 792, rotation: 0 }),
+          render: vi.fn().mockReturnValue({ promise: Promise.resolve() }),
+          view: [0, 0, 612, 792],
+          rotate: 0,
+          userUnit: 1,
+          getOperatorList: vi.fn().mockResolvedValue({ fnArray: [], argsArray: [] }),
+          getAnnotations: vi.fn().mockResolvedValue([]),
+          objs: { get: vi.fn() },
+        };
+      }
+      throw new Error(`Mock getPage error: Invalid page number ${String(pageNum)}`);
+    });
+
+    const result = await handler({ sources: [{ path: 'large.pdf' }] });
+    const parsed = JSON.parse(result.content[0]?.text ?? '{}') as {
+      auto_read?: {
+        results: Array<{
+          read_pdf_arguments?: { sources?: Array<{ pages?: number[] }> };
+        }>;
+      };
+      results: Array<{
+        data?: {
+          chunks?: Array<{ page: number }>;
+        };
+      }>;
+    };
+
+    const extractionPages = parsed.auto_read?.results[0]?.read_pdf_arguments?.sources?.[0]?.pages;
+    expect(extractionPages?.length).toBe(5);
+    expect(extractionPages?.every((page) => page >= 1 && page <= 100)).toBe(true);
+
+    const chunkPages = new Set(parsed.results[0]?.data?.chunks?.map((chunk) => chunk.page) ?? []);
+    expect(chunkPages.size).toBeLessThanOrEqual(5);
+    expect(mockGetDocument).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips auto-read overhead when only source pages are specified', async () => {
+    const loaderModule = await import('../../src/pdf/loader.js');
+    const loadCoreSpy = vi.spyOn(loaderModule, 'loadPdfDocumentCore');
+
+    try {
+      const result = await handler({
+        sources: [{ path: 'test.pdf', pages: [1, 2] }],
+      });
+      const parsed = JSON.parse(result.content[0]?.text ?? '{}') as {
+        auto_read?: { enabled: boolean };
+        results: Array<{ success: boolean }>;
+      };
+
+      expect(parsed.auto_read).toBeUndefined();
+      expect(parsed.results[0]?.success).toBe(true);
+      expect(loadCoreSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      loadCoreSpy.mockRestore();
+    }
+  });
+
+  it('passes the session pdfDocument into OCR without reloading', async () => {
+    const getTextContent = vi.fn().mockResolvedValue({ items: [] });
+    mockGetPage.mockResolvedValue({
+      getTextContent,
+      getViewport: vi.fn().mockReturnValue({ width: 612, height: 792, rotation: 0 }),
+      view: [0, 0, 612, 792],
+      rotate: 0,
+      userUnit: 1,
+      getAnnotations: vi.fn(),
+      getOperatorList: vi.fn().mockResolvedValue({ fnArray: [], argsArray: [] }),
+      objs: { get: vi.fn() },
+    });
+
+    let ocrPdfDocument: unknown;
+    mockOcrPdfSourcePages.mockImplementation(async (_source, _options, pdfDocument) => {
+      ocrPdfDocument = pdfDocument;
+      return {
+        source: 'scanned.pdf',
+        numPages: 3,
+        pages: [
+          {
+            page: 1,
+            text: 'OCR recovered page text',
+            confidence: 0.91,
+            words: [],
+            provider: 'command',
+            source_render_evidence_id: 'page-1-render-scale-2',
+            provenance: { engine: 'external-command', source: 'ocr-provider' },
+          },
+        ],
+        warnings: [],
+      };
+    });
+
+    await handler({
+      sources: [{ path: 'scanned.pdf', pages: [1] }],
+      include_document_map: true,
+      include_ocr_text_layer: true,
+      include_metadata: false,
+      include_page_count: false,
+      include_full_text: false,
+    });
+
+    expect(mockGetDocument).toHaveBeenCalledTimes(1);
+    expect(ocrPdfDocument).toBeDefined();
+    expect(ocrPdfDocument).toHaveProperty('numPages', 3);
   });
 
   it('omits redundant per-page text parts when markdown and chunks are enabled by default', async () => {

--- a/test/pdf/autoReadPolicy.test.ts
+++ b/test/pdf/autoReadPolicy.test.ts
@@ -4,6 +4,7 @@ import {
   buildReadOptions,
   DEFAULT_AUTO_DETAIL,
   hasExplicitReadOptions,
+  hasExplicitSourcePageSelection,
   MAX_CONCURRENT_SOURCES,
   shouldUseAutoRead,
 } from '../../src/pdf/autoReadPolicy.js';
@@ -35,9 +36,27 @@ describe('autoReadPolicy', () => {
     });
   });
 
+  describe('hasExplicitSourcePageSelection', () => {
+    test('returns false when no source pages are set', () => {
+      expect(hasExplicitSourcePageSelection(baseInput())).toBe(false);
+    });
+
+    test('returns true when any source pins pages', () => {
+      expect(
+        hasExplicitSourcePageSelection(baseInput({ sources: [{ path: '/test.pdf', pages: [1] }] }))
+      ).toBe(true);
+    });
+  });
+
   describe('shouldUseAutoRead', () => {
     test('defaults to true when no explicit options and no auto flag', () => {
       expect(shouldUseAutoRead(baseInput())).toBe(true);
+    });
+
+    test('returns false when only source pages are specified', () => {
+      expect(
+        shouldUseAutoRead(baseInput({ sources: [{ path: '/test.pdf', pages: [1, 2] }] }))
+      ).toBe(false);
     });
 
     test('returns false when auto is explicitly false', () => {

--- a/test/pdf/readPdfOverhead.test.ts
+++ b/test/pdf/readPdfOverhead.test.ts
@@ -86,6 +86,36 @@ describe('PdfSessionScope', () => {
     loadCoreSpy?.mockRestore();
   });
 
+  it('deduplicates concurrent acquire for the same source key', async () => {
+    const session = new PdfSessionScope();
+    const destroyLoadingTask = vi.fn().mockResolvedValue(undefined);
+    const fakeDoc = {
+      numPages: 1,
+      loadingTask: { destroy: destroyLoadingTask },
+    };
+
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+
+    loadCoreSpy = vi.spyOn(loader, 'loadPdfDocumentCore').mockImplementation(async () => {
+      await gate;
+      return fakeDoc as unknown as Awaited<ReturnType<typeof loader.loadPdfDocumentCore>>;
+    });
+
+    const first = session.acquire({ path: SAMPLE_PDF }, SAMPLE_PDF);
+    const second = session.acquire({ path: SAMPLE_PDF }, SAMPLE_PDF);
+    releaseGate();
+    const [docA, docB] = await Promise.all([first, second]);
+
+    expect(docA).toBe(docB);
+    expect(loadCoreSpy).toHaveBeenCalledTimes(1);
+    expect(session.activeSourceCount()).toBe(1);
+
+    await session.destroyAll();
+  });
+
   it('tracks a single active source across acquire/release', async () => {
     const session = new PdfSessionScope();
     const destroyLoadingTask = vi.fn().mockResolvedValue(undefined);

--- a/test/scripts/sotaReleaseGate.test.ts
+++ b/test/scripts/sotaReleaseGate.test.ts
@@ -25,7 +25,10 @@ const writeArtifact = (artifactDir: string, fileName: string, data: JsonValue) =
 const writeValidPerformanceArtifact = (artifactDir: string) => {
   writeArtifact(artifactDir, 'pdf_performance_benchmark.json', {
     profile: 'pdf_performance_benchmark',
-    results: [{ name: 'v3_agent_document_twin', average_ms: 8.5 }],
+    results: [
+      { name: 'v3_agent_document_twin', average_ms: 8.5 },
+      { name: 'default_auto_read_balanced', average_ms: 6.2 },
+    ],
   });
 };
 


### PR DESCRIPTION
## Summary

Addresses verifier gaps from the v3.0.11 overhead release:

- **PdfSessionScope race fix**: pending-load map deduplicates concurrent `acquire()` for the same source key.
- **Pages-only manual path**: `shouldUseAutoRead` now returns false when callers only specify `sources[].pages`, avoiding forced balanced auto inspection.
- **Benchmark coverage**: adds `default_auto_read_balanced` hot-path scenario plus release-gate checks.
- **Regression tests**: handler tests for 100-page page budget, single-parse reuse (`mockGetDocument` count), OCR `pdfDocument` handoff, and concurrent session acquire.

## Validation

- `bun run typecheck`, `check`, `test` (395 pass), `build`, `package:smoke`
- `benchmark:release-gate` passes with updated performance artifacts

## Changeset

Patch via `.changeset/read-pdf-overhead-hardening.md`.