### PR TITLE
feat(rust): pin SSRF and prove v3.0.14 behavior

### DIFF
--- a/.github/workflows/rust-parity-differential.yml
+++ b/.github/workflows/rust-parity-differential.yml
@@ -118,6 +118,19 @@ jobs:
             echo "::error::proof SHA binding failed: lastComparedMainSha=$LAST_COMPARED candidate=$CANDIDATE_SHA"
             exit 1
           fi
+          BEHAVIOR_ARTIFACT="${SCRATCH_DIR}/v3014-behavior-result.json"
+          if [ ! -f "$BEHAVIOR_ARTIFACT" ]; then
+            echo "::error::v3.0.14 behavior result missing at $BEHAVIOR_ARTIFACT"
+            exit 1
+          fi
+          jq -e --arg sha "$CANDIDATE_SHA" '
+            .profile == "pdf_reader_v3014_behavior_result" and
+            .candidateSha == $sha and .pass == true and
+            .caseCount == 10 and .passed == 10 and .skipped == 0
+          ' "$BEHAVIOR_ARTIFACT" >/dev/null || {
+            echo "::error::v3.0.14 behavior result is incomplete, failing, or not SHA-bound"
+            exit 1
+          }
           echo "proof SHA binding OK: lastComparedMainSha=$LAST_COMPARED"
 
       - name: Warn on stale capabilities without re-proof
@@ -135,6 +148,7 @@ jobs:
             ${{ env.SCRATCH_DIR }}/differential.log
             ${{ env.SCRATCH_DIR }}/oracle.json
             ${{ env.SCRATCH_DIR }}/ts-vs-rust-text.json
+            ${{ env.SCRATCH_DIR }}/v3014-behavior-result.json
           if-no-files-found: error
 
   rust-parity-drift-pass:

--- a/crates/pdf-reader-core/src/read_pdf.rs
+++ b/crates/pdf-reader-core/src/read_pdf.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::text_index::{extract_page_texts, TextIndexError, TextIndexErrorCode};
+use crate::text_index::{extract_pdf_text, PdfInfo, TextIndexError, TextIndexErrorCode};
 use crate::url_fetch::{cleanup_temp_file, fetch_url_to_temp_file};
 use crate::{hash_file, FileHash, HashError, ENGINE_NAME, ENGINE_VERSION};
 
@@ -368,7 +368,7 @@ fn build_data(
     pages: &[crate::document_twin::PageText],
     total_pages: u32,
     input: &ReadPdfInput,
-    source_label: &str,
+    pdf_info: Option<&PdfInfo>,
     explicit_page_selection: bool,
 ) -> ReadPdfData {
     use crate::document_twin::{
@@ -602,13 +602,22 @@ fn build_data(
     };
 
     if want_meta {
-        let mut info = json!({
-            "Title": Path::new(source_label).file_name().and_then(|n| n.to_str()).unwrap_or("document"),
-            "Producer": "pdf-reader-core",
-            "PDFFormatVersion": "unknown",
-            "text_chars": text_chars,
-            "route": READ_PDF_ROUTE,
-        });
+        let mut info = pdf_info
+            .map(|pdf_info| {
+                let mut values = serde_json::Map::new();
+                values.insert("PDFFormatVersion".into(), json!(pdf_info.format_version));
+                for (key, value) in &pdf_info.fields {
+                    values.insert(key.clone(), json!(value));
+                }
+                Value::Object(values)
+            })
+            .unwrap_or_else(|| json!({}));
+        info.as_object_mut()
+            .expect("info object")
+            .insert("text_chars".into(), json!(text_chars));
+        info.as_object_mut()
+            .expect("info object")
+            .insert("route".into(), json!(READ_PDF_ROUTE));
         if want_page_count {
             info.as_object_mut()
                 .expect("info object")
@@ -866,8 +875,13 @@ fn read_local_pdf_filtered(
     source_label: &str,
 ) -> Result<ReadPdfSourceResult, ReadPdfError> {
     let _hash: FileHash = hash_file(path, DEFAULT_MAX_FILE_BYTES)?;
-    let pages = extract_page_texts(path, DEFAULT_MAX_FILE_BYTES)?;
-    let total_pages = pages.len().max(1) as u32;
+    let extracted = extract_pdf_text(path, DEFAULT_MAX_FILE_BYTES)?;
+    let total_pages = extracted.pages.len().max(1) as u32;
+    let pages = extracted
+        .pages
+        .iter()
+        .map(|page| page.text.clone())
+        .collect::<Vec<_>>();
     let explicit_pages = parse_page_spec(pages_spec)?;
     let auto_pages = if explicit_pages.is_none()
         && input.auto.unwrap_or(false)
@@ -886,7 +900,7 @@ fn read_local_pdf_filtered(
         &selected,
         total_pages,
         input,
-        source_label,
+        Some(&extracted.info),
         explicit_pages.is_some(),
     );
     if !invalid_pages.is_empty() {
@@ -1300,7 +1314,7 @@ mod tests {
                 include_full_text: true,
                 ..Default::default()
             },
-            "fixture.pdf",
+            None,
             true,
         );
         assert!(data.full_text.is_none());
@@ -1329,7 +1343,7 @@ mod tests {
                 include_page_count: false,
                 ..Default::default()
             },
-            "fixture.pdf",
+            None,
             false,
         );
         let serialized = serde_json::to_value(data).expect("serialize data");
@@ -1351,7 +1365,7 @@ mod tests {
                 auto_detail: Some("fast".into()),
                 ..Default::default()
             },
-            "fixture.pdf",
+            None,
             false,
         );
         assert!(data.markdown.is_some());

--- a/crates/pdf-reader-core/src/search_pdf.rs
+++ b/crates/pdf-reader-core/src/search_pdf.rs
@@ -331,6 +331,7 @@ pub fn search_pdf(input: &SearchPdfInput) -> Result<SearchPdfResponse, SearchPdf
                             "snippet": item.snippet,
                             "match_start": item.match_start,
                             "match_end": item.match_end,
+                            "text_item_index": item.text_item_index,
                             "provenance": {
                                 "engine": item.route,
                                 "route": item.route,

--- a/crates/pdf-reader-core/src/ssrf.rs
+++ b/crates/pdf-reader-core/src/ssrf.rs
@@ -1,16 +1,38 @@
-//! SSRF denylist for URL PDF loading (aligned with GHSA-f3xw-ff5r-rj7c intent).
+//! DNS resolution and globally-routable address policy for URL PDF loading.
 
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
 
-fn is_private_ipv4(ip: Ipv4Addr) -> bool {
+pub(crate) trait DnsResolver: Send + Sync {
+    fn resolve(&self, host: &str, port: u16) -> io::Result<Vec<SocketAddr>>;
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct SystemDnsResolver;
+
+impl DnsResolver for SystemDnsResolver {
+    fn resolve(&self, host: &str, port: u16) -> io::Result<Vec<SocketAddr>> {
+        (host, port)
+            .to_socket_addrs()
+            .map(|addresses| addresses.collect())
+    }
+}
+
+fn is_non_global_ipv4(ip: Ipv4Addr) -> bool {
     let o = ip.octets();
-    o[0] == 10
+    o[0] == 0
+        || o[0] == 10
         || o[0] == 127
-        || o[0] == 0
-        || (o[0] == 172 && (16..=31).contains(&o[1]))
-        || (o[0] == 192 && o[1] == 168)
         || (o[0] == 169 && o[1] == 254)
+        || (o[0] == 172 && (16..=31).contains(&o[1]))
+        || (o[0] == 192 && o[1] == 0 && o[2] == 0)
+        || (o[0] == 192 && o[1] == 0 && o[2] == 2)
+        || (o[0] == 192 && o[1] == 88 && o[2] == 99)
+        || (o[0] == 192 && o[1] == 168)
         || (o[0] == 100 && (64..=127).contains(&o[1]))
+        || (o[0] == 198 && (o[1] == 18 || o[1] == 19))
+        || (o[0] == 198 && o[1] == 51 && o[2] == 100)
+        || (o[0] == 203 && o[1] == 0 && o[2] == 113)
         || o[0] >= 224
 }
 
@@ -23,115 +45,160 @@ fn hextets_to_ipv4(hi: u16, lo: u16) -> Ipv4Addr {
     )
 }
 
-fn is_private_ipv6(ip: Ipv6Addr) -> bool {
+fn is_non_global_ipv6(ip: Ipv6Addr) -> bool {
     let s = ip.segments();
-    // :: and ::1
     if ip.is_unspecified() || ip.is_loopback() {
         return true;
     }
-    // ULA fc00::/7
-    if (s[0] & 0xfe00) == 0xfc00 {
+    // ULA, deprecated site-local, link-local, and multicast.
+    if (s[0] & 0xfe00) == 0xfc00
+        || (s[0] & 0xffc0) == 0xfec0
+        || (s[0] & 0xffc0) == 0xfe80
+        || (s[0] & 0xff00) == 0xff00
+    {
         return true;
     }
-    // link-local fe80::/10
-    if (s[0] & 0xffc0) == 0xfe80 {
-        return true;
-    }
-    // multicast ff00::/8
-    if (s[0] & 0xff00) == 0xff00 {
-        return true;
-    }
-    // IPv4-mapped ::ffff:0:0/96
+    // IPv4-mapped and IPv4-compatible forms inherit the IPv4 policy.
     if s[0] == 0 && s[1] == 0 && s[2] == 0 && s[3] == 0 && s[4] == 0 && s[5] == 0xffff {
-        return is_private_ipv4(hextets_to_ipv4(s[6], s[7]));
+        return is_non_global_ipv4(hextets_to_ipv4(s[6], s[7]));
     }
-    // IPv4-compatible ::/96
     if s[0] == 0 && s[1] == 0 && s[2] == 0 && s[3] == 0 && s[4] == 0 && s[5] == 0 {
-        return is_private_ipv4(hextets_to_ipv4(s[6], s[7]));
+        return is_non_global_ipv4(hextets_to_ipv4(s[6], s[7]));
     }
-    // NAT64 well-known 64:ff9b::/96
+    // NAT64 well-known prefix embeds an IPv4 address.
     if s[0] == 0x64 && s[1] == 0xff9b && s[2] == 0 && s[3] == 0 && s[4] == 0 && s[5] == 0 {
-        return is_private_ipv4(hextets_to_ipv4(s[6], s[7]));
+        return is_non_global_ipv4(hextets_to_ipv4(s[6], s[7]));
     }
-    // NAT64 local-use 64:ff9b:1::/48
-    if s[0] == 0x64 && s[1] == 0xff9b && s[2] == 1 {
+    // NAT64 local-use, discard-only, documentation, benchmarking, ORCHID,
+    // and Teredo are not valid public fetch targets.
+    if (s[0] == 0x64 && s[1] == 0xff9b && s[2] == 1)
+        || (s[0] == 0x100 && s[1] == 0 && s[2] == 0 && s[3] == 0)
+        || (s[0] == 0x2001 && s[1] == 0)
+        || (s[0] == 0x2001 && s[1] == 2)
+        || (s[0] == 0x2001 && s[1] == 0x0db8)
+        || (s[0] == 0x2001 && (s[1] & 0xfff0) == 0x0010)
+        || (s[0] == 0x2001 && (s[1] & 0xfff0) == 0x0020)
+    {
         return true;
     }
-    // 6to4 2002::/16
+    // 6to4 inherits the policy of its embedded IPv4 address.
     if s[0] == 0x2002 {
-        return is_private_ipv4(hextets_to_ipv4(s[1], s[2]));
-    }
-    // Teredo 2001:0::/32
-    if s[0] == 0x2001 && s[1] == 0 {
-        return true;
-    }
-    // documentation 2001:db8::/32
-    if s[0] == 0x2001 && s[1] == 0xdb8 {
-        return true;
-    }
-    // discard-only 100::/64
-    if s[0] == 0x100 && s[1] == 0 && s[2] == 0 && s[3] == 0 {
-        return true;
+        return is_non_global_ipv4(hextets_to_ipv4(s[1], s[2]));
     }
     false
 }
 
+/// Returns true for addresses that must never be reached by URL PDF loading.
+///
+/// The historical public name is retained for compatibility; the policy is
+/// intentionally broader than RFC1918 and rejects non-global special-use space.
 pub fn is_private_ip(ip: IpAddr) -> bool {
     match ip {
-        IpAddr::V4(v4) => is_private_ipv4(v4),
-        IpAddr::V6(v6) => is_private_ipv6(v6),
+        IpAddr::V4(v4) => is_non_global_ipv4(v4),
+        IpAddr::V6(v6) => is_non_global_ipv6(v6),
     }
 }
 
-pub fn assert_host_not_private(host: &str) -> Result<(), String> {
+pub(crate) fn resolve_public_addrs_with<R, F>(
+    host: &str,
+    port: u16,
+    resolver: &R,
+    is_denied: F,
+) -> Result<Vec<SocketAddr>, String>
+where
+    R: DnsResolver,
+    F: Fn(IpAddr) -> bool,
+{
     let host = host.trim().trim_matches(|c| c == '[' || c == ']');
-    if let Ok(ip) = host.parse::<IpAddr>() {
-        if is_private_ip(ip) {
-            return Err(format!(
-                "URL host '{host}' resolves to a non-public address (SSRF protection)."
-            ));
-        }
-        return Ok(());
-    }
-    // DNS: resolve all addresses
-    use std::net::ToSocketAddrs;
-    let addrs = (host, 0u16)
-        .to_socket_addrs()
-        .map_err(|_| format!("URL host '{host}' could not be resolved."))?;
-    let mut any = false;
-    for addr in addrs {
-        any = true;
-        if is_private_ip(addr.ip()) {
-            return Err(format!(
-                "URL host '{host}' resolves to a non-public address (SSRF protection)."
-            ));
-        }
-    }
-    if !any {
+    let mut addresses = if let Ok(ip) = host.parse::<IpAddr>() {
+        vec![SocketAddr::new(ip, port)]
+    } else {
+        resolver
+            .resolve(host, port)
+            .map_err(|_| format!("URL host '{host}' could not be resolved."))?
+    };
+
+    if addresses.is_empty() {
         return Err(format!("URL host '{host}' resolved to no addresses."));
     }
-    Ok(())
+    if addresses.iter().any(|address| is_denied(address.ip())) {
+        return Err(format!(
+            "URL host '{host}' resolves to a non-public address (SSRF protection)."
+        ));
+    }
+    if addresses.iter().any(|address| address.port() != port) {
+        return Err(format!(
+            "URL host '{host}' resolved with an unexpected port (SSRF protection)."
+        ));
+    }
+
+    addresses.sort_unstable();
+    addresses.dedup();
+    Ok(addresses)
+}
+
+pub(crate) fn resolve_public_addrs(host: &str, port: u16) -> Result<Vec<SocketAddr>, String> {
+    resolve_public_addrs_with(host, port, &SystemDnsResolver, is_private_ip)
+}
+
+pub fn assert_host_not_private(host: &str) -> Result<(), String> {
+    resolve_public_addrs(host, 0).map(|_| ())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::Ipv6Addr;
 
-    #[test]
-    fn blocks_nat64_metadata() {
-        let ip: Ipv6Addr = "64:ff9b::a9fe:a9fe".parse().unwrap();
-        assert!(is_private_ipv6(ip));
+    #[derive(Debug)]
+    struct FixedResolver(Vec<SocketAddr>);
+
+    impl DnsResolver for FixedResolver {
+        fn resolve(&self, _host: &str, _port: u16) -> io::Result<Vec<SocketAddr>> {
+            Ok(self.0.clone())
+        }
     }
 
     #[test]
-    fn blocks_loopback_v4() {
-        assert!(is_private_ipv4(Ipv4Addr::new(127, 0, 0, 1)));
-        assert!(is_private_ipv4(Ipv4Addr::new(169, 254, 169, 254)));
+    fn blocks_private_transition_and_special_use_addresses() {
+        for value in [
+            "127.0.0.1",
+            "169.254.169.254",
+            "192.0.2.1",
+            "198.18.0.1",
+            "198.51.100.1",
+            "203.0.113.1",
+            "::1",
+            "64:ff9b::a9fe:a9fe",
+            "2001:db8::1",
+            "2002:7f00:1::",
+        ] {
+            assert!(is_private_ip(value.parse().expect("test IP")), "{value}");
+        }
+        for value in ["8.8.8.8", "1.1.1.1", "2606:4700:4700::1111"] {
+            assert!(!is_private_ip(value.parse().expect("test IP")), "{value}");
+        }
     }
 
     #[test]
-    fn allows_public_v4() {
-        assert!(!is_private_ipv4(Ipv4Addr::new(8, 8, 8, 8)));
+    fn rejects_mixed_public_and_private_dns_answers() {
+        let resolver = FixedResolver(vec![
+            "8.8.8.8:443".parse().unwrap(),
+            "127.0.0.1:443".parse().unwrap(),
+        ]);
+        let error = resolve_public_addrs_with("mixed.example", 443, &resolver, is_private_ip)
+            .expect_err("mixed answer must fail closed");
+        assert!(error.contains("non-public address"));
+    }
+
+    #[test]
+    fn deduplicates_public_answers_and_preserves_port() {
+        let resolver = FixedResolver(vec![
+            "8.8.8.8:8443".parse().unwrap(),
+            "8.8.8.8:8443".parse().unwrap(),
+        ]);
+        assert_eq!(
+            resolve_public_addrs_with("public.example", 8443, &resolver, is_private_ip).unwrap(),
+            vec!["8.8.8.8:8443".parse().unwrap()]
+        );
     }
 }

--- a/crates/pdf-reader-core/src/text_index.rs
+++ b/crates/pdf-reader-core/src/text_index.rs
@@ -1,8 +1,13 @@
 //! Literal PDF text indexing and search for pdf-reader-mcp.
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
+use pdf_extract::{
+    decode_text_string, output_doc, ColorSpace, Document, MediaBox, Object, OutputDev, OutputError,
+    Path as PdfPath, Transform,
+};
 use serde::{Deserialize, Serialize};
 
 pub const TEXT_INDEX_ROUTE: &str = "rust-text-index";
@@ -15,7 +20,26 @@ pub struct TextSearchMatch {
     pub snippet: String,
     pub match_start: u32,
     pub match_end: u32,
+    pub text_item_index: u32,
     pub route: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtractedPageText {
+    pub text: String,
+    pub items: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PdfInfo {
+    pub format_version: String,
+    pub fields: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtractedPdfText {
+    pub pages: Vec<ExtractedPageText>,
+    pub info: PdfInfo,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -75,7 +99,7 @@ impl TextIndexError {
     }
 }
 
-pub fn extract_page_texts(path: &Path, max_file_bytes: u64) -> Result<Vec<String>, TextIndexError> {
+fn validate_pdf_path(path: &Path, max_file_bytes: u64) -> Result<(), TextIndexError> {
     let meta = fs::metadata(path).map_err(|err| {
         TextIndexError::invalid_request(format!(
             "Unable to access file at '{}': {err}",
@@ -97,18 +121,177 @@ pub fn extract_page_texts(path: &Path, max_file_bytes: u64) -> Result<Vec<String
         )));
     }
 
-    let pages = pdf_extract::extract_text_by_pages(path).map_err(|err| {
+    Ok(())
+}
+
+#[derive(Default)]
+struct TextItemOutput {
+    pages: Vec<Vec<String>>,
+    current_item: Option<String>,
+}
+
+impl TextItemOutput {
+    fn finish_item(&mut self) {
+        let Some(item) = self.current_item.take() else {
+            return;
+        };
+        if !item.is_empty() {
+            if let Some(page) = self.pages.last_mut() {
+                page.push(item);
+            }
+        }
+    }
+}
+
+impl OutputDev for TextItemOutput {
+    fn begin_page(
+        &mut self,
+        _page_num: u32,
+        _media_box: &MediaBox,
+        _art_box: Option<(f64, f64, f64, f64)>,
+    ) -> Result<(), OutputError> {
+        self.finish_item();
+        self.pages.push(Vec::new());
+        Ok(())
+    }
+
+    fn end_page(&mut self) -> Result<(), OutputError> {
+        self.finish_item();
+        Ok(())
+    }
+
+    fn output_character(
+        &mut self,
+        _trm: &Transform,
+        _width: f64,
+        _spacing: f64,
+        _font_size: f64,
+        character: &str,
+    ) -> Result<(), OutputError> {
+        if let Some(item) = self.current_item.as_mut() {
+            item.push_str(character);
+        }
+        Ok(())
+    }
+
+    fn begin_word(&mut self) -> Result<(), OutputError> {
+        // A TJ operator can emit several strings for one logical PDF.js text item.
+        // Keep those fragments together until the text matrix advances to a new line.
+        if self.current_item.is_none() {
+            self.current_item = Some(String::new());
+        }
+        Ok(())
+    }
+
+    fn end_word(&mut self) -> Result<(), OutputError> {
+        Ok(())
+    }
+
+    fn end_line(&mut self) -> Result<(), OutputError> {
+        self.finish_item();
+        Ok(())
+    }
+
+    fn stroke(
+        &mut self,
+        _ctm: &Transform,
+        _colorspace: &ColorSpace,
+        _color: &[f64],
+        _path: &PdfPath,
+    ) -> Result<(), OutputError> {
+        Ok(())
+    }
+
+    fn fill(
+        &mut self,
+        _ctm: &Transform,
+        _colorspace: &ColorSpace,
+        _color: &[f64],
+        _path: &PdfPath,
+    ) -> Result<(), OutputError> {
+        Ok(())
+    }
+}
+
+fn read_pdf_info(doc: &Document) -> PdfInfo {
+    let mut fields = BTreeMap::new();
+    let info_object = doc
+        .trailer
+        .get(b"Info")
+        .ok()
+        .and_then(|object| match object {
+            Object::Reference(id) => doc.get_object(*id).ok(),
+            Object::Dictionary(_) => Some(object),
+            _ => None,
+        });
+    if let Some(info) = info_object.and_then(|object| object.as_dict().ok()) {
+        for key in [
+            "Title",
+            "Author",
+            "Subject",
+            "Keywords",
+            "Creator",
+            "Producer",
+            "CreationDate",
+            "ModDate",
+            "Trapped",
+        ] {
+            if let Ok(value) = info.get(key.as_bytes()) {
+                if let Ok(decoded) = decode_text_string(value) {
+                    fields.insert(key.to_string(), decoded);
+                }
+            }
+        }
+    }
+    PdfInfo {
+        format_version: doc.version.clone(),
+        fields,
+    }
+}
+
+pub fn extract_pdf_text(
+    path: &Path,
+    max_file_bytes: u64,
+) -> Result<ExtractedPdfText, TextIndexError> {
+    validate_pdf_path(path, max_file_bytes)?;
+
+    let mut doc = Document::load(path).map_err(|err| {
+        TextIndexError::extraction_failed(format!("Failed to extract PDF text: {err}"))
+    })?;
+    if doc.is_encrypted() {
+        doc.decrypt("").map_err(|err| {
+            TextIndexError::extraction_failed(format!("Failed to extract PDF text: {err}"))
+        })?;
+    }
+    let info = read_pdf_info(&doc);
+    let mut output = TextItemOutput::default();
+    output_doc(&doc, &mut output).map_err(|err| {
         TextIndexError::extraction_failed(format!("Failed to extract PDF text: {err}"))
     })?;
 
-    if pages.is_empty() {
-        return Ok(vec![String::new()]);
-    }
+    let pages = if output.pages.is_empty() {
+        vec![ExtractedPageText {
+            text: String::new(),
+            items: Vec::new(),
+        }]
+    } else {
+        output
+            .pages
+            .into_iter()
+            .map(|items| ExtractedPageText {
+                text: items.concat(),
+                items,
+            })
+            .collect()
+    };
 
-    Ok(pages
-        .into_iter()
-        .map(|page| page.trim().to_string())
-        .collect())
+    Ok(ExtractedPdfText { pages, info })
+}
+
+pub fn extract_page_texts(path: &Path, max_file_bytes: u64) -> Result<Vec<String>, TextIndexError> {
+    let extracted = extract_pdf_text(path, max_file_bytes)?;
+
+    Ok(extracted.pages.into_iter().map(|page| page.text).collect())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -153,7 +336,8 @@ pub fn search_pdf_text_pages(
 
     // TS 3.0.14 does not persist extracted document text beside the source.
     // Keep search side-effect free; a future cache needs an explicit private-root contract.
-    let pages = extract_page_texts(path, max_file_bytes)?;
+    let extracted = extract_pdf_text(path, max_file_bytes)?;
+    let pages = extracted.pages;
     let page_cache = None;
     let num_pages = pages.len().max(1) as u32;
     let searched_pages: Vec<u32> = requested_pages
@@ -168,28 +352,40 @@ pub fn search_pdf_text_pages(
 
     for &page in &searched_pages {
         let page_index = (page - 1) as usize;
-        let text = pages.get(page_index).map(String::as_str).unwrap_or("");
-        let remaining = max_matches.saturating_add(1) as usize - matches.len();
-        let page_matches =
-            find_matches_in_text_bounded(text, query, case_sensitive, whole_word, remaining);
+        let page_text = pages.get(page_index);
+        for (text_item_index, text) in page_text
+            .map(|page| page.items.iter())
+            .into_iter()
+            .flatten()
+            .enumerate()
+        {
+            let remaining = max_matches.saturating_add(1) as usize - matches.len();
+            let item_matches =
+                find_matches_in_text_bounded(text, query, case_sensitive, whole_word, remaining);
 
-        for (start, end) in page_matches {
-            if matches.len() >= max_matches as usize {
-                truncated = true;
-                break;
+            for (start, end) in item_matches {
+                if matches.len() >= max_matches as usize {
+                    truncated = true;
+                    break;
+                }
+
+                let matched_text = text[start..end].to_string();
+                let snippet = build_snippet(text, start, end, context_chars as usize);
+                matches.push(TextSearchMatch {
+                    id: format!("p{page}-match-{}", matches.len() + 1),
+                    page,
+                    text: matched_text,
+                    snippet,
+                    match_start: utf16_offset(text, start),
+                    match_end: utf16_offset(text, end),
+                    text_item_index: text_item_index as u32,
+                    route: TEXT_INDEX_ROUTE.into(),
+                });
             }
 
-            let matched_text = text[start..end].to_string();
-            let snippet = build_snippet(text, start, end, context_chars as usize);
-            matches.push(TextSearchMatch {
-                id: format!("p{page}-match-{}", matches.len() + 1),
-                page,
-                text: matched_text,
-                snippet,
-                match_start: start as u32,
-                match_end: end as u32,
-                route: TEXT_INDEX_ROUTE.into(),
-            });
+            if truncated {
+                break;
+            }
         }
 
         if truncated {
@@ -206,6 +402,14 @@ pub fn search_pdf_text_pages(
         truncated,
         page_cache,
     })
+}
+
+fn utf16_offset(text: &str, byte_offset: usize) -> u32 {
+    text[..byte_offset.min(text.len())]
+        .encode_utf16()
+        .count()
+        .try_into()
+        .unwrap_or(u32::MAX)
 }
 
 fn is_word_char(value: Option<char>) -> bool {
@@ -423,6 +627,14 @@ mod tests {
             assert!(text.is_char_boundary(start));
             assert!(text.is_char_boundary(end));
         }
+    }
+
+    #[test]
+    fn reports_offsets_in_javascript_utf16_code_units() {
+        let text = "😀Café";
+        let (start, end) = find_matches_in_text(text, "Café", true, false)[0];
+        assert_eq!(utf16_offset(text, start), 2);
+        assert_eq!(utf16_offset(text, end), 6);
     }
 
     #[test]

--- a/crates/pdf-reader-core/src/url_fetch.rs
+++ b/crates/pdf-reader-core/src/url_fetch.rs
@@ -1,17 +1,47 @@
-//! HTTP(S) PDF body fetch with SSRF protection and redirect revalidation.
+//! HTTP(S) PDF body fetch with DNS-pinned SSRF protection per redirect hop.
 
 use std::fs;
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
+use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use crate::ssrf::assert_host_not_private;
+use crate::ssrf::{is_private_ip, resolve_public_addrs_with, DnsResolver, SystemDnsResolver};
 
 const MAX_REDIRECTS: usize = 5;
 const MAX_BYTES: u64 = 256 * 1024 * 1024;
 const TIMEOUT_SECS: u64 = 30;
 
-pub fn fetch_url_to_temp_file(url: &str) -> Result<PathBuf, String> {
+#[derive(Debug, Clone)]
+struct PinnedResolver {
+    expected_netloc: String,
+    addresses: Vec<SocketAddr>,
+}
+
+impl ureq::Resolver for PinnedResolver {
+    fn resolve(&self, netloc: &str) -> io::Result<Vec<SocketAddr>> {
+        if netloc != self.expected_netloc {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!(
+                    "refusing unvalidated network target '{netloc}' (expected '{}')",
+                    self.expected_netloc
+                ),
+            ));
+        }
+        Ok(self.addresses.clone())
+    }
+}
+
+fn fetch_url_to_temp_file_with<R, F>(
+    url: &str,
+    resolver: &R,
+    is_denied: F,
+) -> Result<PathBuf, String>
+where
+    R: DnsResolver,
+    F: Fn(IpAddr) -> bool + Copy,
+{
     let mut current = url.to_string();
     for _ in 0..=MAX_REDIRECTS {
         let parsed = url::Url::parse(&current).map_err(|e| format!("Invalid URL: {e}"))?;
@@ -21,11 +51,24 @@ pub fn fetch_url_to_temp_file(url: &str) -> Result<PathBuf, String> {
         let host = parsed
             .host_str()
             .ok_or_else(|| "URL host is required.".to_string())?;
-        assert_host_not_private(host)?;
+        let port = parsed
+            .port_or_known_default()
+            .ok_or_else(|| "URL port could not be determined.".to_string())?;
+        let addresses = resolve_public_addrs_with(host, port, resolver, is_denied)?;
+        let expected_netloc = format!("{host}:{port}");
 
+        // A fresh, pool-free agent makes each hop a separate validation and
+        // connection boundary. The URL retains the hostname for Host and TLS SNI.
         let agent = ureq::AgentBuilder::new()
             .timeout(Duration::from_secs(TIMEOUT_SECS))
             .redirects(0)
+            .try_proxy_from_env(false)
+            .max_idle_connections(0)
+            .max_idle_connections_per_host(0)
+            .resolver(PinnedResolver {
+                expected_netloc,
+                addresses,
+            })
             .build();
 
         let response = agent
@@ -77,6 +120,118 @@ pub fn fetch_url_to_temp_file(url: &str) -> Result<PathBuf, String> {
     Err(format!("Too many redirects (>{MAX_REDIRECTS})."))
 }
 
+pub fn fetch_url_to_temp_file(url: &str) -> Result<PathBuf, String> {
+    fetch_url_to_temp_file_with(url, &SystemDnsResolver, is_private_ip)
+}
+
 pub fn cleanup_temp_file(path: &Path) {
     let _ = fs::remove_file(path);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::net::{Ipv4Addr, TcpListener};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+
+    #[derive(Clone)]
+    struct ScriptedResolver {
+        answers: Arc<Mutex<HashMap<String, Vec<Vec<SocketAddr>>>>>,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl ScriptedResolver {
+        fn new(answers: HashMap<String, Vec<Vec<SocketAddr>>>) -> Self {
+            Self {
+                answers: Arc::new(Mutex::new(answers)),
+                calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+
+    impl DnsResolver for ScriptedResolver {
+        fn resolve(&self, host: &str, _port: u16) -> io::Result<Vec<SocketAddr>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let mut answers = self.answers.lock().expect("resolver answers lock");
+            let script = answers.get_mut(host).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::NotFound, format!("no DNS script for {host}"))
+            })?;
+            if script.is_empty() {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("DNS script exhausted for {host}"),
+                ));
+            }
+            Ok(script.remove(0))
+        }
+    }
+
+    fn spawn_one_response(response: &'static [u8]) -> SocketAddr {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind test server");
+        let address = listener.local_addr().expect("test server address");
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept test request");
+            let mut request = [0_u8; 2048];
+            let _ = stream.read(&mut request).expect("read test request");
+            stream.write_all(response).expect("write test response");
+        });
+        address
+    }
+
+    #[test]
+    fn one_dns_resolution_is_pinned_to_the_actual_connection() {
+        let server = spawn_one_response(
+            b"HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\n%PDF-1.4",
+        );
+        let rebound = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), server.port());
+        let resolver = ScriptedResolver::new(HashMap::from([(
+            "rebind.test".into(),
+            vec![vec![server], vec![rebound]],
+        )]));
+
+        let path = fetch_url_to_temp_file_with(
+            &format!("http://rebind.test:{}/sample.pdf", server.port()),
+            &resolver,
+            |_| false,
+        )
+        .expect("fetch through pinned address");
+        assert_eq!(resolver.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(fs::read(&path).unwrap(), b"%PDF-1.4");
+        cleanup_temp_file(&path);
+    }
+
+    #[test]
+    fn redirect_target_is_revalidated_before_connection() {
+        let redirect = spawn_one_response(
+            b"HTTP/1.1 302 Found\r\nLocation: http://blocked.test:6553/private.pdf\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        );
+        let blocked: SocketAddr = "127.0.0.2:6553".parse().unwrap();
+        let resolver = ScriptedResolver::new(HashMap::from([
+            ("first.test".into(), vec![vec![redirect]]),
+            ("blocked.test".into(), vec![vec![blocked]]),
+        ]));
+
+        let error = fetch_url_to_temp_file_with(
+            &format!("http://first.test:{}/redirect", redirect.port()),
+            &resolver,
+            |ip| ip == blocked.ip(),
+        )
+        .expect_err("redirect to denied target must fail");
+        assert!(error.contains("non-public address"), "{error}");
+        assert_eq!(resolver.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn pinned_resolver_rejects_unexpected_netloc() {
+        let resolver = PinnedResolver {
+            expected_netloc: "allowed.test:443".into(),
+            addresses: vec!["8.8.8.8:443".parse().unwrap()],
+        };
+        let error = ureq::Resolver::resolve(&resolver, "other.test:443")
+            .expect_err("unexpected netloc must fail closed");
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    }
 }

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -71,12 +71,12 @@
     }
   },
   "claimedForDifferential": [
-    "read_pdf full_text (normalized whitespace) on sample.pdf",
-    "search_pdf match page+text for fixed query on sample.pdf",
-    "loopback URL rejected with the explicit non-public-address SSRF policy error",
-    "auto off when include_* keys present"
+    "exact 10-case immutable TS v3.0.14 behavior subset: full text, page selection/order/duplicates, metadata, literal search, case sensitivity, whole word, Unicode, UTF-16 offsets, missing and malformed inputs, and mixed-source partial success",
+    "DNS-pinned URL fetch: one resolution per redirect hop, reject mixed public/non-public answers, disable ambient proxies, and revalidate every redirect; still PARTIAL because resolver timeout and TLS-SNI fixtures remain open",
+    "auto off when include_* keys are present"
   ],
   "explicitlyNotClaimed": [
+    "complete TS 3.0.14 semantic parity outside the immutable 10-case subset",
     "geometry/bboxes",
     "render/crop/OCR/analyze success path",
     "COS outline/annotations/forms",

--- a/scripts/differential/capture-v3014-behavior-oracle.ts
+++ b/scripts/differential/capture-v3014-behavior-oracle.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env bun
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDir, '../..');
+const corpusPath = join(scriptDir, 'fixtures/v3014-behavior-corpus.json');
+const oraclePath = join(scriptDir, 'fixtures/v3014-behavior-oracle.json');
+const fixtureDir = join(repoRoot, 'test/fixtures/differential');
+const runnerSource = join(scriptDir, 'v3014-baseline-runner.ts');
+const refresh = process.argv.includes('--refresh');
+const oracle = JSON.parse(readFileSync(oraclePath, 'utf8')) as {
+  baseline: { tag: string; commit: string };
+  expectations: Record<string, unknown>;
+};
+
+function run(command: string, args: string[], cwd: string, capture = false): string {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: capture ? ['ignore', 'pipe', 'inherit'] : 'inherit',
+  });
+  if (result.status !== 0) throw new Error(`${command} ${args.join(' ')} failed`);
+  return result.stdout ?? '';
+}
+
+const resolved = run('git', ['rev-list', '-n', '1', oracle.baseline.tag], repoRoot, true).trim();
+if (resolved !== oracle.baseline.commit) {
+  throw new Error(`${oracle.baseline.tag} moved: expected ${oracle.baseline.commit}, got ${resolved}`);
+}
+
+const worktree = mkdtempSync(join(tmpdir(), 'pdf-reader-v3014-oracle-'));
+try {
+  run('git', ['worktree', 'add', '--detach', worktree, oracle.baseline.commit], repoRoot);
+  run('bun', ['install', '--frozen-lockfile'], worktree);
+  const runner = join(worktree, 'v3014-baseline-runner.ts');
+  writeFileSync(runner, readFileSync(runnerSource));
+  const stdout = run('bun', [runner, corpusPath, fixtureDir], worktree, true);
+  const expectations = JSON.parse(stdout) as Record<string, unknown>;
+  if (refresh) {
+    const next = { ...oracle, expectations };
+    writeFileSync(oraclePath, `${JSON.stringify(next, null, 2)}\n`);
+    console.error(`refreshed ${oraclePath}`);
+  } else if (JSON.stringify(expectations) !== JSON.stringify(oracle.expectations)) {
+    throw new Error('stored v3.0.14 behavior oracle differs from replayed baseline; use --refresh only after review');
+  } else {
+    console.log(`v3.0.14 behavior oracle replay: OK (${Object.keys(expectations).length} cases)`);
+  }
+} finally {
+  spawnSync('git', ['worktree', 'remove', '--force', worktree], { cwd: repoRoot, stdio: 'ignore' });
+  rmSync(worktree, { recursive: true, force: true });
+}

--- a/scripts/differential/check-v3014-behavior-differential.ts
+++ b/scripts/differential/check-v3014-behavior-differential.ts
@@ -1,0 +1,238 @@
+#!/usr/bin/env bun
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDir, '../..');
+const fixtureDir = join(repoRoot, 'test/fixtures/differential');
+const corpusPath = join(scriptDir, 'fixtures/v3014-behavior-corpus.json');
+const oraclePath = join(scriptDir, 'fixtures/v3014-behavior-oracle.json');
+const fixtureManifestPath = join(scriptDir, 'fixtures/v3014-behavior-fixtures.json');
+const rustCliPath = join(repoRoot, 'target/release/pdf-reader-cli');
+const outputFlag = process.argv.indexOf('--output');
+const outputPath = outputFlag >= 0 ? process.argv[outputFlag + 1] : undefined;
+
+type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
+type Case = { id: string; tool: string; input: Record<string, unknown> };
+type Oracle = {
+  baseline: {
+    tag: string;
+    commit: string;
+    tree: string;
+    bunLockSha256: string;
+    entrypointSha256: Record<string, string>;
+  };
+  expectations: Record<string, Json>;
+};
+
+const corpus = JSON.parse(readFileSync(corpusPath, 'utf8')) as { cases: Case[] };
+const oracle = JSON.parse(readFileSync(oraclePath, 'utf8')) as Oracle;
+const fixtureManifest = JSON.parse(readFileSync(fixtureManifestPath, 'utf8')) as {
+  fixtures: Array<{ path: string; bytes: number; sha256: string }>;
+};
+const sha256 = (bytes: Uint8Array | string): string =>
+  createHash('sha256').update(bytes).digest('hex');
+const git = (...args: string[]): Buffer => {
+  const result = spawnSync('git', args, { cwd: repoRoot });
+  if (result.status !== 0) throw new Error(result.stderr.toString());
+  return result.stdout;
+};
+const normalizeText = (value: string): string =>
+  value.replaceAll('\r\n', '\n').normalize('NFC');
+
+function verifyAuthority(): Record<string, string> {
+  const commit = git('rev-list', '-n', '1', oracle.baseline.tag).toString().trim();
+  if (commit !== oracle.baseline.commit) {
+    throw new Error(`${oracle.baseline.tag} moved: expected ${oracle.baseline.commit}, got ${commit}`);
+  }
+  const tree = git('rev-parse', `${commit}^{tree}`).toString().trim();
+  if (tree !== oracle.baseline.tree) throw new Error(`baseline tree mismatch: ${tree}`);
+  const lockDigest = sha256(git('show', `${commit}:bun.lock`));
+  if (lockDigest !== oracle.baseline.bunLockSha256) throw new Error('baseline bun.lock mismatch');
+  for (const [path, expected] of Object.entries(oracle.baseline.entrypointSha256)) {
+    const actual = sha256(git('show', `${commit}:${path}`));
+    if (actual !== expected) throw new Error(`baseline entrypoint mismatch: ${path}`);
+  }
+  for (const fixture of fixtureManifest.fixtures) {
+    const path = join(repoRoot, fixture.path);
+    if (!existsSync(path)) throw new Error(`missing fixture: ${fixture.path}`);
+    const bytes = readFileSync(path);
+    if (bytes.length !== fixture.bytes || sha256(bytes) !== fixture.sha256) {
+      throw new Error(`fixture digest mismatch: ${fixture.path}`);
+    }
+  }
+  const ids = corpus.cases.map((entry) => entry.id);
+  if (ids.length !== 10 || new Set(ids).size !== ids.length) {
+    throw new Error(`behavior corpus must contain 10 unique cases (got ${ids.length})`);
+  }
+  if (JSON.stringify(ids.sort()) !== JSON.stringify(Object.keys(oracle.expectations).sort())) {
+    throw new Error('corpus and oracle case IDs differ');
+  }
+  return {
+    baselineCommit: commit,
+    baselineTree: tree,
+    corpusSha256: sha256(readFileSync(corpusPath)),
+    oracleSha256: sha256(readFileSync(oraclePath)),
+    fixtureManifestSha256: sha256(readFileSync(fixtureManifestPath)),
+  };
+}
+
+function materializeInput(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(materializeInput);
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    const mapped: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(record)) {
+      mapped[key === 'fixture' ? 'path' : key] =
+        key === 'fixture' && typeof entry === 'string'
+          ? join(fixtureDir, entry)
+          : materializeInput(entry);
+    }
+    return mapped;
+  }
+  return value;
+}
+
+function rustCall(entry: Case): Record<string, unknown> {
+  if (!existsSync(rustCliPath)) throw new Error(`missing Rust CLI: ${rustCliPath}`);
+  const result = spawnSync(rustCliPath, [], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    input: JSON.stringify({ tool: entry.tool, input: materializeInput(entry.input) }),
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  if (!result.stdout) throw new Error(`Rust CLI produced no JSON: ${result.stderr}`);
+  return JSON.parse(result.stdout) as Record<string, unknown>;
+}
+
+function unwrapPayload(envelope: Record<string, unknown>): Record<string, unknown> | undefined {
+  const result = envelope.result as { content?: Array<{ text?: string }> } | undefined;
+  const text = result?.content?.[0]?.text;
+  return typeof text === 'string' ? (JSON.parse(text) as Record<string, unknown>) : undefined;
+}
+
+function errorCategory(message: string): string {
+  const lower = message.toLowerCase();
+  if (lower.includes('not found') || lower.includes('no such file') || lower.includes('unable to access')) {
+    return 'file_not_found';
+  }
+  if (lower.includes('pdf') && (lower.includes('parse') || lower.includes('cross reference'))) {
+    return 'invalid_pdf';
+  }
+  return 'unknown_error';
+}
+
+function warnings(value: unknown): Json[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((warning) => {
+    const text = String(warning);
+    const match = text.match(/(?:page numbers?|pages?)\s+([0-9, ]+).*?(?:total pages|page count)\s*\(?([0-9]+)\)?/i);
+    return match
+      ? {
+          category: 'page_out_of_range',
+          requested: match[1]!.split(',').map((part) => Number(part.trim())),
+          total: Number(match[2]),
+        }
+      : { category: 'unknown_warning' };
+  });
+}
+
+function canonicalRead(id: string, envelope: Record<string, unknown>): Json {
+  if (envelope.status === 'error') {
+    return { outcome: 'error', category: errorCategory(String(envelope.message ?? '')) };
+  }
+  const payload = unwrapPayload(envelope);
+  const results = payload?.results as Array<Record<string, unknown>> | undefined;
+  if (!results) return { outcome: 'error', category: 'invalid_envelope' };
+  if (id === 'read-mixed-source-partial') {
+    return {
+      outcome: 'success',
+      results: results.map((result) => {
+        const data = result.data as Record<string, unknown> | undefined;
+        return result.success === true
+          ? { success: true, num_pages: Number(data?.num_pages) }
+          : { success: false, category: errorCategory(String(result.error ?? '')) };
+      }),
+    };
+  }
+  const first = results[0];
+  if (!first?.success) {
+    return { outcome: 'error', category: errorCategory(String(first?.error ?? '')) };
+  }
+  const data = first.data as Record<string, unknown>;
+  const canonical: Record<string, Json> = {
+    outcome: 'success',
+    num_pages: Number(data.num_pages),
+  };
+  if (id === 'read-all-metadata') {
+    const info = data.info as Record<string, unknown> | undefined;
+    canonical.info = Object.fromEntries(
+      ['PDFFormatVersion', 'Title', 'Author', 'Subject', 'Keywords', 'Creator', 'Producer'].map(
+        (key) => [key, (info?.[key] ?? null) as Json]
+      )
+    );
+    canonical.full_text = normalizeText(String(data.full_text ?? ''));
+  }
+  if (id.startsWith('read-pages-')) {
+    canonical.page_texts = Array.isArray(data.page_texts)
+      ? data.page_texts.map((page) => ({
+          page: Number((page as Record<string, unknown>).page),
+          text: normalizeText(String((page as Record<string, unknown>).text ?? '')),
+        }))
+      : [];
+  }
+  canonical.warnings = warnings(data.warnings);
+  return canonical;
+}
+
+function canonicalSearch(envelope: Record<string, unknown>): Json {
+  const payload = unwrapPayload(envelope);
+  const first = (payload?.results as Array<Record<string, unknown>> | undefined)?.[0];
+  if (!first?.success) {
+    return { outcome: 'error', category: errorCategory(String(first?.error ?? envelope.message ?? '')) };
+  }
+  return {
+    outcome: 'success',
+    num_pages: Number(first.num_pages),
+    searched_pages: (first.searched_pages ?? []) as Json,
+    matches: ((first.matches ?? []) as Array<Record<string, unknown>>).map((match) => ({
+      page: Number(match.page),
+      text: normalizeText(String(match.text ?? '')),
+      match_start: Number(match.match_start),
+      match_end: Number(match.match_end),
+      text_item_index: Number(match.text_item_index),
+    })),
+  };
+}
+
+const authority = verifyAuthority();
+const failures: Array<{ id: string; expected: Json; actual: Json }> = [];
+const observations: Record<string, Json> = {};
+for (const entry of corpus.cases) {
+  const envelope = rustCall(entry);
+  const actual = entry.tool === 'read_pdf' ? canonicalRead(entry.id, envelope) : canonicalSearch(envelope);
+  const expected = oracle.expectations[entry.id]!;
+  observations[entry.id] = actual;
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) failures.push({ id: entry.id, expected, actual });
+}
+const report = {
+  schemaVersion: 1,
+  profile: 'pdf_reader_v3014_behavior_result',
+  candidateSha:
+    process.env.CANDIDATE_SHA ?? git('rev-parse', 'HEAD').toString().trim(),
+  ...authority,
+  caseCount: corpus.cases.length,
+  passed: corpus.cases.length - failures.length,
+  skipped: 0,
+  pass: failures.length === 0,
+  observations,
+  failures,
+};
+const serialized = `${JSON.stringify(report, null, 2)}\n`;
+if (outputPath) await Bun.write(outputPath, serialized);
+console.log(serialized.trimEnd());
+if (failures.length > 0) process.exit(1);

--- a/scripts/differential/fixtures/v3014-behavior-corpus.json
+++ b/scripts/differential/fixtures/v3014-behavior-corpus.json
@@ -1,0 +1,118 @@
+{
+  "schemaVersion": 1,
+  "profile": "pdf_reader_v3014_behavior_corpus",
+  "cases": [
+    {
+      "id": "read-all-metadata",
+      "tool": "read_pdf",
+      "input": {
+        "sources": [{ "fixture": "v3014-behavior-v1.pdf" }],
+        "auto": false,
+        "include_full_text": true,
+        "include_metadata": true,
+        "include_page_count": true
+      }
+    },
+    {
+      "id": "read-pages-array-dedupe-sort",
+      "tool": "read_pdf",
+      "input": {
+        "sources": [{ "fixture": "v3014-behavior-v1.pdf", "pages": [3, 1, 3] }],
+        "auto": false,
+        "include_full_text": true,
+        "include_metadata": true,
+        "include_page_count": true
+      }
+    },
+    {
+      "id": "read-pages-range-out-of-range",
+      "tool": "read_pdf",
+      "input": {
+        "sources": [{ "fixture": "v3014-behavior-v1.pdf", "pages": "2,9" }],
+        "auto": false,
+        "include_full_text": true,
+        "include_metadata": true,
+        "include_page_count": true
+      }
+    },
+    {
+      "id": "search-ci-all",
+      "tool": "search_pdf",
+      "input": {
+        "sources": [{ "fixture": "v3014-behavior-v1.pdf" }],
+        "query": "needle",
+        "context_chars": 0,
+        "max_pages": 10,
+        "max_matches_per_source": 50
+      }
+    },
+    {
+      "id": "search-cs-upper",
+      "tool": "search_pdf",
+      "input": {
+        "sources": [{ "fixture": "v3014-behavior-v1.pdf" }],
+        "query": "NEEDLE",
+        "case_sensitive": true,
+        "context_chars": 0,
+        "max_pages": 10,
+        "max_matches_per_source": 50
+      }
+    },
+    {
+      "id": "search-whole-word",
+      "tool": "search_pdf",
+      "input": {
+        "sources": [{ "fixture": "v3014-behavior-v1.pdf" }],
+        "query": "cat",
+        "whole_word": true,
+        "context_chars": 0,
+        "max_pages": 10,
+        "max_matches_per_source": 50
+      }
+    },
+    {
+      "id": "search-selected-unicode",
+      "tool": "search_pdf",
+      "input": {
+        "sources": [{ "fixture": "v3014-behavior-v1.pdf", "pages": [2] }],
+        "query": "CAFÉ",
+        "context_chars": 0,
+        "max_pages": 10,
+        "max_matches_per_source": 50
+      }
+    },
+    {
+      "id": "read-missing-file",
+      "tool": "read_pdf",
+      "input": {
+        "sources": [{ "fixture": "no-such-v3014.pdf" }],
+        "auto": false,
+        "include_full_text": true,
+        "include_page_count": true
+      }
+    },
+    {
+      "id": "read-malformed",
+      "tool": "read_pdf",
+      "input": {
+        "sources": [{ "fixture": "v3014-malformed-v1.pdf" }],
+        "auto": false,
+        "include_full_text": true,
+        "include_page_count": true
+      }
+    },
+    {
+      "id": "read-mixed-source-partial",
+      "tool": "read_pdf",
+      "input": {
+        "sources": [
+          { "fixture": "v3014-behavior-v1.pdf" },
+          { "fixture": "no-such-v3014.pdf" }
+        ],
+        "auto": false,
+        "include_full_text": true,
+        "include_page_count": true
+      }
+    }
+  ]
+}

--- a/scripts/differential/fixtures/v3014-behavior-fixtures.json
+++ b/scripts/differential/fixtures/v3014-behavior-fixtures.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "generator": "scripts/differential/generate-v3014-behavior-fixtures.ts",
+  "fixtures": [
+    {
+      "path": "test/fixtures/differential/v3014-behavior-v1.pdf",
+      "bytes": 1559,
+      "sha256": "b457e7452b3fc57d1d7c1416600b71a3ce928c1e966a39e19ef462508064be38"
+    },
+    {
+      "path": "test/fixtures/differential/v3014-malformed-v1.pdf",
+      "bytes": 36,
+      "sha256": "9d2af66045549c01cbad6e0d8c8c5a64bb644cfad2b76a0e7a6fbd578d3efabf"
+    }
+  ]
+}

--- a/scripts/differential/fixtures/v3014-behavior-oracle.json
+++ b/scripts/differential/fixtures/v3014-behavior-oracle.json
@@ -1,0 +1,101 @@
+{
+  "schemaVersion": 1,
+  "profile": "pdf_reader_v3014_behavior_oracle",
+  "baseline": {
+    "tag": "v3.0.14",
+    "commit": "92651c79c6ce8d10dfa3c76332176c26f222bd78",
+    "tree": "f6fc4e58f692736c8bd6aaf9d4c9cfa806d113ab",
+    "bunLockSha256": "07f469c8200fb82c9092cef178c1bdd67f8cf61fe6c027303665395eede9dd45",
+    "entrypointSha256": {
+      "src/pdf/readCoordinator.ts": "827cb1018a8621287de154132c0a00a00188497b84622a168a343d0df3ce5eca",
+      "src/pdf/search.ts": "ef0a1916d1399e1e807294a8170577bd59a285c73180389f82f05ec5e38d1521",
+      "src/pdf/autoReadPolicy.ts": "168b5b00ae00229a7cf2c0e84b68e1bb41e288eefe957bd46e3f84db2af9537a",
+      "src/pdf/pdfSession.ts": "15c147e45deac7b1b219aeb904e0a653f22d055d3446822fb88cca3fbc7c3459"
+    }
+  },
+  "normalization": {
+    "version": 1,
+    "text": "Unicode NFC and CRLF-to-LF only",
+    "errors": "stable category plus bounded source-independent meaning",
+    "excluded": ["absolute source path", "timestamps", "bbox", "provenance", "snippet"]
+  },
+  "expectations": {
+    "read-all-metadata": {
+      "outcome": "success",
+      "num_pages": 3,
+      "info": {
+        "PDFFormatVersion": "1.4",
+        "Title": "Parity Corpus V1",
+        "Author": "Sylphx Oracle",
+        "Subject": "TS 3.0.14 behavioral contract",
+        "Keywords": "parity multipage search",
+        "Creator": "fixture-generator-v1",
+        "Producer": "fixture-generator-v1"
+      },
+      "full_text": "PAGE_ONE_ALPHANeedle at start. cat catalog CAT.\n\nPAGE_TWO_BETAprefix Needle suffixCafé résumé\n\nPAGE_THREE_GAMMAneedle tail NEEDLE",
+      "warnings": []
+    },
+    "read-pages-array-dedupe-sort": {
+      "outcome": "success",
+      "num_pages": 3,
+      "page_texts": [
+        { "page": 1, "text": "PAGE_ONE_ALPHANeedle at start. cat catalog CAT." },
+        { "page": 3, "text": "PAGE_THREE_GAMMAneedle tail NEEDLE" }
+      ],
+      "warnings": []
+    },
+    "read-pages-range-out-of-range": {
+      "outcome": "success",
+      "num_pages": 3,
+      "page_texts": [
+        { "page": 2, "text": "PAGE_TWO_BETAprefix Needle suffixCafé résumé" }
+      ],
+      "warnings": [{ "category": "page_out_of_range", "requested": [9], "total": 3 }]
+    },
+    "search-ci-all": {
+      "outcome": "success",
+      "num_pages": 3,
+      "searched_pages": [1, 2, 3],
+      "matches": [
+        { "page": 1, "text": "Needle", "match_start": 0, "match_end": 6, "text_item_index": 1 },
+        { "page": 2, "text": "Needle", "match_start": 7, "match_end": 13, "text_item_index": 1 },
+        { "page": 3, "text": "needle", "match_start": 0, "match_end": 6, "text_item_index": 1 },
+        { "page": 3, "text": "NEEDLE", "match_start": 12, "match_end": 18, "text_item_index": 1 }
+      ]
+    },
+    "search-cs-upper": {
+      "outcome": "success",
+      "num_pages": 3,
+      "searched_pages": [1, 2, 3],
+      "matches": [
+        { "page": 3, "text": "NEEDLE", "match_start": 12, "match_end": 18, "text_item_index": 1 }
+      ]
+    },
+    "search-whole-word": {
+      "outcome": "success",
+      "num_pages": 3,
+      "searched_pages": [1, 2, 3],
+      "matches": [
+        { "page": 1, "text": "cat", "match_start": 17, "match_end": 20, "text_item_index": 1 },
+        { "page": 1, "text": "CAT", "match_start": 29, "match_end": 32, "text_item_index": 1 }
+      ]
+    },
+    "search-selected-unicode": {
+      "outcome": "success",
+      "num_pages": 3,
+      "searched_pages": [2],
+      "matches": [
+        { "page": 2, "text": "Café", "match_start": 0, "match_end": 4, "text_item_index": 2 }
+      ]
+    },
+    "read-missing-file": { "outcome": "error", "category": "file_not_found" },
+    "read-malformed": { "outcome": "error", "category": "invalid_pdf" },
+    "read-mixed-source-partial": {
+      "outcome": "success",
+      "results": [
+        { "success": true, "num_pages": 3 },
+        { "success": false, "category": "file_not_found" }
+      ]
+    }
+  }
+}

--- a/scripts/differential/generate-v3014-behavior-fixtures.ts
+++ b/scripts/differential/generate-v3014-behavior-fixtures.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env bun
+
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDir, '../..');
+const fixtureDir = join(repoRoot, 'test/fixtures/differential');
+const manifestPath = join(scriptDir, 'fixtures/v3014-behavior-fixtures.json');
+const pdfPath = join(fixtureDir, 'v3014-behavior-v1.pdf');
+const malformedPath = join(fixtureDir, 'v3014-malformed-v1.pdf');
+const write = process.argv.includes('--write');
+
+const sha256 = (bytes: Uint8Array): string =>
+  createHash('sha256').update(bytes).digest('hex');
+
+function buildPdf(): Buffer {
+  const pageStreams = [
+    ['PAGE_ONE_ALPHA', 'Needle at start. cat catalog CAT.'],
+    ['PAGE_TWO_BETA', 'prefix Needle suffix', 'Caf\\351 r\\351sum\\351'],
+    ['PAGE_THREE_GAMMA', 'needle tail NEEDLE'],
+  ].map(
+    (lines) =>
+      `BT\n/F1 12 Tf\n72 720 Td\n${lines
+        .map((line, index) => `${index === 0 ? '' : '0 -18 Td\n'}(${line}) Tj`)
+        .join('\n')}\nET\n`
+  );
+
+  const objects = new Map<number, string>([
+    [1, '<< /Type /Catalog /Pages 2 0 R >>'],
+    [2, '<< /Type /Pages /Kids [3 0 R 5 0 R 7 0 R] /Count 3 >>'],
+    [
+      3,
+      '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 9 0 R >> >> /Contents 4 0 R >>',
+    ],
+    [4, `<< /Length ${Buffer.byteLength(pageStreams[0]!, 'latin1')} >>\nstream\n${pageStreams[0]}endstream`],
+    [
+      5,
+      '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 9 0 R >> >> /Contents 6 0 R >>',
+    ],
+    [6, `<< /Length ${Buffer.byteLength(pageStreams[1]!, 'latin1')} >>\nstream\n${pageStreams[1]}endstream`],
+    [
+      7,
+      '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 9 0 R >> >> /Contents 8 0 R >>',
+    ],
+    [8, `<< /Length ${Buffer.byteLength(pageStreams[2]!, 'latin1')} >>\nstream\n${pageStreams[2]}endstream`],
+    [9, '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>'],
+    [
+      10,
+      '<< /Title (Parity Corpus V1) /Author (Sylphx Oracle) /Subject (TS 3.0.14 behavioral contract) /Keywords (parity multipage search) /Creator (fixture-generator-v1) /Producer (fixture-generator-v1) >>',
+    ],
+  ]);
+
+  const chunks: Buffer[] = [Buffer.from('%PDF-1.4\n%\xe2\xe3\xcf\xd3\n', 'latin1')];
+  const offsets = [0];
+  let length = chunks[0]!.length;
+  for (let id = 1; id <= objects.size; id += 1) {
+    offsets[id] = length;
+    const chunk = Buffer.from(`${id} 0 obj\n${objects.get(id)}\nendobj\n`, 'latin1');
+    chunks.push(chunk);
+    length += chunk.length;
+  }
+  const xrefOffset = length;
+  const xref = [
+    `xref\n0 ${objects.size + 1}\n`,
+    '0000000000 65535 f \n',
+    ...offsets.slice(1).map((offset) => `${String(offset).padStart(10, '0')} 00000 n \n`),
+    `trailer\n<< /Size ${objects.size + 1} /Root 1 0 R /Info 10 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`,
+  ].join('');
+  chunks.push(Buffer.from(xref, 'ascii'));
+  return Buffer.concat(chunks);
+}
+
+const files = [
+  { path: pdfPath, bytes: buildPdf() },
+  { path: malformedPath, bytes: Buffer.from('%PDF-1.4\n%not-a-valid-pdf-structure\n') },
+];
+const manifest = {
+  schemaVersion: 1,
+  generator: relative(repoRoot, fileURLToPath(import.meta.url)),
+  fixtures: files.map(({ path, bytes }) => ({
+    path: relative(repoRoot, path),
+    bytes: bytes.length,
+    sha256: sha256(bytes),
+  })),
+};
+const manifestBytes = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
+
+if (write) {
+  mkdirSync(fixtureDir, { recursive: true });
+  mkdirSync(dirname(manifestPath), { recursive: true });
+  for (const file of files) writeFileSync(file.path, file.bytes);
+  writeFileSync(manifestPath, manifestBytes);
+  console.error(`wrote ${files.length} fixtures and ${relative(repoRoot, manifestPath)}`);
+  process.exit(0);
+}
+
+const mismatches: string[] = [];
+for (const file of files) {
+  if (!existsSync(file.path) || !readFileSync(file.path).equals(file.bytes)) {
+    mismatches.push(relative(repoRoot, file.path));
+  }
+}
+if (!existsSync(manifestPath) || !readFileSync(manifestPath).equals(manifestBytes)) {
+  mismatches.push(relative(repoRoot, manifestPath));
+}
+if (mismatches.length > 0) {
+  throw new Error(`behavior fixtures are stale or missing: ${mismatches.join(', ')}; run with --write`);
+}
+console.log(`v3.0.14 behavior fixtures: OK (${files.length})`);

--- a/scripts/differential/v3014-baseline-runner.ts
+++ b/scripts/differential/v3014-baseline-runner.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env bun
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { buildReadOptions } from './src/pdf/autoReadPolicy.ts';
+import { PdfSessionScope } from './src/pdf/pdfSession.ts';
+import { processSingleSource } from './src/pdf/readCoordinator.ts';
+import { defaultSearchPdfOptions, searchPdfSource } from './src/pdf/search.ts';
+
+const [corpusPath, fixtureDir] = process.argv.slice(2);
+if (!corpusPath || !fixtureDir) throw new Error('usage: runner <corpus.json> <fixture-dir>');
+const corpus = JSON.parse(readFileSync(corpusPath, 'utf8')) as {
+  cases: Array<{ id: string; tool: string; input: Record<string, unknown> }>;
+};
+const normalizeText = (value: string): string =>
+  value.replaceAll('\r\n', '\n').normalize('NFC');
+
+function materialize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(materialize);
+  if (value && typeof value === 'object') {
+    const output: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      output[key === 'fixture' ? 'path' : key] =
+        key === 'fixture' && typeof entry === 'string' ? join(fixtureDir, entry) : materialize(entry);
+    }
+    return output;
+  }
+  return value;
+}
+
+function category(message: string): string {
+  const lower = message.toLowerCase();
+  if (lower.includes('file not found') || lower.includes('no such file')) return 'file_not_found';
+  if (lower.includes('failed to load pdf') || lower.includes('invalid pdf')) return 'invalid_pdf';
+  return 'unknown_error';
+}
+
+function canonicalWarnings(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) return [];
+  return value.map((warning) => {
+    const text = String(warning);
+    const match = text.match(/page numbers?\s+([0-9, ]+).*?total pages\s*\(([0-9]+)\)/i);
+    return match
+      ? {
+          category: 'page_out_of_range',
+          requested: match[1]!.split(',').map((part) => Number(part.trim())),
+          total: Number(match[2]),
+        }
+      : { category: 'unknown_warning' };
+  });
+}
+
+async function readCase(id: string, input: Record<string, unknown>) {
+  const sources = input.sources as Array<Record<string, unknown>>;
+  const options = buildReadOptions(input as never);
+  const results = [];
+  const session = new PdfSessionScope();
+  for (const source of sources) results.push(await processSingleSource(source, options, session));
+  if (id === 'read-mixed-source-partial') {
+    return {
+      outcome: 'success',
+      results: results.map((result) =>
+        result.success
+          ? { success: true, num_pages: result.data?.num_pages }
+          : { success: false, category: category(result.error ?? '') }
+      ),
+    };
+  }
+  const first = results[0]!;
+  if (!first.success) return { outcome: 'error', category: category(first.error ?? '') };
+  const output: Record<string, unknown> = {
+    outcome: 'success',
+    num_pages: first.data?.num_pages,
+  };
+  if (id === 'read-all-metadata') {
+    output.info = Object.fromEntries(
+      ['PDFFormatVersion', 'Title', 'Author', 'Subject', 'Keywords', 'Creator', 'Producer'].map(
+        (key) => [key, first.data?.info?.[key] ?? null]
+      )
+    );
+    output.full_text = normalizeText(first.data?.full_text ?? '');
+  }
+  if (id.startsWith('read-pages-')) {
+    output.page_texts = (first.data?.page_texts ?? []).map((page) => ({
+      page: page.page,
+      text: normalizeText(page.text),
+    }));
+  }
+  output.warnings = canonicalWarnings(first.data?.warnings);
+  return output;
+}
+
+async function searchCase(input: Record<string, unknown>) {
+  const source = (input.sources as Array<Record<string, unknown>>)[0]!;
+  const query = String(input.query);
+  const result = await searchPdfSource(source, {
+    ...defaultSearchPdfOptions(query),
+    case_sensitive: Boolean(input.case_sensitive),
+    whole_word: Boolean(input.whole_word),
+    context_chars: Number(input.context_chars ?? 0),
+    max_pages: Number(input.max_pages ?? 10),
+    max_matches_per_source: Number(input.max_matches_per_source ?? 50),
+    prefer_speed: false,
+  });
+  if (!result.success) return { outcome: 'error', category: category(result.error ?? '') };
+  return {
+    outcome: 'success',
+    num_pages: result.num_pages,
+    searched_pages: result.searched_pages,
+    matches: (result.matches ?? []).map((match) => ({
+      page: match.page,
+      text: normalizeText(match.text),
+      match_start: match.match_start,
+      match_end: match.match_end,
+      text_item_index: match.text_item_index,
+    })),
+  };
+}
+
+const expectations: Record<string, unknown> = {};
+for (const entry of corpus.cases) {
+  const input = materialize(entry.input) as Record<string, unknown>;
+  expectations[entry.id] =
+    entry.tool === 'read_pdf' ? await readCase(entry.id, input) : await searchCase(input);
+}
+console.log(JSON.stringify(expectations));

--- a/scripts/run-pdf-reader-differential.sh
+++ b/scripts/run-pdf-reader-differential.sh
@@ -12,6 +12,7 @@ LOG="$SCRATCH/differential.log"
 ARTIFACT="$SCRATCH/verification.json"
 ORACLE_JSON="$SCRATCH/oracle.json"
 TEXT_DIFFERENTIAL_JSON="$SCRATCH/ts-vs-rust-text.json"
+V3014_BEHAVIOR_JSON="$SCRATCH/v3014-behavior-result.json"
 SLICE_FILTER="all"
 : >"$LOG"
 
@@ -63,6 +64,14 @@ fi
 echo "--- immutable TypeScript v3.0.14 input contract oracle ---" | tee -a "$LOG"
 bun "$REPO_ROOT/scripts/check-v3014-input-schema-oracle.ts" 2>&1 | tee -a "$LOG"
 
+echo "--- deterministic v3.0.14 behavior fixtures + baseline replay ---" | tee -a "$LOG"
+bun "$REPO_ROOT/scripts/differential/generate-v3014-behavior-fixtures.ts" 2>&1 | tee -a "$LOG"
+bun "$REPO_ROOT/scripts/differential/capture-v3014-behavior-oracle.ts" 2>&1 | tee -a "$LOG"
+
+echo "--- immutable v3.0.14 behavior differential (10 exact cases) ---" | tee -a "$LOG"
+bun "$REPO_ROOT/scripts/differential/check-v3014-behavior-differential.ts" \
+  --output "$V3014_BEHAVIOR_JSON" >>"$LOG"
+
 echo "--- live TypeScript handler -> Rust text claimed-subset check ---" | tee -a "$LOG"
 env -u PDF_READER_USE_RUST_TEXT_SEARCH -u PDF_READER_ENGINE_MODE \
   bun "$REPO_ROOT/scripts/differential/ts-vs-rust-text-oracle.ts" \
@@ -79,13 +88,24 @@ PDF_READER_MCP_SLICE_FILTER="$SLICE_FILTER" \
 CANDIDATE_SHA="${CANDIDATE_SHA:-$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)}"
 BASELINE_TS_SHA="$(git -C "$REPO_ROOT" rev-list -n 1 v3.0.14 2>/dev/null || echo unknown)"
 RUST_SHA="$CANDIDATE_SHA"
-BEHAVIOR_SPEC_HASH="$(sha256sum "$REPO_ROOT/scripts/differential/fixtures/pdf-reader-mcp-corpus.json" "$REPO_ROOT/test/fixtures/read-pdf-golden.json" 2>/dev/null | awk '{print $1}' | sha256sum | awk '{print $1}' || echo missing)"
+BEHAVIOR_SPEC_HASH="$(sha256sum \
+  "$REPO_ROOT/scripts/differential/fixtures/pdf-reader-mcp-corpus.json" \
+  "$REPO_ROOT/test/fixtures/read-pdf-golden.json" \
+  "$REPO_ROOT/scripts/differential/fixtures/v3014-behavior-corpus.json" \
+  "$REPO_ROOT/scripts/differential/fixtures/v3014-behavior-oracle.json" \
+  "$REPO_ROOT/scripts/differential/fixtures/v3014-behavior-fixtures.json" \
+  2>/dev/null | awk '{print $1}' | sha256sum | awk '{print $1}' || echo missing)"
 FIXTURE_CORPUS_HASH="$(jq -r '.fixtureCorpusHash' "$ORACLE_JSON")"
 GOLDEN_FIXTURE_HASH="$(jq -r '.goldenFixtureHash' "$ORACLE_JSON")"
 CASE_COUNT="$(jq '.cases | length' "$ORACLE_JSON")"
 READ_PDF_CASE_COUNT="$(jq '[.cases[] | select(.domain == "readPdfTool")] | length' "$ORACLE_JSON")"
 STDIO_PROBE_CASE_COUNT="$(jq '[.cases[] | select(.domain == "stdioProbe")] | length' "$ORACLE_JSON")"
 TOOL_ROUTE_CASE_COUNT="$(jq '[.cases[] | select(.domain == "toolRouteContract")] | length' "$ORACLE_JSON")"
+V3014_BEHAVIOR_CASE_COUNT="$(jq '.caseCount' "$V3014_BEHAVIOR_JSON")"
+V3014_BEHAVIOR_PASSED="$(jq '.passed' "$V3014_BEHAVIOR_JSON")"
+V3014_BEHAVIOR_SKIPPED="$(jq '.skipped' "$V3014_BEHAVIOR_JSON")"
+V3014_BEHAVIOR_CORPUS_HASH="$(jq -r '.corpusSha256' "$V3014_BEHAVIOR_JSON")"
+V3014_BEHAVIOR_ORACLE_HASH="$(jq -r '.oracleSha256' "$V3014_BEHAVIOR_JSON")"
 
 case "$SLICE_FILTER" in
   tool.read_pdf) ARTIFACT_SLICE="tool.read_pdf" ;;
@@ -102,12 +122,17 @@ jq -n \
   --arg behaviorSpecHash "$BEHAVIOR_SPEC_HASH" \
   --arg fixtureCorpusHash "$FIXTURE_CORPUS_HASH" \
   --arg goldenFixtureHash "$GOLDEN_FIXTURE_HASH" \
+  --arg v3014BehaviorCorpusHash "$V3014_BEHAVIOR_CORPUS_HASH" \
+  --arg v3014BehaviorOracleHash "$V3014_BEHAVIOR_ORACLE_HASH" \
   --arg sliceFilter "$SLICE_FILTER" \
   --arg slice "$ARTIFACT_SLICE" \
   --argjson caseCount "$CASE_COUNT" \
   --argjson readPdfCaseCount "$READ_PDF_CASE_COUNT" \
   --argjson stdioProbeCaseCount "$STDIO_PROBE_CASE_COUNT" \
   --argjson toolRouteCaseCount "$TOOL_ROUTE_CASE_COUNT" \
+  --argjson v3014BehaviorCaseCount "$V3014_BEHAVIOR_CASE_COUNT" \
+  --argjson v3014BehaviorPassed "$V3014_BEHAVIOR_PASSED" \
+  --argjson v3014BehaviorSkipped "$V3014_BEHAVIOR_SKIPPED" \
   '{
     schemaVersion: 2,
     slice: $slice,
@@ -121,13 +146,20 @@ jq -n \
     behaviorSpecHash: $behaviorSpecHash,
     fixtureCorpusHash: $fixtureCorpusHash,
     goldenFixtureHash: $goldenFixtureHash,
+    v3014BehaviorCorpusHash: $v3014BehaviorCorpusHash,
+    v3014BehaviorOracleHash: $v3014BehaviorOracleHash,
     caseCount: $caseCount,
     readPdfCaseCount: $readPdfCaseCount,
     stdioProbeCaseCount: $stdioProbeCaseCount,
     toolRouteCaseCount: $toolRouteCaseCount,
+    v3014BehaviorCaseCount: $v3014BehaviorCaseCount,
+    v3014BehaviorPassed: $v3014BehaviorPassed,
+    v3014BehaviorSkipped: $v3014BehaviorSkipped,
     harness: "scripts/run-pdf-reader-differential.sh",
     differentialTest: "crates/pdf-reader-mcp-server/tests/pdf_reader_mcp_differential.rs#pdf_reader_mcp_differential_matches_ts_oracle",
     immutableInputOracle: "scripts/check-v3014-input-schema-oracle.ts",
+    immutableBehaviorOracle: "scripts/differential/fixtures/v3014-behavior-oracle.json",
+    immutableBehaviorDifferential: "scripts/differential/check-v3014-behavior-differential.ts",
     liveTextOracle: "scripts/differential/ts-vs-rust-text-oracle.ts",
     structuralConsistencyOracle: "scripts/differential/pdf-reader-mcp-oracle.ts",
     nonClaims: ["full TS 3.0.14 behavioral parity", "visual parity", "Document Twin semantic parity"],

--- a/scripts/sota-release-gate.ts
+++ b/scripts/sota-release-gate.ts
@@ -292,13 +292,14 @@ export const buildSotaReleaseGateReport = async (
   );
   addCheck(
     checks,
-    'mcp:pure_rust_default',
+    'mcp:rust_opt_in_boundary',
     binWrapper.includes('resolve_rust_bin') &&
       binWrapper.includes('pdf-reader-mcp-server') &&
-      !binWrapper.includes('PDF_READER_ENGINE_MODE=full') &&
+      binWrapper.includes('PDF_READER_ENGINE_MODE') &&
+      binWrapper.includes('exec node "$ROOT/dist/index.js"') &&
       !binWrapper.includes('legacy-engine-runtime') &&
       !fs.existsSync(path.join(repoRoot, 'crates/pdf-reader-mcp-server/src/parity_bridge.rs')),
-    'Default production path is pure-Rust rmcp (no TS parity bridge)'
+    'Published npm default remains TypeScript while the incomplete pure-Rust rmcp path is explicit opt-in'
   );
   addCheck(
     checks,
@@ -322,7 +323,7 @@ export const buildSotaReleaseGateReport = async (
     httpTransportSource.includes('StreamableHttpService') &&
       httpTransportSource.includes('/mcp/health') &&
       binWrapper.includes('resolve_rust_bin') &&
-      binWrapper.includes('PDF_READER_MCP_ENGINE'),
+      binWrapper.includes('PDF_READER_MCP_TRANSPORT'),
     'Rust rmcp streamable HTTP remains available as opt-in engine (not production default)'
   );
 

--- a/test/differentialHarness.matrix.test.ts
+++ b/test/differentialHarness.matrix.test.ts
@@ -14,6 +14,12 @@ describe('pdf-reader-mcp differential harness (rej-010)', () => {
       existsSync(path.join(repoRoot, 'scripts/differential/fixtures/pdf-reader-mcp-corpus.json'))
     ).toBe(true);
     expect(
+      existsSync(path.join(repoRoot, 'scripts/differential/fixtures/v3014-behavior-oracle.json'))
+    ).toBe(true);
+    expect(
+      existsSync(path.join(repoRoot, 'scripts/differential/check-v3014-behavior-differential.ts'))
+    ).toBe(true);
+    expect(
       existsSync(
         path.join(repoRoot, 'crates/pdf-reader-mcp-server/tests/pdf_reader_mcp_differential.rs')
       )
@@ -26,7 +32,8 @@ describe('pdf-reader-mcp differential harness (rej-010)', () => {
     expect(harness).toContain('pdf-reader-mcp-differential');
     expect(harness).toContain('pdf-reader-mcp-oracle.ts');
     expect(harness).toContain('pdf_reader_mcp_differential_matches_ts_oracle');
-    expect(harness).toContain('differential_green');
+    expect(harness).toContain('claimed_subset_green');
+    expect(harness).toContain('v3014-behavior-result.json');
     expect(harness).toContain('check-no-ts-stdio-backend.sh');
     expect(harness).toContain('--slice');
     expect(harness).toContain('tool.search_pdf|tool.pdf_evidence');

--- a/test/fixtures/differential/v3014-behavior-v1.pdf
+++ b/test/fixtures/differential/v3014-behavior-v1.pdf
@@ -1,0 +1,79 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R 5 0 R 7 0 R] /Count 3 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 9 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 94 >>
+stream
+BT
+/F1 12 Tf
+72 720 Td
+(PAGE_ONE_ALPHA) Tj
+0 -18 Td
+(Needle at start. cat catalog CAT.) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 9 0 R >> >> /Contents 6 0 R >>
+endobj
+6 0 obj
+<< /Length 115 >>
+stream
+BT
+/F1 12 Tf
+72 720 Td
+(PAGE_TWO_BETA) Tj
+0 -18 Td
+(prefix Needle suffix) Tj
+0 -18 Td
+(Caf\351 r\351sum\351) Tj
+ET
+endstream
+endobj
+7 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 9 0 R >> >> /Contents 8 0 R >>
+endobj
+8 0 obj
+<< /Length 81 >>
+stream
+BT
+/F1 12 Tf
+72 720 Td
+(PAGE_THREE_GAMMA) Tj
+0 -18 Td
+(needle tail NEEDLE) Tj
+ET
+endstream
+endobj
+9 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+10 0 obj
+<< /Title (Parity Corpus V1) /Author (Sylphx Oracle) /Subject (TS 3.0.14 behavioral contract) /Keywords (parity multipage search) /Creator (fixture-generator-v1) /Producer (fixture-generator-v1) >>
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000133 00000 n 
+0000000259 00000 n 
+0000000402 00000 n 
+0000000528 00000 n 
+0000000693 00000 n 
+0000000819 00000 n 
+0000000949 00000 n 
+0000001046 00000 n 
+trailer
+<< /Size 11 /Root 1 0 R /Info 10 0 R >>
+startxref
+1260
+%%EOF

--- a/test/fixtures/differential/v3014-malformed-v1.pdf
+++ b/test/fixtures/differential/v3014-malformed-v1.pdf
@@ -1,0 +1,2 @@
+%PDF-1.4
+%not-a-valid-pdf-structure

--- a/test/fixtures/read-pdf-golden.json
+++ b/test/fixtures/read-pdf-golden.json
@@ -25,9 +25,9 @@
                   "version": "3.1.1"
                 },
                 "info": {
-                  "Title": "sample.pdf",
-                  "Producer": "pdf-reader-core",
-                  "PDFFormatVersion": "unknown",
+                  "Title": "sample",
+                  "Producer": "Mac OS X 10.5.4 Quartz PDFContext",
+                  "PDFFormatVersion": "1.3",
                   "route": "rust-read-pdf-v1"
                 }
               }

--- a/test/integration/http-transport.test.ts
+++ b/test/integration/http-transport.test.ts
@@ -175,9 +175,10 @@ describe('MCP Server HTTP Transport Integration (Rust rmcp)', () => {
     expect(
       (response.result as { serverInfo?: { name?: string; version?: string } })?.serverInfo?.name
     ).toBe('pdf-reader-mcp');
-    expect(
-      (response.result as { serverInfo?: { name?: string; version?: string } })?.serverInfo?.version
-    ).toBe(packageJson.version);
+    const serverVersion = (response.result as { serverInfo?: { version?: string } })?.serverInfo
+      ?.version;
+    expect(serverVersion).toBe('0.0.0-pure-rust-experimental');
+    expect(serverVersion).not.toBe(packageJson.version);
   });
 
   it('should list available tools over HTTP', async () => {

--- a/test/integration/mcp-server.test.ts
+++ b/test/integration/mcp-server.test.ts
@@ -200,7 +200,7 @@ describe('MCP Server Integration', () => {
     }
   });
 
-  mcpIt('should call pdf_evidence render_page operation with a test PDF', async () => {
+  mcpIt('should fail closed for unavailable pdf_evidence render_page', async () => {
     const testPdfPath = path.resolve(__dirname, '../fixtures/sample.pdf');
 
     const callRequest = createRequest(5, 'tools/call', {
@@ -225,29 +225,13 @@ describe('MCP Server Integration', () => {
 
     expect(response.id).toBe(5);
 
-    if (response.error || response.result?.isError) {
-      expect(response.error?.message || response.result?.content?.[0]?.text).toContain('PDF');
-    } else {
-      const textContent = response.result?.content?.[0]?.text ?? '';
-      const parsed = JSON.parse(textContent) as {
-        profile: string;
-        results: Array<{
-          success: boolean;
-          rendered_pages?: Array<{ data?: string; image_content_index?: number }>;
-        }>;
-      };
-
-      expect(response.result?.content?.[0]?.type).toBe('text');
-      expect(response.result?.content?.[1]?.type).toBe('image');
-      expect(response.result?.content?.[1]?.mimeType).toBe('image/png');
-      expect(parsed.profile).toBe('page_render_evidence');
-      expect(parsed.results[0]?.success).toBe(true);
-      expect(parsed.results[0]?.rendered_pages?.[0]?.data).toBeUndefined();
-      expect(parsed.results[0]?.rendered_pages?.[0]?.image_content_index).toBe(1);
-    }
+    expect(response.error || response.result?.isError).toBeTruthy();
+    expect(response.error?.message || response.result?.content?.[0]?.text).toContain(
+      "pdf_evidence operation 'render_page' is not available in the pure-Rust engine yet"
+    );
   });
 
-  mcpIt('should call pdf_evidence extract_regions operation with a test PDF', async () => {
+  mcpIt('should fail closed for unavailable pdf_evidence extract_regions', async () => {
     const testPdfPath = path.resolve(__dirname, '../fixtures/sample.pdf');
 
     const callRequest = createRequest(6, 'tools/call', {
@@ -283,90 +267,53 @@ describe('MCP Server Integration', () => {
 
     expect(response.id).toBe(6);
 
-    if (response.error || response.result?.isError) {
-      expect(response.error?.message || response.result?.content?.[0]?.text).toContain('PDF');
-    } else {
-      const textContent = response.result?.content?.[0]?.text ?? '';
-      const parsed = JSON.parse(textContent) as {
-        profile: string;
-        results: Array<{
-          success: boolean;
-          regions?: Array<{ data?: string; image_content_index?: number; region_id?: string }>;
-        }>;
-      };
-
-      expect(response.result?.content?.[0]?.type).toBe('text');
-      expect(response.result?.content?.[1]?.type).toBe('image');
-      expect(response.result?.content?.[1]?.mimeType).toBe('image/png');
-      expect(parsed.profile).toBe('region_crop_evidence');
-      expect(parsed.results[0]?.success).toBe(true);
-      expect(parsed.results[0]?.regions?.[0]?.region_id).toBe('bottom-left');
-      expect(parsed.results[0]?.regions?.[0]?.data).toBeUndefined();
-      expect(parsed.results[0]?.regions?.[0]?.image_content_index).toBe(1);
-    }
+    expect(response.error || response.result?.isError).toBeTruthy();
+    expect(response.error?.message || response.result?.content?.[0]?.text).toContain(
+      "pdf_evidence operation 'extract_regions' is not available in the pure-Rust engine yet"
+    );
   });
 
-  mcpIt(
-    'should call pdf_evidence analyze_regions operation with a configured provider',
-    async () => {
-      const testPdfPath = path.resolve(__dirname, '../fixtures/sample.pdf');
+  mcpIt('should fail closed for unavailable pdf_evidence analyze_regions', async () => {
+    const testPdfPath = path.resolve(__dirname, '../fixtures/sample.pdf');
 
-      const callRequest = createRequest(7, 'tools/call', {
-        name: 'pdf_evidence',
-        arguments: {
-          operation: 'analyze_regions',
-          sources: [
-            {
-              path: testPdfPath,
-              regions: [
-                {
-                  id: 'table-1',
-                  page: 1,
-                  bounding_box: { left: 0, bottom: 0, right: 100, top: 100 },
-                },
-              ],
-            },
-          ],
-          scale: 1,
-          max_regions: 1,
-          languages: ['eng'],
-        },
-      });
+    const callRequest = createRequest(7, 'tools/call', {
+      name: 'pdf_evidence',
+      arguments: {
+        operation: 'analyze_regions',
+        sources: [
+          {
+            path: testPdfPath,
+            regions: [
+              {
+                id: 'table-1',
+                page: 1,
+                bounding_box: { left: 0, bottom: 0, right: 100, top: 100 },
+              },
+            ],
+          },
+        ],
+        scale: 1,
+        max_regions: 1,
+        languages: ['eng'],
+      },
+    });
 
-      sendMessage(serverProc, callRequest);
-      const response = (await readResponse(serverProc, 10000)) as {
-        id: number;
-        result?: { content?: Array<{ type: string; text?: string }>; isError?: boolean };
-        error?: { message: string };
-      };
+    sendMessage(serverProc, callRequest);
+    const response = (await readResponse(serverProc, 10000)) as {
+      id: number;
+      result?: { content?: Array<{ type: string; text?: string }>; isError?: boolean };
+      error?: { message: string };
+    };
 
-      expect(response.id).toBe(7);
+    expect(response.id).toBe(7);
 
-      if (response.error || response.result?.isError) {
-        expect(response.error?.message || response.result?.content?.[0]?.text).toContain('PDF');
-      } else {
-        const textContent = response.result?.content?.[0]?.text ?? '';
-        const parsed = JSON.parse(textContent) as {
-          profile: string;
-          results: Array<{
-            success: boolean;
-            region_analyses?: Array<{ description?: string; kind?: string; provider?: string }>;
-          }>;
-        };
+    expect(response.error || response.result?.isError).toBeTruthy();
+    expect(response.error?.message || response.result?.content?.[0]?.text).toContain(
+      "pdf_evidence operation 'analyze_regions' is not available in the pure-Rust engine yet"
+    );
+  });
 
-        expect(response.result?.content?.[0]?.type).toBe('text');
-        expect(parsed.profile).toBe('region_analysis');
-        expect(parsed.results[0]?.success).toBe(true);
-        expect(parsed.results[0]?.region_analyses?.[0]?.description).toContain(
-          'Mock region analysis'
-        );
-        expect(parsed.results[0]?.region_analyses?.[0]?.kind).toBe('table');
-        expect(parsed.results[0]?.region_analyses?.[0]?.provider).toBe('command');
-      }
-    }
-  );
-
-  mcpIt('should call pdf_evidence ocr_pages operation with a configured OCR provider', async () => {
+  mcpIt('should fail closed for unavailable pdf_evidence ocr_pages', async () => {
     const testPdfPath = path.resolve(__dirname, '../fixtures/sample.pdf');
 
     const callRequest = createRequest(8, 'tools/call', {
@@ -389,25 +336,10 @@ describe('MCP Server Integration', () => {
 
     expect(response.id).toBe(8);
 
-    if (response.error || response.result?.isError) {
-      expect(response.error?.message || response.result?.content?.[0]?.text).toContain('PDF');
-    } else {
-      const textContent = response.result?.content?.[0]?.text ?? '';
-      const parsed = JSON.parse(textContent) as {
-        profile: string;
-        results: Array<{
-          success: boolean;
-          ocr_pages?: Array<{ text?: string; provider?: string; data?: string }>;
-        }>;
-      };
-
-      expect(response.result?.content?.[0]?.type).toBe('text');
-      expect(parsed.profile).toBe('ocr_text_layer');
-      expect(parsed.results[0]?.success).toBe(true);
-      expect(parsed.results[0]?.ocr_pages?.[0]?.text).toBe('Mock OCR text for page 1');
-      expect(parsed.results[0]?.ocr_pages?.[0]?.provider).toBe('command');
-      expect(parsed.results[0]?.ocr_pages?.[0]?.data).toBeUndefined();
-    }
+    expect(response.error || response.result?.isError).toBeTruthy();
+    expect(response.error?.message || response.result?.content?.[0]?.text).toContain(
+      "pdf_evidence operation 'ocr_pages' is not available in the pure-Rust engine yet"
+    );
   });
 
   mcpIt('should call search_pdf tool with a test PDF', async () => {

--- a/test/integration/stdio-transport.test.ts
+++ b/test/integration/stdio-transport.test.ts
@@ -212,7 +212,8 @@ describe('MCP Server stdio Transport Integration (Rust rmcp)', () => {
 
     expect(response.id).toBe(101);
     expect(response.result?.serverInfo?.name).toBe('pdf-reader-mcp');
-    expect(response.result?.serverInfo?.version).toBe(packageJson.version);
+    expect(response.result?.serverInfo?.version).toBe('0.0.0-pure-rust-experimental');
+    expect(response.result?.serverInfo?.version).not.toBe(packageJson.version);
     freshProc.kill('SIGTERM');
   });
 

--- a/test/releaseGate.test.ts
+++ b/test/releaseGate.test.ts
@@ -9,9 +9,7 @@ describe('pdf reader SOTA release gate golden probes', () => {
     );
 
     expect(report.profile).toBe('pdf_sota_release_gate');
-    expect(report.checks.some((check) => check.id === 'mcp:rust_process_full_parity_default')).toBe(
-      true
-    );
+    expect(report.checks.some((check) => check.id === 'mcp:rust_opt_in_boundary')).toBe(true);
     expect(report.checks.some((check) => check.id === 'mcp:production_contract_suite')).toBe(true);
     expect(report.checks.some((check) => check.id === 'mcp:rust_web_http_transport')).toBe(true);
     expect(report.checks.some((check) => check.id === 'mcp:http_transport_parity')).toBe(true);


### PR DESCRIPTION
## Outcome

This advances the experimental Rust engine by one independently reviewed claimed subset. It does not declare drop-in parity and does not lift the publish freeze.

## What changed

- pins validated DNS answers to the actual connection for every URL/redirect hop
- rejects mixed public/non-public DNS answers and disables ambient proxies
- adds a detached, immutable TS v3.0.14 behavior oracle with 10 exact cases
- aligns Rust text items, JavaScript UTF-16 search offsets, metadata, page selection, and error behavior for that corpus
- binds the behavior artifact to the exact candidate SHA in CI
- repairs release tests to assert the honest TS-default/Rust-opt-in boundary

## Proof

- independent review R1 FAIL on formatting; fixed; R2 PASS 0.96
- cargo test --workspace: green
- cargo clippy --workspace --all-targets -- -D warnings: green
- full differential: 25 structural/live cases + 10 exact behavior cases green
- bun test coverage: 487 pass, 6 intentional experimental skips, 0 fail
- production contract 7/7; matrix, typecheck, Biome, actionlint, fmt, diff check green

## Explicit nonclaims / remaining release blockers

DNS resolver timeout and TLS/SNI fixtures; broad real-PDF corpus; geometry/render/crop/OCR/analyze; complete Document Twin semantics; cross-platform npm native packaging; removal of experimental capability skips; same-machine release benchmark.

Product truth remains dropInFor3014=false and publishFreeze=true.