### PR TITLE
fix(release): hard-fail before changesets publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,12 +95,19 @@ jobs:
           path: benchmark-artifacts/
           if-no-files-found: ignore
 
-      - name: Create release PR or publish
+      # Keep this as a standalone shell boundary. changesets/action executes
+      # `publish` directly, so shell operators embedded in that input do not
+      # enforce a failing freeze.
+      - name: Enforce Rust replacement publish freeze
+        run: |
+          echo "PUBLISH FREEZE: verified-candidate artifact admission is not wired yet" >&2
+          exit 1
+
+      - name: Create release PR
         id: changesets
         uses: changesets/action@v1
         with:
           version: bun changeset version && bun run sync:server-json
-          publish: 'echo "PUBLISH FREEZE: verified-candidate artifact admission is not wired yet" && exit 1'
           title: 'chore(release): version packages'
           commit: 'chore(release): version packages'
           createGithubReleases: true

--- a/test/releaseGate.test.ts
+++ b/test/releaseGate.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { buildSotaReleaseGateReport } from '../scripts/sota-release-gate.js';
 
@@ -19,5 +20,19 @@ describe('pdf reader SOTA release gate golden probes', () => {
     expect(report.checks.some((check) => check.id === 'mcp:http_gate_script_present')).toBe(true);
     expect(report.checks.some((check) => check.id === 'mcp:stdio_transport_parity')).toBe(true);
     expect(report.checks.some((check) => check.id === 'mcp:stdio_gate_script_present')).toBe(true);
+  });
+
+  it('hard-fails the release workflow before changesets can publish', () => {
+    const workflow = readFileSync(
+      path.join(import.meta.dirname, '..', '.github/workflows/release.yml'),
+      'utf8'
+    );
+    const freeze = workflow.indexOf('- name: Enforce Rust replacement publish freeze');
+    const changesets = workflow.indexOf('uses: changesets/action@v1');
+
+    expect(freeze).toBeGreaterThan(-1);
+    expect(workflow.slice(freeze, changesets)).toContain('exit 1');
+    expect(freeze).toBeLessThan(changesets);
+    expect(workflow).not.toContain('publish:');
   });
 });


### PR DESCRIPTION
## Root cause

The release workflow supplied an echo command containing shell operators to changesets/action publish. That action executes the configured command directly, so the operators were passed as echo arguments. The freeze prevented publication but falsely reported the release workflow as successful.

## Fix

- add an unconditional standalone shell freeze step before changesets/action
- remove the misleading publish input entirely
- add a regression test for freeze presence, exit 1, ordering, and absence of publish input

## Evidence

- live main run 29625863245 proved the old command was direct-executed and falsely green
- independent review PASS 0.98
- actionlint, Biome, focused tests, and diff check green
- npm/crates/MCP Registry publish workflows remain disabled and separately hard-fail

No publication is performed by this PR.