### PR TITLE
fix(release): restore rmcp compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.4.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
+checksum = "cc4c9c94680f75470ee8083a0667988b5d7b5beb70b9f998a8e51de7c682ce60"
 dependencies = [
  "async-trait",
  "base64",
@@ -1072,9 +1072,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.8.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+checksum = "90c23c8f26cae4da838fbc3eadfaecf2d549d97c04b558e7bd90526a9c28b42a"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/crates/pdf-reader-mcp-server/Cargo.toml
+++ b/crates/pdf-reader-mcp-server/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1"
 axum = "0.8"
 chrono = { version = "0.4", features = ["serde"] }
 pdf-reader-core = { path = "../pdf-reader-core" }
-rmcp = { version = "1.4.0", features = ["server", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "0.16.0", features = ["server", "transport-io", "transport-streamable-http-server"] }
 schemars = { version = "1", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/test/integration/http-transport.test.ts
+++ b/test/integration/http-transport.test.ts
@@ -260,7 +260,7 @@ describe('MCP Server HTTP Transport Integration (Rust rmcp)', () => {
       await client.initializeSession();
 
       const args: Record<string, unknown> = { ...(caseEntry?.input ?? {}) };
-      if (caseEntry?.fixture) {
+      if (caseEntry?.fixture && !Object.hasOwn(args, 'sources')) {
         const fixturePath = path.resolve(__dirname, '../fixtures', caseEntry.fixture);
         args.sources = [{ path: fixturePath }];
       }


### PR DESCRIPTION
## Outcome

Restores the Rust server to `rmcp` 0.16 after the unvalidated 1.4 major bump reached `main` and broke release compilation in six places (`schema_for_input` removal and new non-exhaustive structs). A compatible 1.x migration can follow with explicit API changes and validation.

Preserves explicit golden-case `sources` in the Rust HTTP parity test. The old harness replaced `sources: []` and URL inputs with the local sample fixture, so two cases expecting validation errors incorrectly received successful sample-PDF results.

## Evidence

- `bun test test/integration/http-transport.test.ts --timeout=30000` — 16 pass, 0 fail
- `bun test test/scripts/corpusTrustRouting.test.ts --timeout=30000` — 1 pass, 0 fail
- `bun test --coverage --timeout=30000` — 477 pass, 0 fail
- `cargo build --release -p pdf-reader-core -p pdf-reader-cli -p pdf-reader-mcp-server`

No runtime behavior, MCP schema, package output, provider dispatch, credentials, npm release intent, or customer data handling changes.
