### PR TITLE
fix(release): build Rust MCP server before package smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,14 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Build package
         run: bun run build
+
+      - name: Build Rust MCP server
+        run: bun run build:rust
 
       - name: Verify package tarball
         run: bun run package:smoke


### PR DESCRIPTION
Fixes Release workflow Verify package tarball failure on tarball:rust-mcp-server.