### PR TITLE
fix(registry): align server.json version with package.json

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
@@ -13,8 +13,18 @@ jobs:
     name: Publish MCP Registry metadata
     runs-on: ubuntu-latest
     steps:
+      - name: Create release bot token
+        id: release-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Checkout repository
         uses: actions/checkout@v7.0.0
+        with:
+          token: ${{ steps.release-token.outputs.token }}
 
       - name: Install mcp-publisher
         run: |
@@ -35,3 +45,15 @@ jobs:
 
       - name: Publish server to MCP Registry
         run: ./mcp-publisher publish
+
+      - name: Commit synced server.json to main
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add server.json
+          if git diff --staged --quiet; then
+            echo "server.json already aligned on main"
+            exit 0
+          fi
+          git commit -m "chore(registry): sync server.json to ${GITHUB_REF_NAME}"
+          git push origin HEAD:main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: bun changeset version
+          version: bun changeset version && bun run sync:server-json
           publish: bun run release
           title: 'chore(release): version packages'
           commit: 'chore(release): version packages'

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "benchmark:release-artifacts": "MCP_PDF_BENCHMARK_OUTPUT_DIR=${MCP_PDF_BENCHMARK_OUTPUT_DIR:-benchmark-artifacts} MCP_PDF_PROVIDER_BENCHMARK_REQUIRED=true bun run benchmark:all && MCP_PDF_BENCHMARK_OUTPUT_DIR=${MCP_PDF_BENCHMARK_OUTPUT_DIR:-benchmark-artifacts} MCP_PDF_PROVIDER_MANIFEST=${MCP_PDF_PROVIDER_MANIFEST:-test/fixtures/provider-crop-manifest.json} MCP_PDF_PROVIDER_MANIFEST_CROP_REQUIRED=true bun run benchmark:provider-manifest-crops && MCP_PDF_BENCHMARK_OUTPUT_DIR=${MCP_PDF_BENCHMARK_OUTPUT_DIR:-benchmark-artifacts} MCP_PDF_PROVIDER_MANIFEST=${MCP_PDF_PROVIDER_MANIFEST:-test/fixtures/provider-analysis-manifest.json} MCP_PDF_PROVIDER_MANIFEST_REQUIRED=true bun run benchmark:provider-manifest",
     "benchmark:release-gate": "bun scripts/sota-release-gate.ts",
     "package:smoke": "bun scripts/package-smoke.ts",
+    "sync:server-json": "bun scripts/sync-server-json.ts",
     "clean": "rm -rf dist coverage",
     "prepublishOnly": "bun run clean && bun run build && bun run package:smoke",
     "release:preflight": "bun run typecheck && bun run check && bun run build && bun run package:smoke && bun run test:cov && bun run docs:build && bun run benchmark:release-artifacts && MCP_PDF_BENCHMARK_OUTPUT_DIR=${MCP_PDF_BENCHMARK_OUTPUT_DIR:-benchmark-artifacts} bun run benchmark:release-gate",

--- a/scripts/sync-server-json.ts
+++ b/scripts/sync-server-json.ts
@@ -1,0 +1,12 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const pkg = JSON.parse(readFileSync('package.json', 'utf8')) as { version: string };
+const server = JSON.parse(readFileSync('server.json', 'utf8')) as {
+  version: string;
+  packages: Array<{ version: string }>;
+};
+
+server.version = pkg.version;
+server.packages[0].version = pkg.version;
+
+writeFileSync('server.json', `${JSON.stringify(server, null, 2)}\n`);

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/SylphxAI/pdf-reader-mcp",
     "source": "github"
   },
-  "version": "3.0.13",
+  "version": "3.0.14",
   "websiteUrl": "https://sylphxai.github.io/pdf-reader-mcp/",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@sylphx/pdf-reader-mcp",
-      "version": "3.0.13",
+      "version": "3.0.14",
       "transport": {
         "type": "stdio"
       }

--- a/test/readmeDiscovery.test.ts
+++ b/test/readmeDiscovery.test.ts
@@ -35,6 +35,8 @@ describe('README discovery surfaces', () => {
     expect(pkg.mcpName).toBe('io.github.SylphxAI/pdf-reader-mcp');
     expect(server.name).toBe(pkg.mcpName);
     expect(server.packages[0].identifier).toBe(pkg.name);
+    expect(server.version).toBe(pkg.version);
+    expect(server.packages[0].version).toBe(pkg.version);
     expect(server.description.length).toBeLessThanOrEqual(100);
     expect(existsSync('.github/workflows/publish-mcp-registry.yml')).toBe(true);
   });


### PR DESCRIPTION
## Summary

- Bump `server.json` top-level and package versions from 3.0.13 → 3.0.14 to match `package.json`, npm, CHANGELOG, and the live MCP Registry listing
- Add `sync:server-json` script and run it during Changesets version PRs so future releases keep registry metadata aligned on `main`
- Extend `test/readmeDiscovery.test.ts` to assert `server.json` version parity with `package.json`
- Update `publish-mcp-registry.yml` to commit synced `server.json` back to `main` after publish (belt-and-suspenders)

## Test plan

- [x] `bun test test/readmeDiscovery.test.ts` (29 expects, exit 0)
- [x] `bun run sync:server-json` + `bun run check` + `bun run typecheck`
- [x] `jq` confirms package.json and server.json both at 3.0.14