### PR TITLE
test(core): FLEET pure residual search/join/cache/hash edges

### DIFF
--- a/crates/pdf-reader-core/src/lib.rs
+++ b/crates/pdf-reader-core/src/lib.rs
@@ -128,4 +128,16 @@ mod tests {
         let err = hash_file(&path, 32).expect_err("oversized");
         assert_eq!(err.code, HashErrorCode::InvalidRequest);
     }
+
+
+    #[test]
+    fn bulk_hash_rejects_oversize_and_missing() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("big.bin");
+        std::fs::write(&path, b"0123456789").expect("write");
+        let err = hash_file(&path, 5).expect_err("oversize");
+        assert_eq!(err.code, HashErrorCode::InvalidRequest);
+        let missing = hash_file(&temp.path().join("nope"), 100).expect_err("missing");
+        assert_eq!(missing.code, HashErrorCode::InvalidRequest);
+    }
 }

--- a/crates/pdf-reader-core/src/page_cache.rs
+++ b/crates/pdf-reader-core/src/page_cache.rs
@@ -124,4 +124,15 @@ mod tests {
         let new_hash = hash_file(&pdf_path, 1024 * 1024).expect("hash");
         assert!(load_cached_pages(&pdf_path, &new_hash.source_hash).is_none());
     }
+
+
+    #[test]
+    fn bulk_page_cache_path_uses_parent_and_hash() {
+        use std::path::Path;
+        let p = page_cache_path(Path::new("/data/docs/file.pdf"), "abc123");
+        assert!(p.to_string_lossy().contains("abc123.json"));
+        assert!(p.to_string_lossy().contains("page-cache"));
+        let p2 = page_cache_path(Path::new("file.pdf"), "h");
+        assert!(p2.to_string_lossy().contains("h.json"));
+    }
 }

--- a/crates/pdf-reader-core/src/read_pdf.rs
+++ b/crates/pdf-reader-core/src/read_pdf.rs
@@ -268,4 +268,48 @@ mod tests {
         assert!(data.num_pages >= 1);
         assert!(data.info.is_some());
     }
+
+
+    #[test]
+    fn bulk_validate_source_path_url_matrix() {
+        assert!(validate_source(&ReadPdfSource {
+            path: Some("/tmp/a.pdf".into()),
+            url: None,
+            pages: None,
+        })
+        .is_ok());
+        assert!(validate_source(&ReadPdfSource {
+            path: None,
+            url: Some("https://x".into()),
+            pages: None,
+        })
+        .is_err());
+        assert!(validate_source(&ReadPdfSource {
+            path: None,
+            url: None,
+            pages: None,
+        })
+        .is_err());
+        assert!(validate_source(&ReadPdfSource {
+            path: Some("/tmp/a.pdf".into()),
+            url: Some("https://x".into()),
+            pages: None,
+        })
+        .is_err());
+        assert!(validate_source(&ReadPdfSource {
+            path: Some("".into()),
+            url: None,
+            pages: None,
+        })
+        .is_err());
+    }
+
+    #[test]
+    fn bulk_join_page_text_skips_empty() {
+        assert_eq!(join_page_text(&[]), "");
+        assert_eq!(
+            join_page_text(&["".into(), "a".into(), "".into(), "b".into()]),
+            "a\n\nb"
+        );
+    }
 }

--- a/crates/pdf-reader-core/src/text_index.rs
+++ b/crates/pdf-reader-core/src/text_index.rs
@@ -300,4 +300,30 @@ mod tests {
         assert_eq!(second.page_cache.as_deref(), Some("cache_hit"));
         assert_eq!(second.total_matches, first.total_matches);
     }
+
+
+    #[test]
+    fn bulk_normalize_case_and_empty_query() {
+        assert_eq!(normalize_for_search("AbC", false), "abc");
+        assert_eq!(normalize_for_search("AbC", true), "AbC");
+        assert!(find_matches_in_text("hello", "", false, false).is_empty());
+        assert!(find_matches_in_text("hello", "z", false, false).is_empty());
+    }
+
+    #[test]
+    fn bulk_whole_word_and_snippet_ellipsis() {
+        let text = "alpha beta alphabet";
+        let whole = find_matches_in_text(text, "alpha", false, true);
+        assert_eq!(whole.len(), 1, "{whole:?}");
+        let loose = find_matches_in_text(text, "alpha", false, false);
+        assert!(loose.len() >= 2, "{loose:?}");
+        assert!(is_word_char(Some('a')));
+        assert!(is_word_char(Some('_')));
+        assert!(!is_word_char(Some(' ')));
+        assert!(!is_word_char(None));
+        let snip = build_snippet("0123456789abcdefghij", 8, 12, 2);
+        assert!(snip.contains("..."), "{snip}");
+        let snip2 = build_snippet("short", 0, 5, 10);
+        assert_eq!(snip2, "short");
+    }
 }


### PR DESCRIPTION
## Summary
FLEET pure residual deepen for pdf-reader search/join/cache/hash edges.

## Scope
- Pure residual only; no authority claim
- Existing HTTP transport delivery PR remains separate

## Residual remaining
- Highest-value TS residual: src/handlers/readPdf.ts + large src/pdf/* backend surface; src/index.ts:21-43 HTTP/stdio TS transport still present on main
