### PR TITLE
docs: fix discovery claims and add evidence-first demo workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Abbreviated shape — see [full example](examples/agent-document-twin.json) and
 Use the returned page and bounding box with `pdf_evidence` (`render_page` or
 `extract_regions`) when the agent needs visual proof before citing.
 
+![Evidence-first PDF workflow](docs/public/demo-workflow.svg)
+
 ## Why agents use it
 
 | Need | What you get |
@@ -349,9 +351,16 @@ agent output, you are exactly who this project is for.
 fastest way to help more agent builders find evidence-first PDF reading. Share
 it in your MCP client setup, team wiki, or agent stack README.
 
-Listed on [MCP Servers](https://mcpservers.org/) and the
-[Model Context Protocol servers](https://github.com/modelcontextprotocol/servers)
-ecosystem. Found a list we are missing? [Open an issue](https://github.com/SylphxAI/pdf-reader-mcp/issues/new).
+### Discovery (in progress)
+
+| Channel | Status |
+| --- | --- |
+| [TensorBlock MCP Index PR #1113](https://github.com/TensorBlock/awesome-mcp-servers/pull/1113) | Open — multimedia/document processing listing |
+| [MCP servers community issue #4500](https://github.com/modelcontextprotocol/servers/issues/4500) | Open — community server highlight |
+| [appcypher/awesome-mcp-servers](https://github.com/appcypher/awesome-mcp-servers/compare/main...SylphxAI:add-pdf-reader-mcp) | Branch ready — upstream PR pending |
+| [mcpservers.org submit](https://mcpservers.org/submit) | Not listed yet — free submission available |
+
+Know another MCP directory? [Open an issue](https://github.com/SylphxAI/pdf-reader-mcp/issues/new) with the link.
 
 ## License
 

--- a/docs/public/demo-workflow.svg
+++ b/docs/public/demo-workflow.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 220" role="img" aria-label="PDF Reader MCP workflow: read, search, verify evidence">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1e293b"/>
+    </linearGradient>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#38bdf8"/>
+    </marker>
+  </defs>
+  <rect width="920" height="220" rx="16" fill="url(#bg)"/>
+  <text x="460" y="34" text-anchor="middle" fill="#e2e8f0" font-family="ui-sans-serif, system-ui, sans-serif" font-size="18" font-weight="700">Evidence-first PDF workflow</text>
+  <g font-family="ui-sans-serif, system-ui, sans-serif">
+    <rect x="36" y="70" width="180" height="96" rx="12" fill="#111827" stroke="#334155"/>
+    <text x="126" y="98" text-anchor="middle" fill="#93c5fd" font-size="13" font-weight="700">1. read_pdf</text>
+    <text x="126" y="122" text-anchor="middle" fill="#cbd5e1" font-size="11">sources only</text>
+    <text x="126" y="142" text-anchor="middle" fill="#94a3b8" font-size="10">Agent Document Twin</text>
+
+    <rect x="260" y="70" width="180" height="96" rx="12" fill="#111827" stroke="#334155"/>
+    <text x="350" y="98" text-anchor="middle" fill="#93c5fd" font-size="13" font-weight="700">2. search_pdf</text>
+    <text x="350" y="122" text-anchor="middle" fill="#cbd5e1" font-size="11">literal query</text>
+    <text x="350" y="142" text-anchor="middle" fill="#94a3b8" font-size="10">page + bbox match</text>
+
+    <rect x="484" y="70" width="180" height="96" rx="12" fill="#111827" stroke="#334155"/>
+    <text x="574" y="98" text-anchor="middle" fill="#93c5fd" font-size="13" font-weight="700">3. pdf_evidence</text>
+    <text x="574" y="122" text-anchor="middle" fill="#cbd5e1" font-size="11">render / crop</text>
+    <text x="574" y="142" text-anchor="middle" fill="#94a3b8" font-size="10">visual proof</text>
+
+    <rect x="708" y="70" width="176" height="96" rx="12" fill="#052e16" stroke="#16a34a"/>
+    <text x="796" y="98" text-anchor="middle" fill="#86efac" font-size="13" font-weight="700">4. cite answer</text>
+    <text x="796" y="122" text-anchor="middle" fill="#bbf7d0" font-size="11">with evidence</text>
+    <text x="796" y="142" text-anchor="middle" fill="#86efac" font-size="10">not a text dump</text>
+  </g>
+  <line x1="216" y1="118" x2="260" y2="118" stroke="#38bdf8" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="440" y1="118" x2="484" y2="118" stroke="#38bdf8" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="664" y1="118" x2="708" y2="118" stroke="#38bdf8" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="460" y="196" text-anchor="middle" fill="#64748b" font-size="11">Local-first · benchmark-gated · npm @sylphx/pdf-reader-mcp</text>
+</svg>

--- a/test/readmeDiscovery.test.ts
+++ b/test/readmeDiscovery.test.ts
@@ -1,0 +1,28 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const readText = (path: string) => readFileSync(path, 'utf8');
+
+describe('README discovery surfaces', () => {
+  it('keeps pain-first fold content and honest discovery status', () => {
+    const readme = readText('README.md');
+
+    expect(readme).toContain('Did it read the truth?');
+    expect(readme).toContain('## Why not a plain text dump?');
+    expect(readme).toContain('39/39');
+    expect(readme).toMatch(/Star the repo|Star this repo/);
+    expect(readme).not.toMatch(/Listed on \[MCP Servers\]/);
+    expect(readme).toContain('Not listed yet');
+    expect(readme).toContain('docs/articles/stop-pdf-hallucinations.md');
+    expect(readme).toContain('docs/public/demo-workflow.svg');
+  });
+
+  it('links the shareable discovery article from docs surfaces', () => {
+    const vitepress = readText('docs/.vitepress/config.ts');
+    const gettingStarted = readText('docs/guide/getting-started.md');
+
+    expect(existsSync('docs/articles/stop-pdf-hallucinations.md')).toBe(true);
+    expect(vitepress).toContain('/articles/stop-pdf-hallucinations');
+    expect(gettingStarted).toContain('/articles/stop-pdf-hallucinations');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes verifier gaps from the public SOTA adoption goal:

- Removes false claim that PDF Reader MCP is already listed on mcpservers.org
- Replaces with honest **Discovery (in progress)** table linking live outreach
- Adds static `docs/public/demo-workflow.svg` and embeds it in README
- Adds `test/readmeDiscovery.test.ts` regression tests for README/docs discovery surfaces

## Live outreach (external)

- https://github.com/TensorBlock/awesome-mcp-servers/pull/1113
- https://github.com/modelcontextprotocol/servers/issues/4500

## Validation

- `bun run docs:build` ✅
- `bun run typecheck` ✅
- `bun run check` ✅
- `bun run test` ✅ (399 tests)
- `bun run benchmark:release-gate` ✅