### PR TITLE
fix(pdf): guard PdfSession acquire against destroyAll races

### DIFF
--- a/.changeset/pdf-session-destroy-race.md
+++ b/.changeset/pdf-session-destroy-race.md
@@ -1,0 +1,5 @@
+---
+"@sylphx/pdf-reader-mcp": patch
+---
+
+Fix PdfSession acquire/destroyAll race so in-flight loads never throw "entry missing", and add auto-read OCR session handoff regression coverage.

--- a/benchmark-artifacts/pdf_performance_benchmark.json
+++ b/benchmark-artifacts/pdf_performance_benchmark.json
@@ -7,37 +7,37 @@
     {
       "name": "metadata_page_count",
       "iterations": 20,
-      "average_ms": 1.15,
-      "min_ms": 0.71,
-      "max_ms": 2.4
+      "average_ms": 0.79,
+      "min_ms": 0.47,
+      "max_ms": 2.83
     },
     {
       "name": "full_text",
       "iterations": 20,
-      "average_ms": 17.68,
-      "min_ms": 13.65,
-      "max_ms": 21.05
+      "average_ms": 9.51,
+      "min_ms": 5.63,
+      "max_ms": 18.32
     },
     {
       "name": "selected_page_text",
       "iterations": 20,
-      "average_ms": 13.74,
-      "min_ms": 7.53,
-      "max_ms": 27.94
+      "average_ms": 7.22,
+      "min_ms": 4.69,
+      "max_ms": 12.61
     },
     {
       "name": "default_auto_read_balanced",
       "iterations": 20,
-      "average_ms": 37.22,
-      "min_ms": 30.74,
-      "max_ms": 49.93
+      "average_ms": 16.8,
+      "min_ms": 15.67,
+      "max_ms": 19.95
     },
     {
       "name": "v3_agent_document_twin",
       "iterations": 20,
-      "average_ms": 25.85,
-      "min_ms": 18.93,
-      "max_ms": 35.43
+      "average_ms": 17.04,
+      "min_ms": 12.92,
+      "max_ms": 23.03
     }
   ]
 }

--- a/benchmark-artifacts/pdf_sota_release_gate.json
+++ b/benchmark-artifacts/pdf_sota_release_gate.json
@@ -1,7 +1,7 @@
 {
   "profile": "pdf_sota_release_gate",
-  "generated_at": "2026-07-08T18:00:57.475Z",
-  "artifact_dir": "/home/runner/work/pdf-reader-mcp/pdf-reader-mcp/benchmark-artifacts",
+  "generated_at": "2026-07-08T18:17:12.041Z",
+  "artifact_dir": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/benchmark-artifacts",
   "status": "passed",
   "summary": {
     "total": 41,
@@ -127,7 +127,7 @@
       "status": "passed",
       "message": "v3 Agent Document Twin scenario has a positive average latency",
       "evidence": {
-        "average_ms": 25.85
+        "average_ms": 17.04
       }
     },
     {
@@ -140,7 +140,7 @@
       "status": "passed",
       "message": "default balanced auto-read scenario has a positive average latency",
       "evidence": {
-        "average_ms": 37.22
+        "average_ms": 16.8
       }
     },
     {

--- a/dist/index.js
+++ b/dist/index.js
@@ -4624,8 +4624,12 @@ var pdfSessionKey = (source) => source.path ?? source.url ?? "";
 class PdfSessionScope {
   entries = new Map;
   pending = new Map;
+  destroyed = false;
   async acquire(source, sourceDescription) {
     const key = pdfSessionKey(source);
+    if (this.destroyed) {
+      return loadPdfDocumentCore(source, sourceDescription);
+    }
     const existing = this.entries.get(key);
     if (existing) {
       existing.refCount += 1;
@@ -4633,23 +4637,32 @@ class PdfSessionScope {
     }
     let pending = this.pending.get(key);
     if (!pending) {
-      pending = loadPdfDocumentCore(source, sourceDescription).then(async (pdfDocument) => {
+      pending = loadPdfDocumentCore(source, sourceDescription).then(async (pdfDocument2) => {
+        if (this.destroyed) {
+          await destroyLoadingTask(pdfDocument2.loadingTask, logger14, "PDF session aborted load");
+          return pdfDocument2;
+        }
         const raced = this.entries.get(key);
         if (raced) {
-          await destroyLoadingTask(pdfDocument.loadingTask, logger14, "PDF session duplicate");
+          await destroyLoadingTask(pdfDocument2.loadingTask, logger14, "PDF session duplicate");
           return raced.pdfDocument;
         }
-        this.entries.set(key, { pdfDocument, refCount: 0 });
-        return pdfDocument;
+        this.entries.set(key, { pdfDocument: pdfDocument2, refCount: 0 });
+        return pdfDocument2;
       }).finally(() => {
         this.pending.delete(key);
       });
       this.pending.set(key, pending);
     }
-    await pending;
-    const entry = this.entries.get(key);
+    const pdfDocument = await pending;
+    if (this.destroyed) {
+      await destroyLoadingTask(pdfDocument.loadingTask, logger14, "PDF session late acquire");
+      return loadPdfDocumentCore(source, sourceDescription);
+    }
+    let entry = this.entries.get(key);
     if (!entry) {
-      throw new Error(`PDF session entry missing after acquire for ${key}`);
+      entry = { pdfDocument, refCount: 0 };
+      this.entries.set(key, entry);
     }
     entry.refCount += 1;
     return entry.pdfDocument;
@@ -4662,6 +4675,10 @@ class PdfSessionScope {
     entry.refCount = Math.max(0, entry.refCount - 1);
   }
   async destroyAll() {
+    if (this.destroyed)
+      return;
+    this.destroyed = true;
+    await Promise.allSettled([...this.pending.values()]);
     this.pending.clear();
     const entries = [...this.entries.values()];
     this.entries.clear();

--- a/src/pdf/pdfSession.ts
+++ b/src/pdf/pdfSession.ts
@@ -24,12 +24,17 @@ type SessionEntry = {
 export class PdfSessionScope {
   private readonly entries = new Map<string, SessionEntry>();
   private readonly pending = new Map<string, Promise<pdfjsLib.PDFDocumentProxy>>();
+  private destroyed = false;
 
   async acquire(
     source: { path?: string | undefined; url?: string | undefined },
     sourceDescription: string
   ): Promise<pdfjsLib.PDFDocumentProxy> {
     const key = pdfSessionKey(source);
+    if (this.destroyed) {
+      return loadPdfDocumentCore(source, sourceDescription);
+    }
+
     const existing = this.entries.get(key);
     if (existing) {
       existing.refCount += 1;
@@ -40,6 +45,10 @@ export class PdfSessionScope {
     if (!pending) {
       pending = loadPdfDocumentCore(source, sourceDescription)
         .then(async (pdfDocument) => {
+          if (this.destroyed) {
+            await destroyLoadingTask(pdfDocument.loadingTask, logger, 'PDF session aborted load');
+            return pdfDocument;
+          }
           const raced = this.entries.get(key);
           if (raced) {
             await destroyLoadingTask(pdfDocument.loadingTask, logger, 'PDF session duplicate');
@@ -54,10 +63,16 @@ export class PdfSessionScope {
       this.pending.set(key, pending);
     }
 
-    await pending;
-    const entry = this.entries.get(key);
+    const pdfDocument = await pending;
+    if (this.destroyed) {
+      await destroyLoadingTask(pdfDocument.loadingTask, logger, 'PDF session late acquire');
+      return loadPdfDocumentCore(source, sourceDescription);
+    }
+
+    let entry = this.entries.get(key);
     if (!entry) {
-      throw new Error(`PDF session entry missing after acquire for ${key}`);
+      entry = { pdfDocument, refCount: 0 };
+      this.entries.set(key, entry);
     }
     entry.refCount += 1;
     return entry.pdfDocument;
@@ -74,6 +89,9 @@ export class PdfSessionScope {
   }
 
   async destroyAll(): Promise<void> {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    await Promise.allSettled([...this.pending.values()]);
     this.pending.clear();
     const entries = [...this.entries.values()];
     this.entries.clear();

--- a/test/handlers/readPdf.test.ts
+++ b/test/handlers/readPdf.test.ts
@@ -697,7 +697,7 @@ describe('handleReadPdfFunc Integration Tests', () => {
     }
   });
 
-  it('passes the session pdfDocument into OCR without reloading', async () => {
+  it('passes the session pdfDocument into OCR on manual read without reloading', async () => {
     const getTextContent = vi.fn().mockResolvedValue({ items: [] });
     mockGetPage.mockResolvedValue({
       getTextContent,
@@ -743,6 +743,63 @@ describe('handleReadPdfFunc Integration Tests', () => {
     expect(mockGetDocument).toHaveBeenCalledTimes(1);
     expect(ocrPdfDocument).toBeDefined();
     expect(ocrPdfDocument).toHaveProperty('numPages', 3);
+  });
+
+  it('passes the session pdfDocument into OCR through auto-read inspect and extract', async () => {
+    const loaderModule = await import('../../src/pdf/loader.js');
+    const loadCoreSpy = vi.spyOn(loaderModule, 'loadPdfDocumentCore');
+    const getTextContent = vi.fn().mockResolvedValue({ items: [] });
+    mockGetPage.mockResolvedValue({
+      getTextContent,
+      getViewport: vi.fn().mockReturnValue({ width: 612, height: 792, rotation: 0 }),
+      view: [0, 0, 612, 792],
+      rotate: 0,
+      userUnit: 1,
+      getAnnotations: vi.fn(),
+      getOperatorList: vi.fn().mockResolvedValue({ fnArray: [], argsArray: [] }),
+      objs: { get: vi.fn() },
+    });
+
+    let ocrPdfDocument: unknown;
+    mockOcrPdfSourcePages.mockImplementation(async (_source, _options, pdfDocument) => {
+      ocrPdfDocument = pdfDocument;
+      return {
+        source: 'scanned.pdf',
+        numPages: 3,
+        pages: [
+          {
+            page: 1,
+            text: 'OCR recovered page text',
+            confidence: 0.91,
+            words: [],
+            provider: 'command',
+            source_render_evidence_id: 'page-1-render-scale-2',
+            provenance: { engine: 'external-command', source: 'ocr-provider' },
+          },
+        ],
+        warnings: [],
+      };
+    });
+
+    try {
+      const result = await handler({
+        sources: [{ path: 'scanned.pdf' }],
+        auto: true,
+        include_ocr_text_layer: true,
+      });
+      const parsed = JSON.parse(result.content[0]?.text ?? '{}') as {
+        auto_read?: { enabled: boolean };
+      };
+
+      expect(parsed.auto_read?.enabled).toBe(true);
+      expect(loadCoreSpy).toHaveBeenCalledTimes(1);
+      expect(mockGetDocument).toHaveBeenCalledTimes(1);
+      expect(mockOcrPdfSourcePages).toHaveBeenCalled();
+      expect(ocrPdfDocument).toBeDefined();
+      expect(ocrPdfDocument).toHaveProperty('numPages', 3);
+    } finally {
+      loadCoreSpy.mockRestore();
+    }
   });
 
   it('omits redundant per-page text parts when markdown and chunks are enabled by default', async () => {

--- a/test/pdf/readPdfOverhead.test.ts
+++ b/test/pdf/readPdfOverhead.test.ts
@@ -116,6 +116,33 @@ describe('PdfSessionScope', () => {
     await session.destroyAll();
   });
 
+  it('does not throw when destroyAll races an in-flight acquire', async () => {
+    const session = new PdfSessionScope();
+    const destroyLoadingTask = vi.fn().mockResolvedValue(undefined);
+    const fakeDoc = {
+      numPages: 1,
+      loadingTask: { destroy: destroyLoadingTask },
+    };
+
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+
+    loadCoreSpy = vi.spyOn(loader, 'loadPdfDocumentCore').mockImplementation(async () => {
+      await gate;
+      return fakeDoc as unknown as Awaited<ReturnType<typeof loader.loadPdfDocumentCore>>;
+    });
+
+    const acquirePromise = session.acquire({ path: SAMPLE_PDF }, SAMPLE_PDF);
+    const destroyPromise = session.destroyAll();
+    releaseGate();
+
+    await expect(acquirePromise).resolves.toBe(fakeDoc);
+    await expect(destroyPromise).resolves.toBeUndefined();
+    expect(session.activeSourceCount()).toBe(0);
+  });
+
   it('tracks a single active source across acquire/release', async () => {
     const session = new PdfSessionScope();
     const destroyLoadingTask = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary

- Fixes `PdfSessionScope.acquire` so `destroyAll()` cannot leave waiters throwing "entry missing after acquire".
- `destroyAll()` now awaits in-flight pending loads before clearing entries.
- Adds auto-read OCR session handoff regression test (inspect → extract → OCR on one parse).
- Adds destroyAll/acquire race regression in `readPdfOverhead.test.ts`.

## Validation

- 397 tests pass
- `benchmark:release-gate` passes
- `package:smoke` passes

## Changeset

Patch via `.changeset/pdf-session-destroy-race.md`.