### PR TITLE
feat(discovery): MCP Registry metadata and expanded platform outreach

### DIFF
--- a/.changeset/mcp-registry-discovery.md
+++ b/.changeset/mcp-registry-discovery.md
@@ -1,0 +1,5 @@
+---
+"@sylphx/pdf-reader-mcp": patch
+---
+
+Add official MCP Registry metadata (`server.json`, `mcpName`) and automate registry publishing on GitHub releases.

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,37 @@
+name: Publish to MCP Registry
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish MCP Registry metadata
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Sync server.json version with release tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.tmp
+          mv server.tmp server.json
+          cat server.json
+
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish

--- a/README.md
+++ b/README.md
@@ -355,10 +355,13 @@ it in your MCP client setup, team wiki, or agent stack README.
 
 | Channel | Status |
 | --- | --- |
+| [Glama MCP directory](https://glama.ai/mcp/servers/SylphxAI/pdf-reader-mcp) | Listed — [claim server](https://glama.ai/mcp/servers/SylphxAI/pdf-reader-mcp/admin) for full discoverability |
+| [Official MCP Registry](https://registry.modelcontextprotocol.io/) | Publishing on next release (`io.github.SylphxAI/pdf-reader-mcp`) |
 | [TensorBlock MCP Index PR #1113](https://github.com/TensorBlock/awesome-mcp-servers/pull/1113) | Open — multimedia/document processing listing |
 | [MCP servers community issue #4500](https://github.com/modelcontextprotocol/servers/issues/4500) | Open — community server highlight |
-| [appcypher/awesome-mcp-servers](https://github.com/appcypher/awesome-mcp-servers/compare/main...SylphxAI:add-pdf-reader-mcp) | Branch ready — upstream PR pending |
-| [mcpservers.org submit](https://mcpservers.org/submit) | Not listed yet — free submission available |
+| [mcp.so listing issue #3068](https://github.com/chatmcp/mcpso/issues/3068) | Open — directory submission request |
+| [appcypher/awesome-mcp-servers compare](https://github.com/appcypher/awesome-mcp-servers/compare/main...SylphxAI:add-pdf-reader-mcp) | Branch ready — upstream PRs disabled |
+| [mcpservers.org submit](https://mcpservers.org/submit) | Not listed yet — free web-form submission |
 
 Know another MCP directory? [Open an issue](https://github.com/SylphxAI/pdf-reader-mcp/issues/new) with the link.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@sylphx/pdf-reader-mcp",
   "version": "3.0.13",
+  "mcpName": "io.github.SylphxAI/pdf-reader-mcp",
   "description": "The most-starred PDF MCP server. Stop agent hallucinations on PDFs — one read_pdf call returns an Agent Document Twin with markdown, tables, trust reports, and source evidence (page + bbox). Local-first. Benchmark-gated.",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.SylphxAI/pdf-reader-mcp",
+  "title": "PDF Reader MCP",
+  "description": "Evidence-first PDF MCP. Agent Document Twin with citeable page+bbox evidence.",
+  "repository": {
+    "url": "https://github.com/SylphxAI/pdf-reader-mcp",
+    "source": "github"
+  },
+  "version": "3.0.13",
+  "websiteUrl": "https://sylphxai.github.io/pdf-reader-mcp/",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@sylphx/pdf-reader-mcp",
+      "version": "3.0.13",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/test/readmeDiscovery.test.ts
+++ b/test/readmeDiscovery.test.ts
@@ -13,8 +13,22 @@ describe('README discovery surfaces', () => {
     expect(readme).toMatch(/Star the repo|Star this repo/);
     expect(readme).not.toMatch(/Listed on \[MCP Servers\]/);
     expect(readme).toContain('Not listed yet');
+    expect(readme).toContain('glama.ai/mcp/servers/SylphxAI/pdf-reader-mcp');
+    expect(readme).toContain('registry.modelcontextprotocol.io');
+    expect(readme).toContain('chatmcp/mcpso/issues/3068');
     expect(readme).toContain('docs/articles/stop-pdf-hallucinations.md');
     expect(readme).toContain('docs/public/demo-workflow.svg');
+  });
+
+  it('ships official MCP Registry metadata aligned with package.json', () => {
+    const pkg = JSON.parse(readText('package.json'));
+    const server = JSON.parse(readText('server.json'));
+
+    expect(pkg.mcpName).toBe('io.github.SylphxAI/pdf-reader-mcp');
+    expect(server.name).toBe(pkg.mcpName);
+    expect(server.packages[0].identifier).toBe(pkg.name);
+    expect(server.description.length).toBeLessThanOrEqual(100);
+    expect(existsSync('.github/workflows/publish-mcp-registry.yml')).toBe(true);
   });
 
   it('links the shareable discovery article from docs surfaces', () => {


### PR DESCRIPTION
Adds official MCP Registry metadata and expands discovery outreach tracking.

- `server.json` + `mcpName` for `io.github.SylphxAI/pdf-reader-mcp`
- `publish-mcp-registry.yml` publishes on GitHub release (OIDC)
- README discovery table with live channel statuses
- Regression tests for registry metadata

Live outreach: Glama (listed), TensorBlock PR #1113, MCP servers #4500, mcp.so #3068.