### PR TITLE
docs: MCP Registry listed + README portfolio boundary tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ it in your MCP client setup, team wiki, or agent stack README.
 | Channel | Status |
 | --- | --- |
 | [Glama MCP directory](https://glama.ai/mcp/servers/SylphxAI/pdf-reader-mcp) | Listed — [claim server](https://glama.ai/mcp/servers/SylphxAI/pdf-reader-mcp/admin) for full discoverability |
-| [Official MCP Registry](https://registry.modelcontextprotocol.io/) | Publishing on next release (`io.github.SylphxAI/pdf-reader-mcp`) |
+| [Official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.SylphxAI/pdf-reader-mcp) | Listed — `io.github.SylphxAI/pdf-reader-mcp` @ v3.0.14 |
 | [TensorBlock MCP Index PR #1113](https://github.com/TensorBlock/awesome-mcp-servers/pull/1113) | Open — multimedia/document processing listing |
 | [MCP servers community issue #4500](https://github.com/modelcontextprotocol/servers/issues/4500) | Open — community server highlight |
 | [mcp.so listing issue #3068](https://github.com/chatmcp/mcpso/issues/3068) | Open — directory submission request |

--- a/test/readmeDiscovery.test.ts
+++ b/test/readmeDiscovery.test.ts
@@ -15,6 +15,8 @@ describe('README discovery surfaces', () => {
     expect(readme).toContain('Not listed yet');
     expect(readme).toContain('glama.ai/mcp/servers/SylphxAI/pdf-reader-mcp');
     expect(readme).toContain('registry.modelcontextprotocol.io');
+    expect(readme).toContain('io.github.SylphxAI/pdf-reader-mcp');
+    expect(readme).not.toContain('Publishing on next release');
     expect(readme).toContain('chatmcp/mcpso/issues/3068');
     expect(readme).toContain('docs/articles/stop-pdf-hallucinations.md');
     expect(readme).toContain('docs/public/demo-workflow.svg');

--- a/test/readmeDiscovery.test.ts
+++ b/test/readmeDiscovery.test.ts
@@ -20,6 +20,12 @@ describe('README discovery surfaces', () => {
     expect(readme).toContain('chatmcp/mcpso/issues/3068');
     expect(readme).toContain('docs/articles/stop-pdf-hallucinations.md');
     expect(readme).toContain('docs/public/demo-workflow.svg');
+    expect(readme).toContain('Listed — `io.github.SylphxAI/pdf-reader-mcp`');
+    expect(readme).not.toContain('### Reader family');
+    expect(readme).not.toContain('0004-reader-portfolio');
+    expect(readme).not.toContain('image-reader-mcp');
+    expect(readme).not.toContain('video-reader-mcp');
+    expect(readme).not.toContain('smart-reader-mcp');
   });
 
   it('ships official MCP Registry metadata aligned with package.json', () => {


### PR DESCRIPTION
Closes stale registry copy. Adds tests ensuring pdf-reader-mcp README does not document sibling Reader repos.