### PR TITLE
docs: align PDF reader roadmap with Rust MCP runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,9 @@ the evidence needed to verify the answer.
 
 ## Provider-Enabled Intelligence
 
-The default package stays TypeScript-first and local-first. Heavy engines are
-optional, deployment-controlled adapters.
+The current package stays local-first. The roadmap target is a Rust MCP server
+with the same public tool contract, plus optional deployment-controlled
+providers for OCR and visual enrichment.
 
 | Capability | Default behavior | Enable with |
 | --- | --- | --- |

--- a/docs/adr/ADR-389-mcp-family-sota-roadmap.md
+++ b/docs/adr/ADR-389-mcp-family-sota-roadmap.md
@@ -25,10 +25,18 @@ and benchmark-gated release quality.
 - Smart Reader routes PDFs but does not replace PDF Reader internals.
 - Architecture Reader and Consultant MCP consume PDF evidence rather than
   duplicating PDF extraction.
-- Rust native acceleration may be added only where benchmarks preserve existing
-  tool semantics and improve measured hot paths.
+- Rust native acceleration and Rust MCP serving may be added only where
+  benchmarks and fixtures preserve existing tool semantics and improve measured
+  hot paths.
 - Provider routes, privacy behavior, confidence, and degraded extraction must
   stay explicit.
+
+## Amendment: Rust-Native MCP Runtime
+
+The family runtime direction now targets Rust MCP servers using
+`modelcontextprotocol/rust-sdk` / `rmcp`. PDF Reader MCP may keep TypeScript
+compatibility wrappers during migration, but the target MCP server runtime is
+Rust with the existing `read_pdf`, `search_pdf`, and `pdf_evidence` contracts.
 
 ## Verification
 

--- a/docs/roadmap/sota-family-roadmap.md
+++ b/docs/roadmap/sota-family-roadmap.md
@@ -36,12 +36,15 @@ instead of letting agents mistake lossy text extraction for truth.
 
 ## Runtime Direction
 
-The current TypeScript package remains the stable public surface. Rust should
-enter as native acceleration for hot paths where benchmarks prove value:
+The current package remains the stable public surface. Rust should become the
+target for MCP serving and native hot paths where benchmarks prove value:
 hashing, search indexes, region lookup, page cache, streaming, layout indexing,
 and large-file handling.
 
-The public MCP tool surface should remain stable while internals migrate.
+The Rust MCP server should use `modelcontextprotocol/rust-sdk` / `rmcp` while
+preserving the public `read_pdf`, `search_pdf`, and `pdf_evidence` tool
+contracts. TypeScript can remain for generated clients, compatibility wrappers,
+and package-transition tests, but it is not the target MCP adapter runtime.
 WASM is useful only for sandboxed extractors or portable document transforms,
 not for the default high-throughput local server.
 
@@ -61,6 +64,7 @@ not for the default high-throughput local server.
 - Identify hot paths with benchmark evidence.
 - Add Rust native modules for search index, hash, region lookup, streaming, and
   cache operations only when they improve measured performance.
+- Add a Rust MCP server facade that preserves existing tool contracts.
 - Preserve exact Agent Document Twin semantics through golden fixtures.
 - Add install diagnostics for native acceleration being unavailable.
 


### PR DESCRIPTION
## Summary
- Amends PDF Reader MCP roadmap/ADR and README to target Rust MCP serving via modelcontextprotocol/rust-sdk / rmcp.
- Keeps existing public PDF tool contracts stable during migration.

## Validation
- git diff --check
- wording sweep for old TypeScript-first/adapter language