### PR TITLE
feat(rust): prove bounded render and crop parity

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,5 +15,6 @@ package-lock.json text eol=lf
 pnpm-lock.yaml text eol=lf
 
 # Ensure specific files are treated as binary (if needed)
+*.pdf binary
 # *.png binary
 # *.jpg binary

--- a/.github/workflows/rust-parity-differential.yml
+++ b/.github/workflows/rust-parity-differential.yml
@@ -100,6 +100,14 @@ jobs:
       - name: Run differential harness
         run: bash "${DIFFERENTIAL_SCRIPT}"
 
+      - name: Enforce honest matrix and pure-Rust capability contract
+        env:
+          PDF_READER_ENGINE_MODE: pure-rust
+          RUN_PURE_RUST_CAPABILITY: "1"
+        run: |
+          bun run check:pure-rust-matrix
+          bun run test:capability-parity
+
       - name: Assert proof SHA binding
         run: |
           set -euo pipefail
@@ -131,6 +139,19 @@ jobs:
             echo "::error::v3.0.14 behavior result is incomplete, failing, or not SHA-bound"
             exit 1
           }
+          VISUAL_ARTIFACT="${SCRATCH_DIR}/v3014-visual-result.json"
+          if [ ! -f "$VISUAL_ARTIFACT" ]; then
+            echo "::error::v3.0.14 visual result missing at $VISUAL_ARTIFACT"
+            exit 1
+          fi
+          jq -e --arg sha "$CANDIDATE_SHA" '
+            .profile == "pdf_reader_v3014_visual_result" and
+            .candidateSha == $sha and .pass == true and
+            .caseCount == 7 and .passed == 7 and .skipped == 0
+          ' "$VISUAL_ARTIFACT" >/dev/null || {
+            echo "::error::v3.0.14 visual result is incomplete, failing, or not SHA-bound"
+            exit 1
+          }
           echo "proof SHA binding OK: lastComparedMainSha=$LAST_COMPARED"
 
       - name: Warn on stale capabilities without re-proof
@@ -149,6 +170,7 @@ jobs:
             ${{ env.SCRATCH_DIR }}/oracle.json
             ${{ env.SCRATCH_DIR }}/ts-vs-rust-text.json
             ${{ env.SCRATCH_DIR }}/v3014-behavior-result.json
+            ${{ env.SCRATCH_DIR }}/v3014-visual-result.json
           if-no-files-found: error
 
   rust-parity-drift-pass:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,6 +1294,7 @@ version = "3.1.1"
 dependencies = [
  "anyhow",
  "axum",
+ "base64",
  "chrono",
  "pdf-reader-core",
  "rmcp",

--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ Pure-Rust is a **work in progress**, not the published product.
 | Tool names `read_pdf` / `search_pdf` / `pdf_evidence` | Present in experimental engine |
 | Selectable-text extract / search | Partial |
 | Full Document Twin (geometry, outline, COS structure) | **Not yet** |
-| Evidence `render_page` / crop / OCR / analyze | **Not yet** (fail-closed) |
+| Evidence `render_page` / `extract_regions` | Partial: bounded Hayro PNG render/crop in the source experiment |
+| Evidence OCR / analyze | **Not yet** (fail-closed) |
 | Cross-platform npm binary | **Not yet** |
 | Drop-in for 3.0.14 | **No** |
 

--- a/crates/pdf-reader-core/src/lib.rs
+++ b/crates/pdf-reader-core/src/lib.rs
@@ -18,9 +18,11 @@ pub use read_pdf::{
     ReadPdfSource, ReadPdfSourceResult, READ_PDF_ROUTE,
 };
 pub use render::{
-    crop_pixels_for_bounding_box, crop_rendered_page_png, render_pdf_page, BoundingBox, CropPixels,
-    RenderError, RenderErrorCode, RenderProvenance, RenderedPage, DEFAULT_MAX_RENDER_PIXELS,
-    DEFAULT_RENDER_SCALE, RENDERER_NAME, RENDER_ENGINE,
+    crop_pixels_for_bounding_box, crop_pixels_for_rendered_page, crop_rendered_page_png,
+    crop_rendered_page_png_with_limit, crop_rendered_page_region, pdf_page_count, render_pdf_page,
+    BoundingBox, CropPixels, RenderDocument, RenderError, RenderErrorCode, RenderLimits,
+    RenderProvenance, RenderedPage, DEFAULT_MAX_RENDER_OUTPUT_BYTES, DEFAULT_MAX_RENDER_PAGES,
+    DEFAULT_MAX_RENDER_PIXELS, DEFAULT_RENDER_SCALE, RENDERER_NAME, RENDER_ENGINE,
 };
 pub use search_pdf::{
     search_pdf, search_pdf_from_value, SearchPdfError, SearchPdfErrorCode, SearchPdfInput,

--- a/crates/pdf-reader-core/src/render.rs
+++ b/crates/pdf-reader-core/src/render.rs
@@ -1,17 +1,21 @@
 //! Bounded, pure-Rust PDF page rendering and region cropping primitives.
 
-use std::io::Cursor;
+use std::io::{self, Cursor, Write};
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use hayro::hayro_interpret::hayro_syntax::page::Rotation;
-use hayro::hayro_interpret::hayro_syntax::Pdf;
+use hayro::hayro_interpret::hayro_syntax::{LoadPdfError, Pdf};
 use hayro::hayro_interpret::InterpreterSettings;
 use hayro::vello_cpu::color::palette::css::WHITE;
 use hayro::{render, RenderCache, RenderSettings};
-use image::{GenericImageView, ImageFormat};
+use image::codecs::png::PngEncoder;
+use image::{ExtendedColorType, GenericImageView, ImageEncoder, ImageFormat, ImageReader, Limits};
 use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_RENDER_SCALE: f32 = 2.0;
 pub const DEFAULT_MAX_RENDER_PIXELS: u64 = 16_000_000;
+pub const DEFAULT_MAX_RENDER_OUTPUT_BYTES: u64 = 64 * 1024 * 1024;
+pub const DEFAULT_MAX_RENDER_PAGES: usize = 20;
 pub const RENDER_ENGINE: &str = "hayro";
 pub const RENDERER_NAME: &str = "hayro/vello_cpu";
 
@@ -19,6 +23,8 @@ pub const RENDERER_NAME: &str = "hayro/vello_cpu";
 pub enum RenderErrorCode {
     InvalidRequest,
     InvalidPdf,
+    EncryptedPdf,
+    LimitExceeded,
     EncodeFailed,
 }
 
@@ -39,6 +45,20 @@ impl RenderError {
     fn invalid_pdf(message: impl Into<String>) -> Self {
         Self {
             code: RenderErrorCode::InvalidPdf,
+            message: message.into(),
+        }
+    }
+
+    fn encrypted_pdf(message: impl Into<String>) -> Self {
+        Self {
+            code: RenderErrorCode::EncryptedPdf,
+            message: message.into(),
+        }
+    }
+
+    fn limit_exceeded(message: impl Into<String>) -> Self {
+        Self {
+            code: RenderErrorCode::LimitExceeded,
             message: message.into(),
         }
     }
@@ -87,6 +107,215 @@ pub struct RenderedPage {
     pub provenance: RenderProvenance,
     #[serde(skip)]
     pub png: Vec<u8>,
+    #[serde(skip)]
+    pdf_to_pixel: [f64; 6],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RenderLimits {
+    pub max_pages: usize,
+    pub max_pixels_per_page: u64,
+    pub max_output_bytes_per_page: u64,
+}
+
+impl Default for RenderLimits {
+    fn default() -> Self {
+        Self {
+            max_pages: DEFAULT_MAX_RENDER_PAGES,
+            max_pixels_per_page: DEFAULT_MAX_RENDER_PIXELS,
+            max_output_bytes_per_page: DEFAULT_MAX_RENDER_OUTPUT_BYTES,
+        }
+    }
+}
+
+/// Parsed, reusable PDF rendering document. The PDF bytes are owned by Hayro,
+/// so selected pages can be rendered without reparsing the document per page.
+pub struct RenderDocument {
+    pdf: Pdf,
+}
+
+impl RenderDocument {
+    pub fn new(pdf_bytes: Vec<u8>) -> Result<Self, RenderError> {
+        let parsed = catch_unwind(AssertUnwindSafe(|| Pdf::new(pdf_bytes))).map_err(|_| {
+            RenderError::invalid_pdf("PDF parser panicked while loading the document.")
+        })?;
+        parsed.map(|pdf| Self { pdf }).map_err(map_load_error)
+    }
+
+    pub fn page_count(&self) -> usize {
+        self.pdf.pages().len()
+    }
+
+    /// Compute the pixel work for a page before invoking the renderer.
+    pub fn planned_render_pixel_count(
+        &self,
+        page_number: usize,
+        scale: f32,
+    ) -> Result<u64, RenderError> {
+        catch_unwind(AssertUnwindSafe(|| {
+            if page_number == 0 {
+                return Err(RenderError::invalid_request("page must be 1 or greater."));
+            }
+            if !scale.is_finite() || scale <= 0.0 {
+                return Err(RenderError::invalid_request(
+                    "scale must be a finite positive number.",
+                ));
+            }
+            let page = self.pdf.pages().get(page_number - 1).ok_or_else(|| {
+                RenderError::invalid_request(format!(
+                    "Requested page {page_number} exceeds document page count {}.",
+                    self.page_count()
+                ))
+            })?;
+            planned_dimensions(page, scale, page_number).map(|(_, _, pixels)| pixels)
+        }))
+        .map_err(|_| RenderError::invalid_pdf("PDF parser panicked while planning a render."))?
+    }
+
+    pub fn render_page(
+        &self,
+        page_number: usize,
+        scale: f32,
+        max_pixels: u64,
+        max_output_bytes: u64,
+    ) -> Result<RenderedPage, RenderError> {
+        catch_unwind(AssertUnwindSafe(|| {
+            self.render_page_impl(page_number, scale, max_pixels, max_output_bytes)
+        }))
+        .map_err(|_| RenderError::invalid_pdf("PDF renderer panicked on malformed content."))?
+    }
+
+    pub fn render_selected_pages(
+        &self,
+        page_numbers: &[usize],
+        scale: f32,
+        limits: RenderLimits,
+    ) -> Result<Vec<RenderedPage>, RenderError> {
+        validate_limits(limits)?;
+        if page_numbers.is_empty() {
+            return Err(RenderError::invalid_request(
+                "At least one page must be selected for rendering.",
+            ));
+        }
+        if page_numbers.len() > limits.max_pages {
+            return Err(RenderError::limit_exceeded(format!(
+                "Requested {} pages, exceeding max_pages {}.",
+                page_numbers.len(),
+                limits.max_pages
+            )));
+        }
+        page_numbers
+            .iter()
+            .map(|page| {
+                self.render_page(
+                    *page,
+                    scale,
+                    limits.max_pixels_per_page,
+                    limits.max_output_bytes_per_page,
+                )
+            })
+            .collect()
+    }
+
+    fn render_page_impl(
+        &self,
+        page_number: usize,
+        scale: f32,
+        max_pixels: u64,
+        max_output_bytes: u64,
+    ) -> Result<RenderedPage, RenderError> {
+        validate_render_request(page_number, scale, max_pixels, max_output_bytes)?;
+        let page = self.pdf.pages().get(page_number - 1).ok_or_else(|| {
+            RenderError::invalid_request(format!(
+                "Requested page {page_number} exceeds document page count {}.",
+                self.page_count()
+            ))
+        })?;
+        let (width, height, pixel_count) = planned_dimensions(page, scale, page_number)?;
+        if pixel_count > max_pixels {
+            return Err(RenderError::limit_exceeded(format!(
+                "Page {page_number} would render {pixel_count} pixels at scale {scale}, exceeding max_pixels_per_page {max_pixels}. Lower scale or raise max_pixels_per_page."
+            )));
+        }
+
+        let viewport_width = u16::try_from(width).map_err(|_| {
+            RenderError::limit_exceeded(format!(
+                "Page {page_number} render width {width} exceeds renderer limit {}.",
+                u16::MAX
+            ))
+        })?;
+        let viewport_height = u16::try_from(height).map_err(|_| {
+            RenderError::limit_exceeded(format!(
+                "Page {page_number} render height {height} exceeds renderer limit {}.",
+                u16::MAX
+            ))
+        })?;
+
+        let pixmap = render(
+            page,
+            &RenderCache::new(),
+            &InterpreterSettings::default(),
+            &RenderSettings {
+                x_scale: scale,
+                y_scale: scale,
+                width: Some(viewport_width),
+                height: Some(viewport_height),
+                bg_color: WHITE,
+            },
+        );
+        let rgba = pixmap.data_as_u8_slice();
+        if rgba.chunks_exact(4).any(|pixel| pixel[3] != 255) {
+            return Err(RenderError::encode_failed(
+                "White-background render unexpectedly contained transparent pixels.",
+            ));
+        }
+        let png = encode_rgba_png_bounded(rgba, width, height, max_output_bytes)?;
+        let mut pdf_to_pixel = page.initial_transform(true).as_coeffs();
+        for coefficient in &mut pdf_to_pixel {
+            *coefficient *= f64::from(scale);
+        }
+
+        Ok(RenderedPage {
+            page: page_number,
+            width,
+            height,
+            scale,
+            pixel_count,
+            rotation: rotation_degrees(page.rotation()),
+            format: "png",
+            mime_type: "image/png",
+            provenance: RenderProvenance {
+                engine: RENDER_ENGINE,
+                renderer: RENDERER_NAME,
+                source: "page-render",
+            },
+            png,
+            pdf_to_pixel,
+        })
+    }
+}
+
+fn planned_dimensions(
+    page: &hayro::hayro_interpret::hayro_syntax::page::Page<'_>,
+    scale: f32,
+    page_number: usize,
+) -> Result<(u32, u32, u64), RenderError> {
+    let (page_width, page_height) = page.render_dimensions();
+    let width = checked_render_dimension(page_width, scale, "width", page_number)?;
+    let height = checked_render_dimension(page_height, scale, "height", page_number)?;
+    let pixel_count = u64::from(width)
+        .checked_mul(u64::from(height))
+        .ok_or_else(|| RenderError::limit_exceeded("Rendered page dimensions overflow."))?;
+    Ok((width, height, pixel_count))
+}
+
+fn map_load_error(error: LoadPdfError) -> RenderError {
+    match error {
+        LoadPdfError::Decryption(_) => RenderError::encrypted_pdf(
+            "Encrypted PDF cannot be rendered without a supported password.",
+        ),
+        LoadPdfError::Invalid => RenderError::invalid_pdf("Unable to parse PDF for rendering."),
+    }
 }
 
 /// Render one 1-indexed PDF page into a white-background PNG.
@@ -98,6 +327,24 @@ pub fn render_pdf_page(
     scale: f32,
     max_pixels: u64,
 ) -> Result<RenderedPage, RenderError> {
+    RenderDocument::new(pdf_bytes)?.render_page(
+        page_number,
+        scale,
+        max_pixels,
+        DEFAULT_MAX_RENDER_OUTPUT_BYTES,
+    )
+}
+
+pub fn pdf_page_count(pdf_bytes: Vec<u8>) -> Result<usize, RenderError> {
+    RenderDocument::new(pdf_bytes).map(|document| document.page_count())
+}
+
+fn validate_render_request(
+    page_number: usize,
+    scale: f32,
+    max_pixels: u64,
+    max_output_bytes: u64,
+) -> Result<(), RenderError> {
     if page_number == 0 {
         return Err(RenderError::invalid_request("page must be 1 or greater."));
     }
@@ -107,77 +354,30 @@ pub fn render_pdf_page(
         ));
     }
     if max_pixels == 0 {
-        return Err(RenderError::invalid_request(
+        return Err(RenderError::limit_exceeded(
             "max_pixels_per_page must be greater than zero.",
         ));
     }
-
-    let pdf = Pdf::new(pdf_bytes)
-        .map_err(|_| RenderError::invalid_pdf("Unable to parse PDF for rendering."))?;
-    let page = pdf.pages().get(page_number - 1).ok_or_else(|| {
-        RenderError::invalid_request(format!(
-            "Requested page {page_number} exceeds document page count {}.",
-            pdf.pages().len()
-        ))
-    })?;
-    let (page_width, page_height) = page.render_dimensions();
-    let width = checked_render_dimension(page_width, scale, "width", page_number)?;
-    let height = checked_render_dimension(page_height, scale, "height", page_number)?;
-    let pixel_count = u64::from(width)
-        .checked_mul(u64::from(height))
-        .ok_or_else(|| RenderError::invalid_request("Rendered page dimensions overflow."))?;
-    if pixel_count > max_pixels {
-        return Err(RenderError::invalid_request(format!(
-            "Page {page_number} would render {pixel_count} pixels at scale {scale}, exceeding max_pixels_per_page {max_pixels}. Lower scale or raise max_pixels_per_page."
-        )));
+    if max_output_bytes == 0 {
+        return Err(RenderError::limit_exceeded(
+            "max_output_bytes_per_page must be greater than zero.",
+        ));
     }
+    Ok(())
+}
 
-    // Hayro currently accepts u16 viewport dimensions. Reject instead of truncating.
-    let viewport_width = u16::try_from(width).map_err(|_| {
-        RenderError::invalid_request(format!(
-            "Page {page_number} render width {width} exceeds renderer limit {}.",
-            u16::MAX
-        ))
-    })?;
-    let viewport_height = u16::try_from(height).map_err(|_| {
-        RenderError::invalid_request(format!(
-            "Page {page_number} render height {height} exceeds renderer limit {}.",
-            u16::MAX
-        ))
-    })?;
-
-    let pixmap = render(
-        page,
-        &RenderCache::new(),
-        &InterpreterSettings::default(),
-        &RenderSettings {
-            x_scale: scale,
-            y_scale: scale,
-            width: Some(viewport_width),
-            height: Some(viewport_height),
-            bg_color: WHITE,
-        },
-    );
-    let png = pixmap
-        .into_png()
-        .map_err(|err| RenderError::encode_failed(format!("Failed to encode page PNG: {err}")))?;
-
-    Ok(RenderedPage {
-        page: page_number,
-        width,
-        height,
-        scale,
-        pixel_count,
-        rotation: rotation_degrees(page.rotation()),
-        format: "png",
-        mime_type: "image/png",
-        provenance: RenderProvenance {
-            engine: RENDER_ENGINE,
-            renderer: RENDERER_NAME,
-            source: "page-render",
-        },
-        png,
-    })
+fn validate_limits(limits: RenderLimits) -> Result<(), RenderError> {
+    if limits.max_pages == 0 {
+        return Err(RenderError::limit_exceeded(
+            "max_pages must be greater than zero.",
+        ));
+    }
+    validate_render_request(
+        1,
+        DEFAULT_RENDER_SCALE,
+        limits.max_pixels_per_page,
+        limits.max_output_bytes_per_page,
+    )
 }
 
 fn rotation_degrees(rotation: Rotation) -> i32 {
@@ -204,11 +404,79 @@ fn checked_render_dimension(
     Ok(scaled.ceil() as u32)
 }
 
+struct BoundedWriter {
+    bytes: Vec<u8>,
+    maximum: usize,
+    exceeded: bool,
+}
+
+impl BoundedWriter {
+    fn new(maximum: u64) -> Result<Self, RenderError> {
+        let maximum = usize::try_from(maximum).map_err(|_| {
+            RenderError::limit_exceeded("Output byte limit exceeds this platform's capacity.")
+        })?;
+        Ok(Self {
+            bytes: Vec::new(),
+            maximum,
+            exceeded: false,
+        })
+    }
+}
+
+impl Write for BoundedWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        let remaining = self.maximum.saturating_sub(self.bytes.len());
+        if buffer.len() > remaining {
+            self.exceeded = true;
+            return Err(io::Error::new(
+                io::ErrorKind::StorageFull,
+                "encoded PNG exceeds output byte limit",
+            ));
+        }
+        self.bytes.extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn encode_rgba_png_bounded(
+    rgba: &[u8],
+    width: u32,
+    height: u32,
+    max_output_bytes: u64,
+) -> Result<Vec<u8>, RenderError> {
+    let expected = u64::from(width)
+        .checked_mul(u64::from(height))
+        .and_then(|pixels| pixels.checked_mul(4))
+        .ok_or_else(|| RenderError::limit_exceeded("RGBA buffer dimensions overflow."))?;
+    if u64::try_from(rgba.len()).ok() != Some(expected) {
+        return Err(RenderError::encode_failed(
+            "Renderer returned an RGBA buffer with an invalid length.",
+        ));
+    }
+
+    let mut writer = BoundedWriter::new(max_output_bytes)?;
+    let result =
+        PngEncoder::new(&mut writer).write_image(rgba, width, height, ExtendedColorType::Rgba8);
+    if writer.exceeded {
+        return Err(RenderError::limit_exceeded(format!(
+            "Encoded PNG exceeds max_output_bytes_per_page {max_output_bytes}."
+        )));
+    }
+    result.map_err(|error| {
+        RenderError::encode_failed(format!("Failed to encode deterministic RGBA PNG: {error}"))
+    })?;
+    Ok(writer.bytes)
+}
+
 /// Convert a PDF bottom-left-origin bounding box into a clamped top-left pixel crop.
 ///
-/// Rounding and padding intentionally match the TypeScript 3.0.14 implementation.
-/// The 3.0.14 crop formula does not account for rotated page coordinates, so this
-/// kernel rejects non-zero rotation rather than returning a plausibly wrong crop.
+/// This compatibility entrypoint assumes a zero-origin page box. Use
+/// [`crop_pixels_for_rendered_page`] when a parsed page is available; it carries
+/// the exact CropBox offset and Hayro render transform.
 pub fn crop_pixels_for_bounding_box(
     page_width: u32,
     page_height: u32,
@@ -227,9 +495,53 @@ pub fn crop_pixels_for_bounding_box(
             "padding must be a finite non-negative number.",
         ));
     }
-    if page_rotation.rem_euclid(360) != 0 {
+    let scale = f64::from(scale);
+    let transform = match page_rotation.rem_euclid(360) {
+        0 => [scale, 0.0, 0.0, -scale, 0.0, f64::from(page_height)],
+        90 => [0.0, scale, scale, 0.0, 0.0, 0.0],
+        180 => [-scale, 0.0, 0.0, scale, f64::from(page_width), 0.0],
+        270 => [
+            0.0,
+            -scale,
+            -scale,
+            0.0,
+            f64::from(page_width),
+            f64::from(page_height),
+        ],
+        other => {
+            return Err(RenderError::invalid_request(format!(
+                "Unsupported page rotation {other}; expected a multiple of 90 degrees."
+            )))
+        }
+    };
+    crop_pixels_for_transform(page_width, page_height, transform, bounding_box, padding)
+}
+
+/// Convert PDF coordinates using the exact transform used to render this page.
+pub fn crop_pixels_for_rendered_page(
+    page: &RenderedPage,
+    bounding_box: BoundingBox,
+    padding: f64,
+) -> Result<CropPixels, RenderError> {
+    crop_pixels_for_transform(
+        page.width,
+        page.height,
+        page.pdf_to_pixel,
+        bounding_box,
+        padding,
+    )
+}
+
+fn crop_pixels_for_transform(
+    page_width: u32,
+    page_height: u32,
+    transform: [f64; 6],
+    bounding_box: BoundingBox,
+    padding: f64,
+) -> Result<CropPixels, RenderError> {
+    if !padding.is_finite() || padding < 0.0 {
         return Err(RenderError::invalid_request(
-            "Region crops on rotated pages are not supported by the TS-compatible crop transform.",
+            "padding must be a finite non-negative number.",
         ));
     }
     if !valid_bounding_box(bounding_box) {
@@ -237,12 +549,48 @@ pub fn crop_pixels_for_bounding_box(
             "Region bounding_box must have right > left and top > bottom.",
         ));
     }
+    let expanded = BoundingBox {
+        left: bounding_box.left - padding,
+        bottom: bounding_box.bottom - padding,
+        right: bounding_box.right + padding,
+        top: bounding_box.top + padding,
+    };
+    if ![expanded.left, expanded.bottom, expanded.right, expanded.top]
+        .iter()
+        .all(|value| value.is_finite())
+    {
+        return Err(RenderError::invalid_request(
+            "Region bounding_box plus padding must remain finite.",
+        ));
+    }
 
-    let scale = f64::from(scale);
-    let left = ((bounding_box.left - padding) * scale).floor();
-    let right = ((bounding_box.right + padding) * scale).ceil();
-    let top = (f64::from(page_height) - (bounding_box.top + padding) * scale).floor();
-    let bottom = (f64::from(page_height) - (bounding_box.bottom - padding) * scale).ceil();
+    let corners = [
+        (expanded.left, expanded.bottom),
+        (expanded.left, expanded.top),
+        (expanded.right, expanded.bottom),
+        (expanded.right, expanded.top),
+    ];
+    let transformed = corners.map(|(x, y)| apply_transform(transform, x, y));
+    let left = transformed
+        .iter()
+        .map(|(x, _)| *x)
+        .fold(f64::INFINITY, f64::min)
+        .floor();
+    let right = transformed
+        .iter()
+        .map(|(x, _)| *x)
+        .fold(f64::NEG_INFINITY, f64::max)
+        .ceil();
+    let top = transformed
+        .iter()
+        .map(|(_, y)| *y)
+        .fold(f64::INFINITY, f64::min)
+        .floor();
+    let bottom = transformed
+        .iter()
+        .map(|(_, y)| *y)
+        .fold(f64::NEG_INFINITY, f64::max)
+        .ceil();
 
     let clamped_left = clamp_pixel(left, page_width);
     let clamped_top = clamp_pixel(top, page_height);
@@ -262,6 +610,13 @@ pub fn crop_pixels_for_bounding_box(
         width,
         height,
     })
+}
+
+fn apply_transform(transform: [f64; 6], x: f64, y: f64) -> (f64, f64) {
+    (
+        transform[0] * x + transform[2] * y + transform[4],
+        transform[1] * x + transform[3] * y + transform[5],
+    )
 }
 
 fn valid_bounding_box(box_: BoundingBox) -> bool {
@@ -284,7 +639,39 @@ pub fn crop_rendered_page_png(
     expected_height: u32,
     crop: CropPixels,
 ) -> Result<Vec<u8>, RenderError> {
-    let source = image::load_from_memory_with_format(page_png, ImageFormat::Png)
+    crop_rendered_page_png_with_limit(
+        page_png,
+        expected_width,
+        expected_height,
+        crop,
+        DEFAULT_MAX_RENDER_OUTPUT_BYTES,
+    )
+}
+
+pub fn crop_rendered_page_png_with_limit(
+    page_png: &[u8],
+    expected_width: u32,
+    expected_height: u32,
+    crop: CropPixels,
+    max_output_bytes: u64,
+) -> Result<Vec<u8>, RenderError> {
+    if max_output_bytes == 0 {
+        return Err(RenderError::limit_exceeded(
+            "max_output_bytes must be greater than zero.",
+        ));
+    }
+    let raw_bytes = u64::from(expected_width)
+        .checked_mul(u64::from(expected_height))
+        .and_then(|pixels| pixels.checked_mul(4))
+        .ok_or_else(|| RenderError::limit_exceeded("Rendered PNG dimensions overflow."))?;
+    let mut reader = ImageReader::with_format(Cursor::new(page_png), ImageFormat::Png);
+    let mut decode_limits = Limits::default();
+    decode_limits.max_image_width = Some(expected_width);
+    decode_limits.max_image_height = Some(expected_height);
+    decode_limits.max_alloc = Some(raw_bytes.saturating_mul(2).saturating_add(1_048_576));
+    reader.limits(decode_limits);
+    let source = catch_unwind(AssertUnwindSafe(|| reader.decode()))
+        .map_err(|_| RenderError::invalid_request("PNG decoder panicked on malformed input."))?
         .map_err(|err| RenderError::invalid_request(format!("Invalid rendered page PNG: {err}")))?;
     if source.dimensions() != (expected_width, expected_height) {
         return Err(RenderError::invalid_request(format!(
@@ -304,25 +691,54 @@ pub fn crop_rendered_page_png(
         ));
     }
 
-    let cropped = source.crop_imm(crop.left, crop.top, crop.width, crop.height);
-    let mut encoded = Cursor::new(Vec::new());
-    cropped
-        .write_to(&mut encoded, ImageFormat::Png)
-        .map_err(|err| RenderError::encode_failed(format!("Failed to encode crop PNG: {err}")))?;
-    Ok(encoded.into_inner())
+    let cropped = source
+        .crop_imm(crop.left, crop.top, crop.width, crop.height)
+        .to_rgba8();
+    encode_rgba_png_bounded(cropped.as_raw(), crop.width, crop.height, max_output_bytes)
+}
+
+/// Transform and crop a PDF-coordinate region from an already rendered page.
+pub fn crop_rendered_page_region(
+    page: &RenderedPage,
+    bounding_box: BoundingBox,
+    padding: f64,
+    max_output_bytes: u64,
+) -> Result<(CropPixels, Vec<u8>), RenderError> {
+    let crop = crop_pixels_for_rendered_page(page, bounding_box, padding)?;
+    let png = crop_rendered_page_png_with_limit(
+        &page.png,
+        page.width,
+        page.height,
+        crop,
+        max_output_bytes,
+    )?;
+    Ok((crop, png))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hayro::hayro_interpret::hayro_syntax::DecryptionError;
 
     fn fixture_pdf(rotation: i32) -> Vec<u8> {
+        fixture_pdf_with_crop_box(rotation, None)
+    }
+
+    fn fixture_pdf_with_crop_box(rotation: i32, crop_box: Option<&str>) -> Vec<u8> {
         let content = "0.1 0.2 0.8 rg\n10 10 100 60 re f\n";
+        let media_box = if crop_box.is_some() {
+            "0 0 200 200"
+        } else {
+            "0 0 120 80"
+        };
+        let crop_box = crop_box
+            .map(|value| format!(" /CropBox [{value}]"))
+            .unwrap_or_default();
         let objects = [
             "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
             "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
             format!(
-                "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 120 80] /Rotate {rotation} /Resources << >> /Contents 4 0 R >>"
+                "<< /Type /Page /Parent 2 0 R /MediaBox [{media_box}]{crop_box} /Rotate {rotation} /Resources << >> /Contents 4 0 R >>"
             ),
             format!(
                 "<< /Length {} >>\nstream\n{content}endstream",
@@ -353,8 +769,13 @@ mod tests {
 
     #[test]
     fn renders_fixture_page_to_bounded_png_at_scale_two() {
-        let rendered = render_pdf_page(fixture_pdf(0), 1, 2.0, DEFAULT_MAX_RENDER_PIXELS)
-            .expect("render fixture");
+        let bytes = fixture_pdf(0);
+        let planned = RenderDocument::new(bytes.clone())
+            .expect("plan fixture")
+            .planned_render_pixel_count(1, 2.0)
+            .expect("planned pixels");
+        let rendered =
+            render_pdf_page(bytes, 1, 2.0, DEFAULT_MAX_RENDER_PIXELS).expect("render fixture");
         assert_eq!(rendered.page, 1);
         assert_eq!(rendered.scale, 2.0);
         assert_eq!((rendered.width, rendered.height), (240, 160));
@@ -362,6 +783,7 @@ mod tests {
             rendered.pixel_count,
             u64::from(rendered.width) * u64::from(rendered.height)
         );
+        assert_eq!(planned, rendered.pixel_count);
         assert!(rendered.pixel_count <= DEFAULT_MAX_RENDER_PIXELS);
         assert_eq!(&rendered.png[..8], b"\x89PNG\r\n\x1a\n");
         assert_eq!(rendered.provenance.engine, RENDER_ENGINE);
@@ -380,7 +802,7 @@ mod tests {
         assert_eq!(err.code, RenderErrorCode::InvalidRequest);
 
         let err = render_pdf_page(bytes, 1, 2.0, 1).expect_err("pixel budget");
-        assert_eq!(err.code, RenderErrorCode::InvalidRequest);
+        assert_eq!(err.code, RenderErrorCode::LimitExceeded);
         assert!(err.message.contains("exceeding max_pixels_per_page"));
     }
 
@@ -390,6 +812,175 @@ mod tests {
             .expect("render rotated fixture");
         assert_eq!(rendered.rotation, 90);
         assert_eq!((rendered.width, rendered.height), (160, 240));
+    }
+
+    #[test]
+    fn reusable_document_reports_pages_and_enforces_selected_page_limit() {
+        let document = RenderDocument::new(fixture_pdf(0)).expect("parse fixture once");
+        assert_eq!(document.page_count(), 1);
+        assert_eq!(pdf_page_count(fixture_pdf(0)).unwrap(), 1);
+        let pages = document
+            .render_selected_pages(
+                &[1],
+                1.0,
+                RenderLimits {
+                    max_pages: 1,
+                    ..RenderLimits::default()
+                },
+            )
+            .expect("render selected page");
+        assert_eq!(pages.len(), 1);
+
+        let error = document
+            .render_selected_pages(
+                &[1, 1],
+                1.0,
+                RenderLimits {
+                    max_pages: 1,
+                    ..RenderLimits::default()
+                },
+            )
+            .expect_err("selected page count must be bounded");
+        assert_eq!(error.code, RenderErrorCode::LimitExceeded);
+    }
+
+    #[test]
+    fn exact_page_transform_handles_all_right_angle_rotations() {
+        let expected = [
+            (
+                0,
+                CropPixels {
+                    left: 10,
+                    top: 60,
+                    width: 20,
+                    height: 10,
+                },
+            ),
+            (
+                90,
+                CropPixels {
+                    left: 10,
+                    top: 10,
+                    width: 10,
+                    height: 20,
+                },
+            ),
+            (
+                180,
+                CropPixels {
+                    left: 90,
+                    top: 10,
+                    width: 20,
+                    height: 10,
+                },
+            ),
+            (
+                270,
+                CropPixels {
+                    left: 60,
+                    top: 90,
+                    width: 10,
+                    height: 20,
+                },
+            ),
+        ];
+        let region = BoundingBox {
+            left: 10.0,
+            bottom: 10.0,
+            right: 30.0,
+            top: 20.0,
+        };
+        for (rotation, expected_crop) in expected {
+            let rendered =
+                render_pdf_page(fixture_pdf(rotation), 1, 1.0, DEFAULT_MAX_RENDER_PIXELS).unwrap();
+            assert_eq!(
+                crop_pixels_for_rendered_page(&rendered, region, 0.0).unwrap(),
+                expected_crop,
+                "rotation {rotation}"
+            );
+        }
+    }
+
+    #[test]
+    fn exact_page_transform_accounts_for_nonzero_crop_box_origin() {
+        let rendered = render_pdf_page(
+            fixture_pdf_with_crop_box(0, Some("50 60 170 140")),
+            1,
+            1.0,
+            DEFAULT_MAX_RENDER_PIXELS,
+        )
+        .expect("render cropped page");
+        assert_eq!((rendered.width, rendered.height), (120, 80));
+        assert_eq!(
+            crop_pixels_for_rendered_page(
+                &rendered,
+                BoundingBox {
+                    left: 60.0,
+                    bottom: 70.0,
+                    right: 80.0,
+                    top: 90.0,
+                },
+                0.0,
+            )
+            .unwrap(),
+            CropPixels {
+                left: 10,
+                top: 50,
+                width: 20,
+                height: 20,
+            }
+        );
+    }
+
+    #[test]
+    fn malformed_pdf_and_output_limit_return_structured_errors_without_panics() {
+        let malformed = render_pdf_page(b"not a PDF".to_vec(), 1, 1.0, DEFAULT_MAX_RENDER_PIXELS)
+            .expect_err("malformed input");
+        assert_eq!(malformed.code, RenderErrorCode::InvalidPdf);
+
+        let document = RenderDocument::new(fixture_pdf(0)).unwrap();
+        let limited = document
+            .render_page(1, 1.0, DEFAULT_MAX_RENDER_PIXELS, 16)
+            .expect_err("encoded output limit");
+        assert_eq!(limited.code, RenderErrorCode::LimitExceeded);
+    }
+
+    #[test]
+    fn encrypted_pdf_load_errors_are_classified_without_exposing_parser_details() {
+        let error = map_load_error(LoadPdfError::Decryption(DecryptionError::PasswordProtected));
+        assert_eq!(error.code, RenderErrorCode::EncryptedPdf);
+        assert!(error.message.contains("Encrypted PDF"));
+    }
+
+    #[test]
+    fn rendered_and_cropped_pngs_are_deterministic_rgba8() {
+        let rendered_a =
+            render_pdf_page(fixture_pdf(0), 1, 1.0, DEFAULT_MAX_RENDER_PIXELS).unwrap();
+        let rendered_b =
+            render_pdf_page(fixture_pdf(0), 1, 1.0, DEFAULT_MAX_RENDER_PIXELS).unwrap();
+        assert_eq!(rendered_a.png, rendered_b.png);
+        assert_eq!(
+            image::load_from_memory_with_format(&rendered_a.png, ImageFormat::Png)
+                .unwrap()
+                .color(),
+            image::ColorType::Rgba8
+        );
+
+        let (crop, crop_png) = crop_rendered_page_region(
+            &rendered_a,
+            BoundingBox {
+                left: 10.0,
+                bottom: 10.0,
+                right: 30.0,
+                top: 20.0,
+            },
+            0.0,
+            DEFAULT_MAX_RENDER_OUTPUT_BYTES,
+        )
+        .unwrap();
+        let decoded = image::load_from_memory_with_format(&crop_png, ImageFormat::Png).unwrap();
+        assert_eq!(decoded.dimensions(), (crop.width, crop.height));
+        assert_eq!(decoded.color(), image::ColorType::Rgba8);
     }
 
     #[test]
@@ -487,8 +1078,16 @@ mod tests {
             },
             0.0,
         )
-        .expect_err("rotated crop must fail closed");
-        assert!(rotated.message.contains("rotated pages"));
+        .expect("rotated crop");
+        assert_eq!(
+            rotated,
+            CropPixels {
+                left: 2,
+                top: 2,
+                width: 4,
+                height: 4,
+            }
+        );
     }
 
     #[test]

--- a/crates/pdf-reader-mcp-server/Cargo.toml
+++ b/crates/pdf-reader-mcp-server/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 axum = "0.8"
+base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 pdf-reader-core = { path = "../pdf-reader-core", version = "3.1.1" }
 rmcp = { version = "0.16.0", features = ["server", "transport-io", "transport-streamable-http-server"] }

--- a/crates/pdf-reader-mcp-server/src/lib.rs
+++ b/crates/pdf-reader-mcp-server/src/lib.rs
@@ -6,6 +6,7 @@ pub mod read_pdf;
 pub mod schema;
 pub mod search;
 pub mod tool_routes;
+mod visual_evidence;
 
 use rmcp::{
     handler::server::router::tool::ToolRouter,
@@ -20,9 +21,11 @@ use serde_json::Value;
 pub const SERVER_NAME: &str = "pdf-reader-mcp";
 /// Experimental pure-Rust engine version — not the published npm product line.
 pub const SERVER_VERSION: &str = "0.0.0-pure-rust-experimental";
-pub const SERVER_INSTRUCTIONS: &str = "Experimental pure-Rust PDF MCP engine (not the published npm latest). \
+pub const SERVER_INSTRUCTIONS: &str =
+    "Experimental pure-Rust PDF MCP engine (not the published npm latest). \
 Supported depth: selectable-text read_pdf, search_pdf, pdf_evidence inspect. \
-render/crop/OCR/analyze fail closed. For production drop-in use @sylphx/pdf-reader-mcp@3.0.14 (TypeScript).";
+Bounded page render and region crop are available with Hayro provenance; OCR/analyze fail closed. \
+For production drop-in use @sylphx/pdf-reader-mcp@3.0.14 (TypeScript).";
 
 fn omit_absent_optional_fields(value: Value) -> Value {
     match value {
@@ -103,7 +106,7 @@ impl PdfReaderMcp {
     }
 
     #[tool(
-        description = "Focused PDF evidence operations. Pure-Rust supports operation=inspect; render/crop/OCR/analyze fail closed with guidance."
+        description = "Focused PDF evidence operations. Pure-Rust supports inspect, bounded page rendering, and region crops; OCR/analyze fail closed with guidance."
     )]
     pub fn pdf_evidence(
         &self,

--- a/crates/pdf-reader-mcp-server/src/pdf_evidence.rs
+++ b/crates/pdf-reader-mcp-server/src/pdf_evidence.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 
 use crate::evidence::attach_evidence;
 use crate::schema::PdfSource;
+use crate::visual_evidence;
 
 const DEFAULT_MAX_FILE_BYTES: u64 = 256 * 1024 * 1024;
 const INSPECT_ROUTE: &str = "rust-pdf-inspect-v1";
@@ -19,13 +20,15 @@ pub fn pdf_evidence(args: Value) -> Result<CallToolResult, rmcp::ErrorData> {
 
     match operation {
         "inspect" => inspect(args),
-        "render_page" | "extract_regions" | "ocr_pages" | "analyze_regions" => {
+        "render_page" => visual_evidence::render_pages(args),
+        "extract_regions" => visual_evidence::extract_regions(args),
+        "ocr_pages" | "analyze_regions" => {
             // Pure-Rust v1: return structured, non-crashing guidance rather than silent no-op.
             // inspect covers the default agent routing path; visual ops need providers/native render.
             Err(rmcp::ErrorData::invalid_request(
                 format!(
                     "pdf_evidence operation '{operation}' is not available in the pure-Rust engine yet. \
-                     Use operation=inspect for page/text routing, or use read_pdf for text extraction."
+                     Use operation=inspect, render_page, or extract_regions, or use read_pdf for text extraction."
                 ),
                 None,
             ))

--- a/crates/pdf-reader-mcp-server/src/visual_evidence.rs
+++ b/crates/pdf-reader-mcp-server/src/visual_evidence.rs
@@ -1,0 +1,830 @@
+//! TS-compatible page render and region crop orchestration over the pure-Rust kernel.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use base64::Engine;
+use pdf_reader_core::render::{
+    crop_pixels_for_bounding_box, crop_rendered_page_png_with_limit, BoundingBox, RenderDocument,
+    DEFAULT_MAX_RENDER_OUTPUT_BYTES, DEFAULT_MAX_RENDER_PIXELS, DEFAULT_RENDER_SCALE,
+};
+use pdf_reader_core::url_fetch::{cleanup_temp_file, fetch_url_to_temp_file};
+use rmcp::model::{CallToolResult, Content};
+use serde_json::{json, Value};
+
+use crate::schema::{
+    PageSpecifier, PdfEvidenceArgs, PdfEvidenceRegion, PdfEvidenceSource, RegionBoundingBox,
+};
+
+const DEFAULT_MAX_FILE_BYTES: u64 = 256 * 1024 * 1024;
+const DEFAULT_MAX_RENDER_PAGES: usize = 5;
+const DEFAULT_MAX_REGIONS: usize = 20;
+const MAX_SELECTED_PAGES: usize = 10_001;
+const MAX_AGGREGATE_IMAGE_BYTES: usize = 256 * 1024 * 1024;
+const MAX_SOURCES_PER_REQUEST: usize = 32;
+const MAX_REQUEST_RENDERED_PAGES: usize = 64;
+const MAX_REQUEST_REGIONS: usize = 200;
+const MAX_REQUEST_RENDER_PIXELS: u64 = 256_000_000;
+
+#[derive(Default)]
+struct RequestWorkBudget {
+    rendered_pages: usize,
+    regions: usize,
+    render_pixels: u64,
+}
+
+impl RequestWorkBudget {
+    fn charge_page(&mut self, pixels: u64) -> Result<(), String> {
+        let rendered_pages = self
+            .rendered_pages
+            .checked_add(1)
+            .ok_or_else(|| "Request render page work overflow.".to_string())?;
+        if rendered_pages > MAX_REQUEST_RENDERED_PAGES {
+            return Err(format!(
+                "Request exceeds render work limit of {MAX_REQUEST_RENDERED_PAGES} pages."
+            ));
+        }
+        let render_pixels = self
+            .render_pixels
+            .checked_add(pixels)
+            .ok_or_else(|| "Request render pixel work overflow.".to_string())?;
+        if render_pixels > MAX_REQUEST_RENDER_PIXELS {
+            return Err(format!(
+                "Request exceeds render work limit of {MAX_REQUEST_RENDER_PIXELS} pixels."
+            ));
+        }
+        self.rendered_pages = rendered_pages;
+        self.render_pixels = render_pixels;
+        Ok(())
+    }
+
+    fn charge_region(&mut self) -> Result<(), String> {
+        let regions = self
+            .regions
+            .checked_add(1)
+            .ok_or_else(|| "Request region work overflow.".to_string())?;
+        if regions > MAX_REQUEST_REGIONS {
+            return Err(format!(
+                "Request exceeds crop work limit of {MAX_REQUEST_REGIONS} regions."
+            ));
+        }
+        self.regions = regions;
+        Ok(())
+    }
+}
+
+struct MaterializedSource {
+    label: String,
+    path: PathBuf,
+    temporary: bool,
+}
+
+impl Drop for MaterializedSource {
+    fn drop(&mut self) {
+        if self.temporary {
+            cleanup_temp_file(&self.path);
+        }
+    }
+}
+
+struct ImagePart {
+    data: String,
+    mime_type: &'static str,
+}
+
+fn tool_result(payload: Value, images: Vec<ImagePart>) -> CallToolResult {
+    let text = serde_json::to_string_pretty(&payload).unwrap_or_else(|_| payload.to_string());
+    let mut content = Vec::with_capacity(images.len() + 1);
+    content.push(Content::text(text));
+    content.extend(
+        images
+            .into_iter()
+            .map(|image| Content::image(image.data, image.mime_type)),
+    );
+    CallToolResult {
+        content,
+        structured_content: Some(payload),
+        is_error: Some(false),
+        meta: None,
+    }
+}
+
+fn all_failed(message: String) -> CallToolResult {
+    CallToolResult::error(vec![Content::text(message)])
+}
+
+fn parse_args(value: Value) -> Result<PdfEvidenceArgs, rmcp::ErrorData> {
+    let args: PdfEvidenceArgs = serde_json::from_value(value).map_err(|error| {
+        rmcp::ErrorData::invalid_params(format!("Invalid pdf_evidence arguments: {error}"), None)
+    })?;
+    args.validate()
+        .map_err(|message| rmcp::ErrorData::invalid_params(message, None))?;
+    if args.sources.len() > MAX_SOURCES_PER_REQUEST {
+        return Err(rmcp::ErrorData::invalid_params(
+            format!("pdf_evidence accepts at most {MAX_SOURCES_PER_REQUEST} sources per request."),
+            None,
+        ));
+    }
+    Ok(args)
+}
+
+fn materialize(source: &PdfEvidenceSource) -> Result<MaterializedSource, String> {
+    if let Some(path) = source.path.as_ref() {
+        return Ok(MaterializedSource {
+            label: path.clone(),
+            path: PathBuf::from(path),
+            temporary: false,
+        });
+    }
+    if let Some(url) = source.url.as_ref() {
+        return fetch_url_to_temp_file(url).map(|path| MaterializedSource {
+            label: url.clone(),
+            path,
+            temporary: true,
+        });
+    }
+    Err("Provide exactly one of path or url for each PDF source.".into())
+}
+
+fn read_pdf(path: &Path) -> Result<Vec<u8>, String> {
+    let metadata = fs::metadata(path)
+        .map_err(|error| format!("Unable to access file at '{}': {error}", path.display()))?;
+    if !metadata.is_file() {
+        return Err(format!("Path '{}' is not a regular file.", path.display()));
+    }
+    if metadata.len() > DEFAULT_MAX_FILE_BYTES {
+        return Err(format!(
+            "File exceeds maximum size of {DEFAULT_MAX_FILE_BYTES} bytes."
+        ));
+    }
+    fs::read(path).map_err(|error| format!("Failed to read PDF bytes: {error}"))
+}
+
+fn parse_ts_positive_page(value: &str) -> Option<u32> {
+    let value = value.trim_start();
+    let value = value.strip_prefix('+').unwrap_or(value);
+    let digits: String = value.chars().take_while(char::is_ascii_digit).collect();
+    (!digits.is_empty())
+        .then(|| digits.parse::<u32>().ok())
+        .flatten()
+        .filter(|page| *page > 0)
+}
+
+fn selected_pages(spec: &Option<PageSpecifier>) -> Result<Option<Vec<u32>>, String> {
+    let Some(spec) = spec else {
+        return Ok(None);
+    };
+    let mut pages = Vec::new();
+    match spec {
+        PageSpecifier::Pages(values) => pages.extend(values.iter().map(|page| page.0)),
+        PageSpecifier::Range(value) => {
+            for raw in value.split(',') {
+                let part = raw.trim();
+                if let Some((start, end)) = part.split_once('-') {
+                    let start = parse_ts_positive_page(start);
+                    let end = if end.trim().is_empty() {
+                        start.map(|page| page.saturating_add(10_000))
+                    } else {
+                        parse_ts_positive_page(end)
+                    };
+                    let (Some(start), Some(end)) = (start, end) else {
+                        return Err(format!("Invalid page range values: {part}"));
+                    };
+                    if start > end {
+                        return Err(format!("Invalid page range values: {part}"));
+                    }
+                    pages.extend(start..=end.min(start.saturating_add(10_000)));
+                } else {
+                    let Some(page) = parse_ts_positive_page(part) else {
+                        return Err(format!("Invalid page number: {part}"));
+                    };
+                    pages.push(page);
+                }
+                if pages.len() > MAX_SELECTED_PAGES {
+                    return Err("Page specification exceeds 10001 selected pages.".into());
+                }
+            }
+        }
+    }
+    pages.sort_unstable();
+    pages.dedup();
+    if pages.is_empty() {
+        return Err("Page specification resulted in an empty set of pages.".into());
+    }
+    Ok(Some(pages))
+}
+
+fn render_warnings(
+    invalid: &[u32],
+    truncated: &[u32],
+    num_pages: usize,
+    max_pages: usize,
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+    if !invalid.is_empty() {
+        warnings.push(format!(
+            "Requested pages {} exceed document page count {num_pages}.",
+            invalid
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if !truncated.is_empty() {
+        warnings.push(format!(
+            "Rendered first {max_pages} selected pages; skipped {} due to max_pages.",
+            truncated
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    warnings
+}
+
+pub fn render_pages(value: Value) -> Result<CallToolResult, rmcp::ErrorData> {
+    let args = parse_args(value)?;
+    let scale_value = args.scale.unwrap_or(f64::from(DEFAULT_RENDER_SCALE));
+    let scale = scale_value as f32;
+    let max_pages = args
+        .max_pages
+        .map_or(DEFAULT_MAX_RENDER_PAGES, |v| v as usize);
+    let max_pixels = args
+        .max_pixels_per_page
+        .unwrap_or(DEFAULT_MAX_RENDER_PIXELS);
+    let include_image = args.include_image.unwrap_or(true);
+    let mut results = Vec::with_capacity(args.sources.len());
+    let mut images = Vec::new();
+    let mut aggregate_bytes = 0usize;
+    let mut work_budget = RequestWorkBudget::default();
+
+    for source in &args.sources {
+        let source_label = source.label();
+        let image_base_index = images.len();
+        let output = (|| -> Result<(Value, Vec<ImagePart>, usize), String> {
+            let mut source_images = Vec::new();
+            let mut source_bytes = 0usize;
+            let materialized = materialize(source)?;
+            let document = RenderDocument::new(read_pdf(&materialized.path)?)
+                .map_err(|error| error.message)?;
+            let num_pages = document.page_count();
+            if num_pages == 0 {
+                return Err("PDF contains no pages.".into());
+            }
+            let requested = selected_pages(&source.pages)?.unwrap_or_else(|| vec![1]);
+            let valid: Vec<u32> = requested
+                .iter()
+                .copied()
+                .filter(|page| (*page as usize) <= num_pages)
+                .collect();
+            let invalid: Vec<u32> = requested
+                .iter()
+                .copied()
+                .filter(|page| (*page as usize) > num_pages)
+                .collect();
+            let pages_to_render = &valid[..valid.len().min(max_pages)];
+            let truncated = &valid[pages_to_render.len()..];
+            if pages_to_render.is_empty() {
+                return Err(format!(
+                    "No valid pages to render for source {}.",
+                    materialized.label
+                ));
+            }
+            let warnings = render_warnings(&invalid, truncated, num_pages, max_pages);
+            let mut rendered_pages = Vec::with_capacity(pages_to_render.len());
+            for page in pages_to_render {
+                let pixels = document
+                    .planned_render_pixel_count(*page as usize, scale)
+                    .map_err(|error| error.message)?;
+                work_budget.charge_page(pixels)?;
+                let rendered = document
+                    .render_page(
+                        *page as usize,
+                        scale,
+                        max_pixels,
+                        DEFAULT_MAX_RENDER_OUTPUT_BYTES,
+                    )
+                    .map_err(|error| error.message)?;
+                source_bytes = source_bytes
+                    .checked_add(rendered.png.len())
+                    .ok_or_else(|| "Rendered image byte count overflow.".to_string())?;
+                if aggregate_bytes
+                    .checked_add(source_bytes)
+                    .is_none_or(|total| total > MAX_AGGREGATE_IMAGE_BYTES)
+                {
+                    return Err(format!(
+                        "Rendered images exceed aggregate byte limit {MAX_AGGREGATE_IMAGE_BYTES}."
+                    ));
+                }
+                let image_content_index =
+                    include_image.then_some(image_base_index + source_images.len() + 1);
+                if include_image {
+                    source_images.push(ImagePart {
+                        data: base64::engine::general_purpose::STANDARD.encode(&rendered.png),
+                        mime_type: rendered.mime_type,
+                    });
+                }
+                let mut summary = json!({
+                    "page": rendered.page,
+                    "evidence_id": format!("page-{}-render-scale-{scale_value}", rendered.page),
+                    "width": rendered.width,
+                    "height": rendered.height,
+                    "scale": scale_value,
+                    "pixel_count": rendered.pixel_count,
+                    "byte_length": rendered.png.len(),
+                    "format": rendered.format,
+                    "mime_type": rendered.mime_type,
+                    "rotation": rendered.rotation,
+                    "provenance": rendered.provenance,
+                });
+                if let Some(index) = image_content_index {
+                    summary["image_content_index"] = json!(index);
+                }
+                rendered_pages.push(summary);
+            }
+            let mut result = json!({
+                "source": materialized.label,
+                "success": true,
+                "num_pages": num_pages,
+                "rendered_pages": rendered_pages,
+            });
+            if !warnings.is_empty() {
+                result["warnings"] = json!(warnings);
+            }
+            Ok((result, source_images, source_bytes))
+        })();
+        match output {
+            Ok((result, source_images, source_bytes)) => {
+                aggregate_bytes += source_bytes;
+                images.extend(source_images);
+                results.push(result);
+            }
+            Err(error) => {
+                results.push(json!({ "source": source_label, "success": false, "error": error }))
+            }
+        }
+    }
+
+    if results.iter().all(|result| result["success"] != true) {
+        let errors = results
+            .iter()
+            .filter_map(|result| result["error"].as_str())
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Ok(all_failed(format!(
+            "All PDF sources failed to render: {errors}"
+        )));
+    }
+    Ok(tool_result(
+        json!({
+            "profile": "page_render_evidence",
+            "render_options": {
+                "scale": scale_value,
+                "max_pages": max_pages,
+                "max_pixels_per_page": max_pixels,
+                "include_image": include_image,
+            },
+            "results": results,
+        }),
+        images,
+    ))
+}
+
+fn region_warnings(
+    invalid_pages: &[u32],
+    truncated_count: usize,
+    total_pages: usize,
+    max_regions: usize,
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+    if !invalid_pages.is_empty() {
+        let mut pages = invalid_pages.to_vec();
+        pages.sort_unstable();
+        pages.dedup();
+        warnings.push(format!(
+            "Requested region pages {} exceed document page count {total_pages}.",
+            pages
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if truncated_count > 0 {
+        warnings.push(format!(
+            "Cropped first {max_regions} valid regions; skipped {truncated_count} due to max_regions."
+        ));
+    }
+    warnings
+}
+
+fn bounding_box(value: &RegionBoundingBox) -> BoundingBox {
+    BoundingBox {
+        left: value.left,
+        bottom: value.bottom,
+        right: value.right,
+        top: value.top,
+    }
+}
+
+pub fn extract_regions(value: Value) -> Result<CallToolResult, rmcp::ErrorData> {
+    let args = parse_args(value)?;
+    if args
+        .sources
+        .iter()
+        .any(|source| source.regions.as_ref().is_none_or(Vec::is_empty))
+    {
+        return Ok(all_failed(
+            "pdf_evidence operation requires sources[].regions for extract_regions and analyze_regions."
+                .into(),
+        ));
+    }
+    let scale_value = args.scale.unwrap_or(f64::from(DEFAULT_RENDER_SCALE));
+    let scale = scale_value as f32;
+    let max_regions = args.max_regions.map_or(DEFAULT_MAX_REGIONS, |v| v as usize);
+    let max_pixels = args
+        .max_pixels_per_page
+        .unwrap_or(DEFAULT_MAX_RENDER_PIXELS);
+    let include_image = args.include_image.unwrap_or(true);
+    let mut results = Vec::with_capacity(args.sources.len());
+    let mut images = Vec::new();
+    let mut aggregate_bytes = 0usize;
+    let mut work_budget = RequestWorkBudget::default();
+
+    for source in &args.sources {
+        let source_label = source.label();
+        let image_base_index = images.len();
+        let output = (|| -> Result<(Value, Vec<ImagePart>, usize), String> {
+            let mut source_images = Vec::new();
+            let mut source_bytes = 0usize;
+            let materialized = materialize(source)?;
+            let document = RenderDocument::new(read_pdf(&materialized.path)?)
+                .map_err(|error| error.message)?;
+            let num_pages = document.page_count();
+            if num_pages == 0 {
+                return Err("PDF contains no pages.".into());
+            }
+            let requested = source.regions.as_ref().expect("regions checked");
+            let invalid_pages: Vec<u32> = requested
+                .iter()
+                .filter(|region| region.page as usize > num_pages)
+                .map(|region| region.page)
+                .collect();
+            let valid: Vec<(usize, &PdfEvidenceRegion)> = requested
+                .iter()
+                .enumerate()
+                .filter(|(_, region)| region.page as usize <= num_pages)
+                .collect();
+            let regions_to_crop = &valid[..valid.len().min(max_regions)];
+            if regions_to_crop.is_empty() {
+                return Err(format!(
+                    "No valid regions to crop for source {}.",
+                    materialized.label
+                ));
+            }
+            let warnings = region_warnings(
+                &invalid_pages,
+                valid.len() - regions_to_crop.len(),
+                num_pages,
+                max_regions,
+            );
+            let mut by_page: Vec<(u32, Vec<(usize, &PdfEvidenceRegion)>)> = Vec::new();
+            for (index, region) in regions_to_crop {
+                if let Some((_, regions)) =
+                    by_page.iter_mut().find(|(page, _)| *page == region.page)
+                {
+                    regions.push((*index, *region));
+                } else {
+                    by_page.push((region.page, vec![(*index, *region)]));
+                }
+            }
+            let mut cropped_regions = Vec::with_capacity(regions_to_crop.len());
+            for (page_number, page_regions) in by_page {
+                let pixels = document
+                    .planned_render_pixel_count(page_number as usize, scale)
+                    .map_err(|error| error.message)?;
+                work_budget.charge_page(pixels)?;
+                let rendered = document
+                    .render_page(
+                        page_number as usize,
+                        scale,
+                        max_pixels,
+                        DEFAULT_MAX_RENDER_OUTPUT_BYTES,
+                    )
+                    .map_err(|error| error.message)?;
+                for (source_index, region) in page_regions {
+                    work_budget.charge_region()?;
+                    // Public v3.0.14 compatibility: PDF.js applied the same
+                    // bottom-left formula to the rotated viewport dimensions
+                    // without transforming the requested PDF coordinates.
+                    let pixels = crop_pixels_for_bounding_box(
+                        rendered.width,
+                        rendered.height,
+                        rendered.scale,
+                        0,
+                        bounding_box(&region.bounding_box),
+                        region.padding.unwrap_or(0.0),
+                    )
+                    .map_err(|error| error.message)?;
+                    let png = crop_rendered_page_png_with_limit(
+                        &rendered.png,
+                        rendered.width,
+                        rendered.height,
+                        pixels,
+                        DEFAULT_MAX_RENDER_OUTPUT_BYTES,
+                    )
+                    .map_err(|error| error.message)?;
+                    source_bytes = source_bytes
+                        .checked_add(png.len())
+                        .ok_or_else(|| "Cropped image byte count overflow.".to_string())?;
+                    if aggregate_bytes
+                        .checked_add(source_bytes)
+                        .is_none_or(|total| total > MAX_AGGREGATE_IMAGE_BYTES)
+                    {
+                        return Err(format!(
+                            "Cropped images exceed aggregate byte limit {MAX_AGGREGATE_IMAGE_BYTES}."
+                        ));
+                    }
+                    let region_id = region
+                        .id
+                        .clone()
+                        .unwrap_or_else(|| format!("region-{}", source_index + 1));
+                    let image_content_index =
+                        include_image.then_some(image_base_index + source_images.len() + 1);
+                    if include_image {
+                        source_images.push(ImagePart {
+                            data: base64::engine::general_purpose::STANDARD.encode(&png),
+                            mime_type: "image/png",
+                        });
+                    }
+                    let mut summary = json!({
+                        "region_id": region_id,
+                        "page": page_number,
+                        "evidence_id": format!("page-{page_number}-{region_id}-crop-scale-{scale_value}"),
+                        "source_bounding_box": region.bounding_box,
+                        "crop_pixels": pixels,
+                        "scale": scale_value,
+                        "byte_length": png.len(),
+                        "format": "png",
+                        "mime_type": "image/png",
+                        "provenance": {
+                            "engine": rendered.provenance.engine,
+                            "renderer": rendered.provenance.renderer,
+                            "source": "region-crop",
+                            "page_render_evidence_id": format!("page-{page_number}-render-scale-{scale_value}"),
+                        },
+                    });
+                    if let Some(index) = image_content_index {
+                        summary["image_content_index"] = json!(index);
+                    }
+                    cropped_regions.push(summary);
+                }
+            }
+            let mut result = json!({
+                "source": materialized.label,
+                "success": true,
+                "num_pages": num_pages,
+                "regions": cropped_regions,
+            });
+            if !warnings.is_empty() {
+                result["warnings"] = json!(warnings);
+            }
+            Ok((result, source_images, source_bytes))
+        })();
+        match output {
+            Ok((result, source_images, source_bytes)) => {
+                aggregate_bytes += source_bytes;
+                images.extend(source_images);
+                results.push(result);
+            }
+            Err(error) => {
+                results.push(json!({ "source": source_label, "success": false, "error": error }))
+            }
+        }
+    }
+
+    if results.iter().all(|result| result["success"] != true) {
+        let errors = results
+            .iter()
+            .filter_map(|result| result["error"].as_str())
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Ok(all_failed(format!(
+            "All PDF sources failed region extraction: {errors}"
+        )));
+    }
+    Ok(tool_result(
+        json!({
+            "profile": "region_crop_evidence",
+            "crop_options": {
+                "scale": scale_value,
+                "max_regions": max_regions,
+                "max_pixels_per_page": max_pixels,
+                "include_image": include_image,
+            },
+            "results": results,
+        }),
+        images,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_path() -> String {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../test/fixtures/differential/v3014-behavior-v1.pdf")
+            .canonicalize()
+            .expect("canonical fixture")
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    #[test]
+    fn page_selection_matches_ts_sort_dedupe_and_prefix_parse() {
+        assert_eq!(
+            selected_pages(&Some(PageSpecifier::Range("3,1,1,2x".into()))).unwrap(),
+            Some(vec![1, 2, 3])
+        );
+        assert_eq!(
+            selected_pages(&Some(PageSpecifier::Range("2-4".into()))).unwrap(),
+            Some(vec![2, 3, 4])
+        );
+    }
+
+    #[test]
+    fn warning_text_matches_v3014_contract() {
+        assert_eq!(
+            render_warnings(&[9], &[3, 4], 2, 2),
+            vec![
+                "Requested pages 9 exceed document page count 2.",
+                "Rendered first 2 selected pages; skipped 3, 4 due to max_pages.",
+            ]
+        );
+        assert_eq!(
+            region_warnings(&[9, 9], 2, 3, 1),
+            vec![
+                "Requested region pages 9 exceed document page count 3.",
+                "Cropped first 1 valid regions; skipped 2 due to max_regions.",
+            ]
+        );
+    }
+
+    #[test]
+    fn public_render_envelope_has_raw_image_part_and_no_inline_data() {
+        let result = render_pages(json!({
+            "operation": "render_page",
+            "sources": [{"path": fixture_path(), "pages": [1]}],
+            "scale": 1,
+            "max_pages": 1,
+        }))
+        .expect("render result");
+        let encoded = serde_json::to_value(result).expect("serialize result");
+        assert_eq!(encoded["isError"], false);
+        assert_eq!(encoded["content"][0]["type"], "text");
+        assert_eq!(encoded["content"][1]["type"], "image");
+        assert_eq!(encoded["content"][1]["mimeType"], "image/png");
+        let image = encoded["content"][1]["data"].as_str().expect("image data");
+        assert!(!image.starts_with("data:"));
+        let payload: Value = serde_json::from_str(
+            encoded["content"][0]["text"]
+                .as_str()
+                .expect("text payload"),
+        )
+        .expect("parse text payload");
+        assert_eq!(payload["profile"], "page_render_evidence");
+        assert_eq!(payload["results"][0]["rendered_pages"][0]["page"], 1);
+        assert_eq!(
+            payload["results"][0]["rendered_pages"][0]["image_content_index"],
+            1
+        );
+        assert!(payload["results"][0]["rendered_pages"][0]
+            .get("data")
+            .is_none());
+    }
+
+    #[test]
+    fn render_selection_and_region_group_order_match_v3014() {
+        let render = render_pages(json!({
+            "operation": "render_page",
+            "sources": [{"path": fixture_path(), "pages": [2, 99, 1, 2]}],
+            "scale": 1,
+            "max_pages": 1,
+            "include_image": false,
+        }))
+        .expect("render result");
+        let payload = render.structured_content.expect("structured render");
+        assert_eq!(payload["results"][0]["rendered_pages"][0]["page"], 1);
+        assert_eq!(
+            payload["results"][0]["warnings"],
+            json!([
+                "Requested pages 99 exceed document page count 3.",
+                "Rendered first 1 selected pages; skipped 2 due to max_pages."
+            ])
+        );
+        assert_eq!(render.content.len(), 1);
+        assert!(payload["results"][0]["rendered_pages"][0]
+            .get("image_content_index")
+            .is_none());
+
+        let crops = extract_regions(json!({
+            "operation": "extract_regions",
+            "sources": [{
+                "path": fixture_path(),
+                "regions": [
+                    {"id": "A", "page": 2, "bounding_box": {"left": 0, "bottom": 0, "right": 20, "top": 20}},
+                    {"page": 1, "bounding_box": {"left": 0, "bottom": 0, "right": 20, "top": 20}},
+                    {"id": "C", "page": 2, "bounding_box": {"left": 20, "bottom": 20, "right": 40, "top": 40}}
+                ]
+            }],
+            "scale": 1,
+            "include_image": false,
+        }))
+        .expect("crop result");
+        let payload = crops.structured_content.expect("structured crops");
+        let ids = payload["results"][0]["regions"]
+            .as_array()
+            .expect("regions")
+            .iter()
+            .map(|region| region["region_id"].as_str().expect("region id"))
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec!["A", "C", "region-2"]);
+        assert_eq!(crops.content.len(), 1);
+    }
+
+    #[test]
+    fn late_source_failure_discards_staged_images_and_preserves_global_indexes() {
+        let path = fixture_path();
+        let crops = extract_regions(json!({
+            "operation": "extract_regions",
+            "sources": [
+                {
+                    "path": path,
+                    "regions": [
+                        {"id": "staged", "page": 1, "bounding_box": {"left": 0, "bottom": 0, "right": 20, "top": 20}},
+                        {"id": "late-failure", "page": 1, "bounding_box": {"left": 10, "bottom": 10, "right": 10, "top": 20}}
+                    ]
+                },
+                {
+                    "path": fixture_path(),
+                    "regions": [
+                        {"id": "survivor", "page": 1, "bounding_box": {"left": 0, "bottom": 0, "right": 20, "top": 20}}
+                    ]
+                }
+            ],
+            "scale": 1,
+        }))
+        .expect("mixed crop result");
+        let payload = crops.structured_content.expect("structured crops");
+        assert_eq!(payload["results"][0]["success"], false);
+        assert_eq!(payload["results"][1]["success"], true);
+        assert_eq!(
+            payload["results"][1]["regions"][0]["image_content_index"],
+            1
+        );
+        assert_eq!(crops.content.len(), 2);
+    }
+
+    #[test]
+    fn request_work_budget_is_charged_before_work_and_never_rolls_back() {
+        let mut budget = RequestWorkBudget::default();
+        for _ in 0..MAX_REQUEST_RENDERED_PAGES {
+            budget.charge_page(1).expect("page within bound");
+        }
+        assert!(budget.charge_page(1).unwrap_err().contains("pages"));
+        assert_eq!(budget.rendered_pages, MAX_REQUEST_RENDERED_PAGES);
+
+        let mut pixel_budget = RequestWorkBudget::default();
+        pixel_budget
+            .charge_page(MAX_REQUEST_RENDER_PIXELS)
+            .expect("pixels at bound");
+        assert!(pixel_budget.charge_page(1).unwrap_err().contains("pixels"));
+        assert_eq!(pixel_budget.render_pixels, MAX_REQUEST_RENDER_PIXELS);
+
+        let mut region_budget = RequestWorkBudget::default();
+        for _ in 0..MAX_REQUEST_REGIONS {
+            region_budget.charge_region().expect("region within bound");
+        }
+        assert!(region_budget
+            .charge_region()
+            .unwrap_err()
+            .contains("regions"));
+        assert_eq!(region_budget.regions, MAX_REQUEST_REGIONS);
+    }
+
+    #[test]
+    fn source_count_is_rejected_before_any_io_or_render_work() {
+        let sources = (0..=MAX_SOURCES_PER_REQUEST)
+            .map(|index| json!({"path": format!("missing-{index}.pdf")}))
+            .collect::<Vec<_>>();
+        let error = render_pages(json!({
+            "operation": "render_page",
+            "sources": sources,
+        }))
+        .expect_err("too many sources");
+        assert!(error.message.contains("at most 32 sources"));
+    }
+}

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -64,21 +64,23 @@
     },
     "pdf_evidence": {
       "inspect": "PARTIAL",
-      "render_page": "FAIL_CLOSED",
-      "extract_regions": "FAIL_CLOSED",
+      "render_page": "PARTIAL",
+      "extract_regions": "PARTIAL",
       "ocr_pages": "FAIL_CLOSED",
       "analyze_regions": "FAIL_CLOSED"
     }
   },
   "claimedForDifferential": [
     "exact 10-case immutable TS v3.0.14 behavior subset: full text, page selection/order/duplicates, metadata, literal search, case sensitivity, whole word, Unicode, UTF-16 offsets, missing and malformed inputs, and mixed-source partial success",
+    "exact 7-case immutable TS v3.0.14 render/crop semantic subset over stdio: defaults, page selection and warnings, region ordering, padding and fractional bounds, rotated pages, mixed-source partial success, all-source failure, MCP image indexing, and truthful Hayro provenance; exact pdf.js pixels and antialiasing are not claimed",
     "DNS-pinned URL fetch: one resolution per redirect hop, reject mixed public/non-public answers, disable ambient proxies, and revalidate every redirect; still PARTIAL because resolver timeout and TLS-SNI fixtures remain open",
     "auto off when include_* keys are present"
   ],
   "explicitlyNotClaimed": [
     "complete TS 3.0.14 semantic parity outside the immutable 10-case subset",
-    "geometry/bboxes",
-    "render/crop/OCR/analyze success path",
+    "text/search geometry, geometry-perfect pdf.js boxes, and general bounding-box parity",
+    "render/crop semantic parity outside the immutable 7-case subset, including exact pdf.js pixels and antialiasing",
+    "OCR/analyze success path",
     "COS outline/annotations/forms",
     "cross-platform npm native binary",
     "npm library exports for pure-Rust",

--- a/scripts/differential/capture-v3014-visual-oracle.ts
+++ b/scripts/differential/capture-v3014-visual-oracle.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env bun
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDir, '../..');
+const corpusPath = join(scriptDir, 'fixtures/v3014-visual-corpus.json');
+const oraclePath = join(scriptDir, 'fixtures/v3014-visual-oracle.json');
+const fixtureDir = join(repoRoot, 'test/fixtures/differential');
+const runnerSource = join(scriptDir, 'v3014-visual-baseline-runner.ts');
+const refresh = process.argv.includes('--refresh');
+const oracle = JSON.parse(readFileSync(oraclePath, 'utf8')) as {
+  baseline: { tag: string; commit: string };
+  expectations: Record<string, unknown>;
+};
+
+function run(command: string, args: string[], cwd: string, capture = false): string {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: capture ? ['ignore', 'pipe', 'inherit'] : 'inherit',
+  });
+  if (result.status !== 0) throw new Error(`${command} ${args.join(' ')} failed`);
+  return result.stdout ?? '';
+}
+
+run('bun', ['scripts/differential/generate-v3014-visual-fixtures.ts'], repoRoot);
+const resolved = run('git', ['rev-list', '-n', '1', oracle.baseline.tag], repoRoot, true).trim();
+if (resolved !== oracle.baseline.commit) {
+  throw new Error(`${oracle.baseline.tag} moved: expected ${oracle.baseline.commit}, got ${resolved}`);
+}
+
+const worktree = mkdtempSync(join(tmpdir(), 'pdf-reader-v3014-visual-oracle-'));
+try {
+  run('git', ['worktree', 'add', '--detach', worktree, oracle.baseline.commit], repoRoot);
+  run('bun', ['install', '--frozen-lockfile'], worktree);
+  const runner = join(worktree, 'v3014-visual-baseline-runner.ts');
+  writeFileSync(runner, readFileSync(runnerSource));
+  const stdout = run('bun', [runner, corpusPath, fixtureDir], worktree, true);
+  const expectations = JSON.parse(stdout) as Record<string, unknown>;
+  if (refresh) {
+    writeFileSync(oraclePath, `${JSON.stringify({ ...oracle, expectations }, null, 2)}\n`);
+    console.error(`refreshed ${oraclePath}`);
+  } else if (JSON.stringify(expectations) !== JSON.stringify(oracle.expectations)) {
+    throw new Error('stored v3.0.14 visual oracle differs from replayed baseline');
+  } else {
+    console.log(`v3.0.14 visual oracle replay: OK (${Object.keys(expectations).length} cases)`);
+  }
+} finally {
+  spawnSync('git', ['worktree', 'remove', '--force', worktree], { cwd: repoRoot, stdio: 'ignore' });
+  rmSync(worktree, { recursive: true, force: true });
+}

--- a/scripts/differential/check-v3014-visual-differential.ts
+++ b/scripts/differential/check-v3014-visual-differential.ts
@@ -1,0 +1,327 @@
+#!/usr/bin/env bun
+
+import { spawn, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PNG } from 'pngjs';
+
+type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
+type Content = { type: string; text?: string; data?: string; mimeType?: string };
+type ToolResult = { content: Content[]; isError?: boolean };
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDir, '../..');
+const fixtureDir = join(repoRoot, 'test/fixtures/differential');
+const corpusPath = join(scriptDir, 'fixtures/v3014-visual-corpus.json');
+const oraclePath = join(scriptDir, 'fixtures/v3014-visual-oracle.json');
+const fixtureManifestPath = join(scriptDir, 'fixtures/v3014-visual-fixtures.json');
+const serverPath = join(repoRoot, 'target/release/pdf-reader-mcp-server');
+const outputFlag = process.argv.indexOf('--output');
+const outputPath = outputFlag >= 0 ? process.argv[outputFlag + 1] : undefined;
+
+const corpus = JSON.parse(readFileSync(corpusPath, 'utf8')) as {
+  cases: Array<{ id: string; input: Record<string, unknown> }>;
+};
+const oracle = JSON.parse(readFileSync(oraclePath, 'utf8')) as {
+  baseline: {
+    tag: string;
+    commit: string;
+    tree: string;
+    bunLockSha256: string;
+    entrypointSha256: Record<string, string>;
+  };
+  expectations: Record<string, Json>;
+};
+const fixtureManifest = JSON.parse(readFileSync(fixtureManifestPath, 'utf8')) as {
+  fixtures: Array<{ path: string; bytes: number; sha256: string }>;
+};
+const sha256 = (bytes: Uint8Array | string): string =>
+  createHash('sha256').update(bytes).digest('hex');
+const git = (...args: string[]): Buffer => {
+  const result = spawnSync('git', args, { cwd: repoRoot });
+  if (result.status !== 0) throw new Error(result.stderr.toString());
+  return result.stdout;
+};
+
+function verifyAuthority(): Record<string, string> {
+  const commit = git('rev-list', '-n', '1', oracle.baseline.tag).toString().trim();
+  if (commit !== oracle.baseline.commit) throw new Error('v3.0.14 visual baseline tag moved');
+  const tree = git('rev-parse', `${commit}^{tree}`).toString().trim();
+  if (tree !== oracle.baseline.tree) throw new Error('v3.0.14 visual baseline tree mismatch');
+  if (sha256(git('show', `${commit}:bun.lock`)) !== oracle.baseline.bunLockSha256) {
+    throw new Error('v3.0.14 visual baseline lock mismatch');
+  }
+  for (const [path, expected] of Object.entries(oracle.baseline.entrypointSha256)) {
+    if (sha256(git('show', `${commit}:${path}`)) !== expected) {
+      throw new Error(`v3.0.14 visual baseline entrypoint mismatch: ${path}`);
+    }
+  }
+  for (const fixture of fixtureManifest.fixtures) {
+    const path = join(repoRoot, fixture.path);
+    const bytes = readFileSync(path);
+    if (bytes.length !== fixture.bytes || sha256(bytes) !== fixture.sha256) {
+      throw new Error(`visual fixture mismatch: ${fixture.path}`);
+    }
+  }
+  const ids = corpus.cases.map((entry) => entry.id);
+  if (ids.length !== 7 || new Set(ids).size !== ids.length) {
+    throw new Error(`visual corpus must contain 7 unique cases (got ${ids.length})`);
+  }
+  if (JSON.stringify(ids.sort()) !== JSON.stringify(Object.keys(oracle.expectations).sort())) {
+    throw new Error('visual corpus and oracle IDs differ');
+  }
+  return {
+    baselineCommit: commit,
+    baselineTree: tree,
+    corpusSha256: sha256(readFileSync(corpusPath)),
+    oracleSha256: sha256(readFileSync(oraclePath)),
+    fixtureManifestSha256: sha256(readFileSync(fixtureManifestPath)),
+  };
+}
+
+function materialize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(materialize);
+  if (value && typeof value === 'object') {
+    const output: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      output[key === 'fixture' ? 'path' : key] =
+        key === 'fixture' && typeof entry === 'string' ? join(fixtureDir, entry) : materialize(entry);
+    }
+    return output;
+  }
+  return value;
+}
+
+function stable(value: Json): Json {
+  if (Array.isArray(value)) return value.map(stable);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, stable(entry)])
+    );
+  }
+  return value;
+}
+
+function errorCategory(message: string): string {
+  const lower = message.toLowerCase();
+  if (lower.includes('right > left') || lower.includes('top > bottom')) {
+    return 'invalid_bounding_box';
+  }
+  if (
+    lower.includes('not found') ||
+    lower.includes('no such file') ||
+    lower.includes('unable to access')
+  ) {
+    return 'file_not_found';
+  }
+  return 'unknown_error';
+}
+
+function imageFacts(content: Content): Record<string, Json> {
+  const bytes = Buffer.from(content.data ?? '', 'base64');
+  const png = PNG.sync.read(bytes);
+  const sample = (x: number, y: number): number[] => {
+    const offset = (y * png.width + x) * 4;
+    return Array.from(png.data.subarray(offset, offset + 4));
+  };
+  return {
+    mime_type: content.mimeType ?? null,
+    raw_base64: !(content.data ?? '').startsWith('data:'),
+    png_signature: bytes.subarray(0, 8).equals(Buffer.from('\x89PNG\r\n\x1a\n', 'binary')),
+    width: png.width,
+    height: png.height,
+    byte_length: bytes.length,
+    samples: [
+      sample(Math.floor(png.width / 4), Math.floor(png.height / 4)),
+      sample(Math.floor((png.width * 3) / 4), Math.floor(png.height / 4)),
+      sample(Math.floor(png.width / 4), Math.floor((png.height * 3) / 4)),
+      sample(Math.floor((png.width * 3) / 4), Math.floor((png.height * 3) / 4)),
+    ],
+  } as Record<string, Json>;
+}
+
+function canonicalize(result: ToolResult): Json {
+  if (result.isError) {
+    return {
+      outcome: 'error',
+      category: errorCategory(result.content[0]?.text ?? ''),
+    };
+  }
+  const payload = JSON.parse(result.content[0]?.text ?? '{}') as Record<string, unknown>;
+  const images = result.content.filter((content) => content.type === 'image').map(imageFacts);
+  const results = ((payload.results ?? []) as Array<Record<string, unknown>>).map((source) => {
+    if (!source.success) {
+      return {
+        source: basename(String(source.source ?? '')),
+        success: false,
+        category: errorCategory(String(source.error ?? '')),
+      };
+    }
+    const output: Record<string, unknown> = {
+      source: basename(String(source.source ?? '')),
+      success: true,
+      num_pages: source.num_pages,
+      warnings: source.warnings ?? [],
+    };
+    if (Array.isArray(source.rendered_pages)) {
+      output.rendered_pages = source.rendered_pages.map((page: Record<string, unknown>) => {
+        const provenance = page.provenance as Record<string, unknown>;
+        if (provenance?.engine !== 'hayro' || provenance?.renderer !== 'hayro/vello_cpu') {
+          throw new Error('Rust render provenance is not truthful');
+        }
+        const index = page.image_content_index as number | undefined;
+        const image = index === undefined ? undefined : images[index - 1];
+        const facts = image
+          ? {
+              ...image,
+              byte_length_consistent: image.byte_length === page.byte_length,
+              byte_length: undefined,
+            }
+          : null;
+        return {
+          page: page.page,
+          evidence_id: page.evidence_id,
+          width: page.width,
+          height: page.height,
+          scale: page.scale,
+          pixel_count: page.pixel_count,
+          format: page.format,
+          mime_type: page.mime_type,
+          rotation: page.rotation,
+          provenance_source: provenance.source,
+          image_content_index: index ?? null,
+          inline_data_absent: !('data' in page),
+          image: facts,
+        };
+      });
+    }
+    if (Array.isArray(source.regions)) {
+      output.regions = source.regions.map((region: Record<string, unknown>) => {
+        const provenance = region.provenance as Record<string, unknown>;
+        if (provenance?.engine !== 'hayro' || provenance?.renderer !== 'hayro/vello_cpu') {
+          throw new Error('Rust crop provenance is not truthful');
+        }
+        const index = region.image_content_index as number | undefined;
+        const image = index === undefined ? undefined : images[index - 1];
+        const facts = image
+          ? {
+              ...image,
+              byte_length_consistent: image.byte_length === region.byte_length,
+              byte_length: undefined,
+            }
+          : null;
+        return {
+          region_id: region.region_id,
+          page: region.page,
+          evidence_id: region.evidence_id,
+          source_bounding_box: region.source_bounding_box,
+          crop_pixels: region.crop_pixels,
+          scale: region.scale,
+          format: region.format,
+          mime_type: region.mime_type,
+          provenance_source: provenance.source,
+          page_render_evidence_id: provenance.page_render_evidence_id,
+          image_content_index: index ?? null,
+          inline_data_absent: !('data' in region),
+          image: facts,
+        };
+      });
+    }
+    return output;
+  });
+  return {
+    outcome: 'success',
+    profile: (payload.profile ?? null) as Json,
+    options: (payload.render_options ?? payload.crop_options ?? null) as Json,
+    content_count: result.content.length,
+    results: results as Json,
+  };
+}
+
+async function main() {
+  if (!existsSync(serverPath)) throw new Error(`missing Rust server: ${serverPath}`);
+  const authority = verifyAuthority();
+  const child = spawn(serverPath, [], {
+    cwd: repoRoot,
+    stdio: ['pipe', 'pipe', 'inherit'],
+    env: { ...process.env, PDF_READER_MCP_TRANSPORT: '', MCP_TRANSPORT: '' },
+  });
+  let buffer = '';
+  const pending = new Map<number, (value: Record<string, unknown>) => void>();
+  child.stdout.on('data', (chunk: Buffer) => {
+    buffer += chunk.toString();
+    while (buffer.includes('\n')) {
+      const index = buffer.indexOf('\n');
+      const line = buffer.slice(0, index).trim();
+      buffer = buffer.slice(index + 1);
+      if (!line) continue;
+      const response = JSON.parse(line) as Record<string, unknown>;
+      const id = Number(response.id);
+      pending.get(id)?.(response);
+      pending.delete(id);
+    }
+  });
+  const request = (id: number, method: string, params: unknown) =>
+    new Promise<Record<string, unknown>>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`Rust MCP request ${id} timed out`));
+      }, 30_000);
+      pending.set(id, (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      });
+      child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`);
+    });
+
+  try {
+    await request(1, 'initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'visual-differential', version: '1' },
+    });
+    child.stdin.write(
+      `${JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })}\n`
+    );
+    const observations: Record<string, Json> = {};
+    const failures: Array<{ id: string; expected: Json; actual: Json }> = [];
+    for (const [index, entry] of corpus.cases.entries()) {
+      const response = await request(index + 10, 'tools/call', {
+        name: 'pdf_evidence',
+        arguments: materialize(entry.input),
+      });
+      if (response.error) throw new Error(`Rust MCP error for ${entry.id}: ${JSON.stringify(response.error)}`);
+      const actual = stable(canonicalize(response.result as ToolResult));
+      const expected = stable(oracle.expectations[entry.id]!);
+      observations[entry.id] = actual;
+      if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+        failures.push({ id: entry.id, expected, actual });
+      }
+    }
+    const report = {
+      schemaVersion: 1,
+      profile: 'pdf_reader_v3014_visual_result',
+      candidateSha:
+        process.env.CANDIDATE_SHA ?? git('rev-parse', 'HEAD').toString().trim(),
+      ...authority,
+      caseCount: corpus.cases.length,
+      passed: corpus.cases.length - failures.length,
+      skipped: 0,
+      pass: failures.length === 0,
+      observations,
+      failures,
+    };
+    const serialized = `${JSON.stringify(report, null, 2)}\n`;
+    if (outputPath) await Bun.write(outputPath, serialized);
+    console.log(serialized.trimEnd());
+    if (failures.length > 0) process.exitCode = 1;
+  } finally {
+    child.kill('SIGTERM');
+  }
+}
+
+await main();

--- a/scripts/differential/fixtures/v3014-visual-corpus.json
+++ b/scripts/differential/fixtures/v3014-visual-corpus.json
@@ -1,0 +1,112 @@
+{
+  "schemaVersion": 1,
+  "profile": "pdf_reader_v3014_visual_corpus",
+  "cases": [
+    {
+      "id": "render-default-page-one",
+      "input": {
+        "operation": "render_page",
+        "sources": [{ "fixture": "v3014-visual-v1.pdf" }]
+      }
+    },
+    {
+      "id": "render-selection-warnings-no-image",
+      "input": {
+        "operation": "render_page",
+        "sources": [{ "fixture": "v3014-visual-v1.pdf", "pages": [2, 99, 1, 2] }],
+        "scale": 1,
+        "max_pages": 1,
+        "include_image": false
+      }
+    },
+    {
+      "id": "crop-order-padding-fractional",
+      "input": {
+        "operation": "extract_regions",
+        "sources": [
+          {
+            "fixture": "v3014-visual-v1.pdf",
+            "regions": [
+              {
+                "id": "A",
+                "page": 2,
+                "bounding_box": { "left": 0, "bottom": 0, "right": 20, "top": 30 },
+                "padding": 2
+              },
+              {
+                "page": 1,
+                "bounding_box": { "left": 0, "bottom": 0, "right": 30, "top": 20 },
+                "padding": 3
+              },
+              {
+                "id": "C",
+                "page": 2,
+                "bounding_box": { "left": 10.2, "bottom": 30.4, "right": 40.6, "top": 60.8 }
+              }
+            ]
+          }
+        ],
+        "scale": 1
+      }
+    },
+    {
+      "id": "render-rotated-page",
+      "input": {
+        "operation": "render_page",
+        "sources": [{ "fixture": "v3014-visual-v1.pdf", "pages": [3] }],
+        "scale": 1,
+        "max_pages": 1
+      }
+    },
+    {
+      "id": "crop-rotated-v3014-formula",
+      "input": {
+        "operation": "extract_regions",
+        "sources": [
+          {
+            "fixture": "v3014-visual-v1.pdf",
+            "regions": [
+              {
+                "id": "rotated",
+                "page": 3,
+                "bounding_box": { "left": 0, "bottom": 0, "right": 60, "top": 80 }
+              }
+            ]
+          }
+        ],
+        "scale": 1
+      }
+    },
+    {
+      "id": "render-mixed-source-partial",
+      "input": {
+        "operation": "render_page",
+        "sources": [
+          { "fixture": "missing-visual.pdf", "pages": [1] },
+          { "fixture": "v3014-visual-v1.pdf", "pages": [2] }
+        ],
+        "scale": 1,
+        "max_pages": 1
+      }
+    },
+    {
+      "id": "crop-degenerate-all-fail",
+      "input": {
+        "operation": "extract_regions",
+        "sources": [
+          {
+            "fixture": "v3014-visual-v1.pdf",
+            "regions": [
+              {
+                "id": "bad",
+                "page": 1,
+                "bounding_box": { "left": 10, "bottom": 10, "right": 10, "top": 20 }
+              }
+            ]
+          }
+        ],
+        "scale": 1
+      }
+    }
+  ]
+}

--- a/scripts/differential/fixtures/v3014-visual-fixtures.json
+++ b/scripts/differential/fixtures/v3014-visual-fixtures.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "generator": "scripts/differential/generate-v3014-visual-fixtures.ts",
+  "fixtures": [
+    {
+      "path": "test/fixtures/differential/v3014-visual-v1.pdf",
+      "bytes": 1175,
+      "sha256": "3e2d9b9d96461359b489c76facafd00eea7bd18f03b6aae23c333340e892e89a"
+    }
+  ]
+}

--- a/scripts/differential/fixtures/v3014-visual-oracle.json
+++ b/scripts/differential/fixtures/v3014-visual-oracle.json
@@ -1,0 +1,552 @@
+{
+  "schemaVersion": 1,
+  "profile": "pdf_reader_v3014_visual_oracle",
+  "baseline": {
+    "tag": "v3.0.14",
+    "commit": "92651c79c6ce8d10dfa3c76332176c26f222bd78",
+    "tree": "f6fc4e58f692736c8bd6aaf9d4c9cfa806d113ab",
+    "bunLockSha256": "07f469c8200fb82c9092cef178c1bdd67f8cf61fe6c027303665395eede9dd45",
+    "entrypointSha256": {
+      "src/handlers/pdfEvidence.ts": "64f54e17c30de61c93ea2083d59b6463def08fcd08e100489e10380d72db1228",
+      "src/handlers/renderPage.ts": "7c0b57658eca56ec995c376a4a20455cc967f13a807a1194a1d746d23db89e7a",
+      "src/handlers/extractRegions.ts": "a125e4fa3b9c3aee1087f7e60a5092ce2354d918d2b1d01bc70f222d42219c33",
+      "src/pdf/renderer.ts": "29cf9917feaa470d3e3dafea5b432439fe0450eaee90b350458fb1e41bfe75a8",
+      "src/pdf/regions.ts": "f7bc3c939e57fd33260d1bf5d8210c0bde0f7cb3ea756c4912b371c1997e4f91"
+    }
+  },
+  "normalization": {
+    "png": "dimensions, signature, interior RGBA samples, and self-consistent byte length; encoded PNG bytes intentionally differ by renderer",
+    "provenance": "source role is compared; producer identity must be truthful and is checked independently"
+  },
+  "expectations": {
+    "render-default-page-one": {
+      "outcome": "success",
+      "profile": "page_render_evidence",
+      "options": {
+        "scale": 2,
+        "max_pages": 5,
+        "max_pixels_per_page": 16000000,
+        "include_image": true
+      },
+      "content_count": 2,
+      "results": [
+        {
+          "source": "v3014-visual-v1.pdf",
+          "success": true,
+          "num_pages": 3,
+          "warnings": [],
+          "rendered_pages": [
+            {
+              "page": 1,
+              "evidence_id": "page-1-render-scale-2",
+              "width": 240,
+              "height": 160,
+              "scale": 2,
+              "pixel_count": 38400,
+              "format": "png",
+              "mime_type": "image/png",
+              "rotation": 0,
+              "provenance_source": "page-render",
+              "image_content_index": 1,
+              "inline_data_absent": true,
+              "image": {
+                "mime_type": "image/png",
+                "raw_base64": true,
+                "png_signature": true,
+                "width": 240,
+                "height": 160,
+                "samples": [
+                  [
+                    0,
+                    0,
+                    255,
+                    255
+                  ],
+                  [
+                    255,
+                    255,
+                    0,
+                    255
+                  ],
+                  [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  [
+                    0,
+                    255,
+                    0,
+                    255
+                  ]
+                ],
+                "byte_length_consistent": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "render-selection-warnings-no-image": {
+      "outcome": "success",
+      "profile": "page_render_evidence",
+      "options": {
+        "scale": 1,
+        "max_pages": 1,
+        "max_pixels_per_page": 16000000,
+        "include_image": false
+      },
+      "content_count": 1,
+      "results": [
+        {
+          "source": "v3014-visual-v1.pdf",
+          "success": true,
+          "num_pages": 3,
+          "warnings": [
+            "Requested pages 99 exceed document page count 3.",
+            "Rendered first 1 selected pages; skipped 2 due to max_pages."
+          ],
+          "rendered_pages": [
+            {
+              "page": 1,
+              "evidence_id": "page-1-render-scale-1",
+              "width": 120,
+              "height": 80,
+              "scale": 1,
+              "pixel_count": 9600,
+              "format": "png",
+              "mime_type": "image/png",
+              "rotation": 0,
+              "provenance_source": "page-render",
+              "image_content_index": null,
+              "inline_data_absent": true,
+              "image": null
+            }
+          ]
+        }
+      ]
+    },
+    "crop-order-padding-fractional": {
+      "outcome": "success",
+      "profile": "region_crop_evidence",
+      "options": {
+        "scale": 1,
+        "max_regions": 20,
+        "max_pixels_per_page": 16000000,
+        "include_image": true
+      },
+      "content_count": 4,
+      "results": [
+        {
+          "source": "v3014-visual-v1.pdf",
+          "success": true,
+          "num_pages": 3,
+          "warnings": [],
+          "regions": [
+            {
+              "region_id": "A",
+              "page": 2,
+              "evidence_id": "page-2-A-crop-scale-1",
+              "source_bounding_box": {
+                "left": 0,
+                "bottom": 0,
+                "right": 20,
+                "top": 30
+              },
+              "crop_pixels": {
+                "left": 0,
+                "top": 88,
+                "width": 22,
+                "height": 32
+              },
+              "scale": 1,
+              "format": "png",
+              "mime_type": "image/png",
+              "provenance_source": "region-crop",
+              "page_render_evidence_id": "page-2-render-scale-1",
+              "image_content_index": 1,
+              "inline_data_absent": true,
+              "image": {
+                "mime_type": "image/png",
+                "raw_base64": true,
+                "png_signature": true,
+                "width": 22,
+                "height": 32,
+                "samples": [
+                  [
+                    0,
+                    204,
+                    204,
+                    255
+                  ],
+                  [
+                    0,
+                    204,
+                    204,
+                    255
+                  ],
+                  [
+                    0,
+                    204,
+                    204,
+                    255
+                  ],
+                  [
+                    0,
+                    204,
+                    204,
+                    255
+                  ]
+                ],
+                "byte_length_consistent": true
+              }
+            },
+            {
+              "region_id": "C",
+              "page": 2,
+              "evidence_id": "page-2-C-crop-scale-1",
+              "source_bounding_box": {
+                "left": 10.2,
+                "bottom": 30.4,
+                "right": 40.6,
+                "top": 60.8
+              },
+              "crop_pixels": {
+                "left": 10,
+                "top": 59,
+                "width": 31,
+                "height": 31
+              },
+              "scale": 1,
+              "format": "png",
+              "mime_type": "image/png",
+              "provenance_source": "region-crop",
+              "page_render_evidence_id": "page-2-render-scale-1",
+              "image_content_index": 2,
+              "inline_data_absent": true,
+              "image": {
+                "mime_type": "image/png",
+                "raw_base64": true,
+                "png_signature": true,
+                "width": 31,
+                "height": 31,
+                "samples": [
+                  [
+                    0,
+                    204,
+                    204,
+                    255
+                  ],
+                  [
+                    0,
+                    204,
+                    204,
+                    255
+                  ],
+                  [
+                    0,
+                    204,
+                    204,
+                    255
+                  ],
+                  [
+                    0,
+                    204,
+                    204,
+                    255
+                  ]
+                ],
+                "byte_length_consistent": true
+              }
+            },
+            {
+              "region_id": "region-2",
+              "page": 1,
+              "evidence_id": "page-1-region-2-crop-scale-1",
+              "source_bounding_box": {
+                "left": 0,
+                "bottom": 0,
+                "right": 30,
+                "top": 20
+              },
+              "crop_pixels": {
+                "left": 0,
+                "top": 57,
+                "width": 33,
+                "height": 23
+              },
+              "scale": 1,
+              "format": "png",
+              "mime_type": "image/png",
+              "provenance_source": "region-crop",
+              "page_render_evidence_id": "page-1-render-scale-1",
+              "image_content_index": 3,
+              "inline_data_absent": true,
+              "image": {
+                "mime_type": "image/png",
+                "raw_base64": true,
+                "png_signature": true,
+                "width": 33,
+                "height": 23,
+                "samples": [
+                  [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  [
+                    255,
+                    0,
+                    0,
+                    255
+                  ],
+                  [
+                    255,
+                    0,
+                    0,
+                    255
+                  ]
+                ],
+                "byte_length_consistent": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "render-rotated-page": {
+      "outcome": "success",
+      "profile": "page_render_evidence",
+      "options": {
+        "scale": 1,
+        "max_pages": 1,
+        "max_pixels_per_page": 16000000,
+        "include_image": true
+      },
+      "content_count": 2,
+      "results": [
+        {
+          "source": "v3014-visual-v1.pdf",
+          "success": true,
+          "num_pages": 3,
+          "warnings": [],
+          "rendered_pages": [
+            {
+              "page": 3,
+              "evidence_id": "page-3-render-scale-1",
+              "width": 80,
+              "height": 120,
+              "scale": 1,
+              "pixel_count": 9600,
+              "format": "png",
+              "mime_type": "image/png",
+              "rotation": 90,
+              "provenance_source": "page-render",
+              "image_content_index": 1,
+              "inline_data_absent": true,
+              "image": {
+                "mime_type": "image/png",
+                "raw_base64": true,
+                "png_signature": true,
+                "width": 80,
+                "height": 120,
+                "samples": [
+                  [
+                    255,
+                    0,
+                    255,
+                    255
+                  ],
+                  [
+                    255,
+                    0,
+                    255,
+                    255
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    255
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    255
+                  ]
+                ],
+                "byte_length_consistent": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "crop-rotated-v3014-formula": {
+      "outcome": "success",
+      "profile": "region_crop_evidence",
+      "options": {
+        "scale": 1,
+        "max_regions": 20,
+        "max_pixels_per_page": 16000000,
+        "include_image": true
+      },
+      "content_count": 2,
+      "results": [
+        {
+          "source": "v3014-visual-v1.pdf",
+          "success": true,
+          "num_pages": 3,
+          "warnings": [],
+          "regions": [
+            {
+              "region_id": "rotated",
+              "page": 3,
+              "evidence_id": "page-3-rotated-crop-scale-1",
+              "source_bounding_box": {
+                "left": 0,
+                "bottom": 0,
+                "right": 60,
+                "top": 80
+              },
+              "crop_pixels": {
+                "left": 0,
+                "top": 40,
+                "width": 60,
+                "height": 80
+              },
+              "scale": 1,
+              "format": "png",
+              "mime_type": "image/png",
+              "provenance_source": "region-crop",
+              "page_render_evidence_id": "page-3-render-scale-1",
+              "image_content_index": 1,
+              "inline_data_absent": true,
+              "image": {
+                "mime_type": "image/png",
+                "raw_base64": true,
+                "png_signature": true,
+                "width": 60,
+                "height": 80,
+                "samples": [
+                  [
+                    0,
+                    0,
+                    0,
+                    255
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    255
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    255
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    255
+                  ]
+                ],
+                "byte_length_consistent": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "render-mixed-source-partial": {
+      "outcome": "success",
+      "profile": "page_render_evidence",
+      "options": {
+        "scale": 1,
+        "max_pages": 1,
+        "max_pixels_per_page": 16000000,
+        "include_image": true
+      },
+      "content_count": 2,
+      "results": [
+        {
+          "source": "missing-visual.pdf",
+          "success": false,
+          "category": "file_not_found"
+        },
+        {
+          "source": "v3014-visual-v1.pdf",
+          "success": true,
+          "num_pages": 3,
+          "warnings": [],
+          "rendered_pages": [
+            {
+              "page": 2,
+              "evidence_id": "page-2-render-scale-1",
+              "width": 80,
+              "height": 120,
+              "scale": 1,
+              "pixel_count": 9600,
+              "format": "png",
+              "mime_type": "image/png",
+              "rotation": 0,
+              "provenance_source": "page-render",
+              "image_content_index": 1,
+              "inline_data_absent": true,
+              "image": {
+                "mime_type": "image/png",
+                "raw_base64": true,
+                "png_signature": true,
+                "width": 80,
+                "height": 120,
+                "samples": [
+                  [
+                    0,
+                    204,
+                    204,
+                    255
+                  ],
+                  [
+                    0,
+                    204,
+                    204,
+                    255
+                  ],
+                  [
+                    0,
+                    204,
+                    204,
+                    255
+                  ],
+                  [
+                    0,
+                    204,
+                    204,
+                    255
+                  ]
+                ],
+                "byte_length_consistent": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "crop-degenerate-all-fail": {
+      "outcome": "error",
+      "category": "invalid_bounding_box"
+    }
+  }
+}

--- a/scripts/differential/generate-v3014-visual-fixtures.ts
+++ b/scripts/differential/generate-v3014-visual-fixtures.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env bun
+
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDir, '../..');
+const fixturePath = join(repoRoot, 'test/fixtures/differential/v3014-visual-v1.pdf');
+const manifestPath = join(scriptDir, 'fixtures/v3014-visual-fixtures.json');
+const write = process.argv.includes('--write');
+
+const sha256 = (bytes: Uint8Array): string =>
+  createHash('sha256').update(bytes).digest('hex');
+
+function buildPdf(): Buffer {
+  const streams = [
+    [
+      '1 0 0 rg 0 0 60 40 re f',
+      '0 1 0 rg 60 0 60 40 re f',
+      '0 0 1 rg 0 40 60 40 re f',
+      '1 1 0 rg 60 40 60 40 re f',
+    ].join('\n'),
+    '0 0.8 0.8 rg 0 0 80 120 re f',
+    ['1 0 1 rg 0 0 60 80 re f', '0 0 0 rg 60 0 60 80 re f'].join('\n'),
+  ].map((stream) => `${stream}\n`);
+
+  const objects = new Map<number, string>([
+    [1, '<< /Type /Catalog /Pages 2 0 R >>'],
+    [2, '<< /Type /Pages /Kids [3 0 R 5 0 R 7 0 R] /Count 3 >>'],
+    [
+      3,
+      '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 120 80] /Resources << >> /Contents 4 0 R >>',
+    ],
+    [4, `<< /Length ${Buffer.byteLength(streams[0]!, 'ascii')} >>\nstream\n${streams[0]}endstream`],
+    [
+      5,
+      '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 80 120] /Resources << >> /Contents 6 0 R >>',
+    ],
+    [6, `<< /Length ${Buffer.byteLength(streams[1]!, 'ascii')} >>\nstream\n${streams[1]}endstream`],
+    [
+      7,
+      '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 120 80] /Rotate 90 /Resources << >> /Contents 8 0 R >>',
+    ],
+    [8, `<< /Length ${Buffer.byteLength(streams[2]!, 'ascii')} >>\nstream\n${streams[2]}endstream`],
+    [
+      9,
+      '<< /Title (Visual Parity Corpus V1) /Creator (fixture-generator-v1) /Producer (fixture-generator-v1) >>',
+    ],
+  ]);
+
+  const chunks: Buffer[] = [Buffer.from('%PDF-1.4\n%\xe2\xe3\xcf\xd3\n', 'latin1')];
+  const offsets = [0];
+  let length = chunks[0]!.length;
+  for (let id = 1; id <= objects.size; id += 1) {
+    offsets[id] = length;
+    const chunk = Buffer.from(`${id} 0 obj\n${objects.get(id)}\nendobj\n`, 'latin1');
+    chunks.push(chunk);
+    length += chunk.length;
+  }
+  const xrefOffset = length;
+  chunks.push(
+    Buffer.from(
+      [
+        `xref\n0 ${objects.size + 1}\n`,
+        '0000000000 65535 f \n',
+        ...offsets.slice(1).map((offset) => `${String(offset).padStart(10, '0')} 00000 n \n`),
+        `trailer\n<< /Size ${objects.size + 1} /Root 1 0 R /Info 9 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`,
+      ].join(''),
+      'ascii'
+    )
+  );
+  return Buffer.concat(chunks);
+}
+
+const bytes = buildPdf();
+const manifest = {
+  schemaVersion: 1,
+  generator: relative(repoRoot, fileURLToPath(import.meta.url)),
+  fixtures: [
+    {
+      path: relative(repoRoot, fixturePath),
+      bytes: bytes.length,
+      sha256: sha256(bytes),
+    },
+  ],
+};
+const manifestBytes = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
+
+if (write) {
+  mkdirSync(dirname(fixturePath), { recursive: true });
+  mkdirSync(dirname(manifestPath), { recursive: true });
+  writeFileSync(fixturePath, bytes);
+  writeFileSync(manifestPath, manifestBytes);
+  console.error(`wrote ${relative(repoRoot, fixturePath)} and manifest`);
+  process.exit(0);
+}
+
+const stale =
+  !existsSync(fixturePath) ||
+  !readFileSync(fixturePath).equals(bytes) ||
+  !existsSync(manifestPath) ||
+  !readFileSync(manifestPath).equals(manifestBytes);
+if (stale) throw new Error('visual fixture is stale or missing; run with --write');
+console.log(`v3.0.14 visual fixture: OK (${bytes.length} bytes)`);

--- a/scripts/differential/v3014-visual-baseline-runner.ts
+++ b/scripts/differential/v3014-visual-baseline-runner.ts
@@ -1,0 +1,162 @@
+#!/usr/bin/env bun
+
+import { readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { PNG } from 'pngjs';
+import { pdfEvidence } from './src/handlers/pdfEvidence.ts';
+
+type Content = { type: string; text?: string; data?: string; mimeType?: string };
+type ToolResult = { content: Content[]; isError?: boolean };
+
+const [corpusPath, fixtureDir] = process.argv.slice(2);
+if (!corpusPath || !fixtureDir) throw new Error('usage: runner <corpus.json> <fixture-dir>');
+const corpus = JSON.parse(readFileSync(corpusPath, 'utf8')) as {
+  cases: Array<{ id: string; input: Record<string, unknown> }>;
+};
+
+function materialize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(materialize);
+  if (value && typeof value === 'object') {
+    const output: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      output[key === 'fixture' ? 'path' : key] =
+        key === 'fixture' && typeof entry === 'string' ? join(fixtureDir, entry) : materialize(entry);
+    }
+    return output;
+  }
+  return value;
+}
+
+function normalizeResult(raw: unknown): ToolResult {
+  if (Array.isArray(raw)) return { content: raw as Content[] };
+  if (raw && typeof raw === 'object' && 'content' in raw) return raw as ToolResult;
+  return { content: [raw as Content] };
+}
+
+function errorCategory(message: string): string {
+  const lower = message.toLowerCase();
+  if (lower.includes('right > left') || lower.includes('top > bottom')) {
+    return 'invalid_bounding_box';
+  }
+  if (lower.includes('not found') || lower.includes('no such file')) return 'file_not_found';
+  return 'unknown_error';
+}
+
+function imageFacts(content: Content): Record<string, unknown> {
+  const bytes = Buffer.from(content.data ?? '', 'base64');
+  const png = PNG.sync.read(bytes);
+  const sample = (x: number, y: number): number[] => {
+    const offset = (y * png.width + x) * 4;
+    return Array.from(png.data.subarray(offset, offset + 4));
+  };
+  return {
+    mime_type: content.mimeType,
+    raw_base64: !(content.data ?? '').startsWith('data:'),
+    png_signature: bytes.subarray(0, 8).equals(Buffer.from('\x89PNG\r\n\x1a\n', 'binary')),
+    width: png.width,
+    height: png.height,
+    byte_length: bytes.length,
+    samples: [
+      sample(Math.floor(png.width / 4), Math.floor(png.height / 4)),
+      sample(Math.floor((png.width * 3) / 4), Math.floor(png.height / 4)),
+      sample(Math.floor(png.width / 4), Math.floor((png.height * 3) / 4)),
+      sample(Math.floor((png.width * 3) / 4), Math.floor((png.height * 3) / 4)),
+    ],
+  };
+}
+
+function canonicalize(result: ToolResult): Record<string, unknown> {
+  if (result.isError) {
+    const message = result.content[0]?.text ?? '';
+    return { outcome: 'error', category: errorCategory(message) };
+  }
+  const payload = JSON.parse(result.content[0]?.text ?? '{}') as Record<string, unknown>;
+  const imageBlocks = result.content.filter((content) => content.type === 'image');
+  const images = imageBlocks.map(imageFacts);
+  const results = ((payload.results ?? []) as Array<Record<string, unknown>>).map((source) => {
+    if (!source.success) {
+      return {
+        source: basename(String(source.source ?? '')),
+        success: false,
+        category: errorCategory(String(source.error ?? '')),
+      };
+    }
+    const output: Record<string, unknown> = {
+      source: basename(String(source.source ?? '')),
+      success: true,
+      num_pages: source.num_pages,
+      warnings: source.warnings ?? [],
+    };
+    if (Array.isArray(source.rendered_pages)) {
+      output.rendered_pages = source.rendered_pages.map((page: Record<string, unknown>) => {
+        const index = page.image_content_index as number | undefined;
+        const image = index === undefined ? undefined : images[index - 1];
+        return {
+          page: page.page,
+          evidence_id: page.evidence_id,
+          width: page.width,
+          height: page.height,
+          scale: page.scale,
+          pixel_count: page.pixel_count,
+          format: page.format,
+          mime_type: page.mime_type,
+          rotation: page.rotation,
+          provenance_source: (page.provenance as Record<string, unknown>)?.source,
+          image_content_index: index ?? null,
+          inline_data_absent: !('data' in page),
+          image: image
+            ? {
+                ...image,
+                byte_length_consistent: image.byte_length === page.byte_length,
+                byte_length: undefined,
+              }
+            : null,
+        };
+      });
+    }
+    if (Array.isArray(source.regions)) {
+      output.regions = source.regions.map((region: Record<string, unknown>) => {
+        const index = region.image_content_index as number | undefined;
+        const image = index === undefined ? undefined : images[index - 1];
+        const provenance = region.provenance as Record<string, unknown>;
+        return {
+          region_id: region.region_id,
+          page: region.page,
+          evidence_id: region.evidence_id,
+          source_bounding_box: region.source_bounding_box,
+          crop_pixels: region.crop_pixels,
+          scale: region.scale,
+          format: region.format,
+          mime_type: region.mime_type,
+          provenance_source: provenance?.source,
+          page_render_evidence_id: provenance?.page_render_evidence_id,
+          image_content_index: index ?? null,
+          inline_data_absent: !('data' in region),
+          image: image
+            ? {
+                ...image,
+                byte_length_consistent: image.byte_length === region.byte_length,
+                byte_length: undefined,
+              }
+            : null,
+        };
+      });
+    }
+    return output;
+  });
+  return {
+    outcome: 'success',
+    profile: payload.profile,
+    options: payload.render_options ?? payload.crop_options,
+    content_count: result.content.length,
+    results,
+  };
+}
+
+const observations: Record<string, unknown> = {};
+for (const entry of corpus.cases) {
+  const input = materialize(entry.input) as never;
+  const raw = await pdfEvidence.handler({ input, ctx: {} });
+  observations[entry.id] = canonicalize(normalizeResult(raw));
+}
+console.log(JSON.stringify(observations));

--- a/scripts/run-pdf-reader-differential.sh
+++ b/scripts/run-pdf-reader-differential.sh
@@ -13,6 +13,7 @@ ARTIFACT="$SCRATCH/verification.json"
 ORACLE_JSON="$SCRATCH/oracle.json"
 TEXT_DIFFERENTIAL_JSON="$SCRATCH/ts-vs-rust-text.json"
 V3014_BEHAVIOR_JSON="$SCRATCH/v3014-behavior-result.json"
+V3014_VISUAL_JSON="$SCRATCH/v3014-visual-result.json"
 SLICE_FILTER="all"
 : >"$LOG"
 
@@ -72,6 +73,14 @@ echo "--- immutable v3.0.14 behavior differential (10 exact cases) ---" | tee -a
 bun "$REPO_ROOT/scripts/differential/check-v3014-behavior-differential.ts" \
   --output "$V3014_BEHAVIOR_JSON" >>"$LOG"
 
+echo "--- deterministic v3.0.14 visual fixture + baseline replay ---" | tee -a "$LOG"
+bun "$REPO_ROOT/scripts/differential/generate-v3014-visual-fixtures.ts" 2>&1 | tee -a "$LOG"
+bun "$REPO_ROOT/scripts/differential/capture-v3014-visual-oracle.ts" 2>&1 | tee -a "$LOG"
+
+echo "--- immutable v3.0.14 render/crop differential (7 semantic cases) ---" | tee -a "$LOG"
+bun "$REPO_ROOT/scripts/differential/check-v3014-visual-differential.ts" \
+  --output "$V3014_VISUAL_JSON" >>"$LOG"
+
 echo "--- live TypeScript handler -> Rust text claimed-subset check ---" | tee -a "$LOG"
 env -u PDF_READER_USE_RUST_TEXT_SEARCH -u PDF_READER_ENGINE_MODE \
   bun "$REPO_ROOT/scripts/differential/ts-vs-rust-text-oracle.ts" \
@@ -94,6 +103,9 @@ BEHAVIOR_SPEC_HASH="$(sha256sum \
   "$REPO_ROOT/scripts/differential/fixtures/v3014-behavior-corpus.json" \
   "$REPO_ROOT/scripts/differential/fixtures/v3014-behavior-oracle.json" \
   "$REPO_ROOT/scripts/differential/fixtures/v3014-behavior-fixtures.json" \
+  "$REPO_ROOT/scripts/differential/fixtures/v3014-visual-corpus.json" \
+  "$REPO_ROOT/scripts/differential/fixtures/v3014-visual-oracle.json" \
+  "$REPO_ROOT/scripts/differential/fixtures/v3014-visual-fixtures.json" \
   2>/dev/null | awk '{print $1}' | sha256sum | awk '{print $1}' || echo missing)"
 FIXTURE_CORPUS_HASH="$(jq -r '.fixtureCorpusHash' "$ORACLE_JSON")"
 GOLDEN_FIXTURE_HASH="$(jq -r '.goldenFixtureHash' "$ORACLE_JSON")"
@@ -106,6 +118,11 @@ V3014_BEHAVIOR_PASSED="$(jq '.passed' "$V3014_BEHAVIOR_JSON")"
 V3014_BEHAVIOR_SKIPPED="$(jq '.skipped' "$V3014_BEHAVIOR_JSON")"
 V3014_BEHAVIOR_CORPUS_HASH="$(jq -r '.corpusSha256' "$V3014_BEHAVIOR_JSON")"
 V3014_BEHAVIOR_ORACLE_HASH="$(jq -r '.oracleSha256' "$V3014_BEHAVIOR_JSON")"
+V3014_VISUAL_CASE_COUNT="$(jq '.caseCount' "$V3014_VISUAL_JSON")"
+V3014_VISUAL_PASSED="$(jq '.passed' "$V3014_VISUAL_JSON")"
+V3014_VISUAL_SKIPPED="$(jq '.skipped' "$V3014_VISUAL_JSON")"
+V3014_VISUAL_CORPUS_HASH="$(jq -r '.corpusSha256' "$V3014_VISUAL_JSON")"
+V3014_VISUAL_ORACLE_HASH="$(jq -r '.oracleSha256' "$V3014_VISUAL_JSON")"
 
 case "$SLICE_FILTER" in
   tool.read_pdf) ARTIFACT_SLICE="tool.read_pdf" ;;
@@ -124,6 +141,8 @@ jq -n \
   --arg goldenFixtureHash "$GOLDEN_FIXTURE_HASH" \
   --arg v3014BehaviorCorpusHash "$V3014_BEHAVIOR_CORPUS_HASH" \
   --arg v3014BehaviorOracleHash "$V3014_BEHAVIOR_ORACLE_HASH" \
+  --arg v3014VisualCorpusHash "$V3014_VISUAL_CORPUS_HASH" \
+  --arg v3014VisualOracleHash "$V3014_VISUAL_ORACLE_HASH" \
   --arg sliceFilter "$SLICE_FILTER" \
   --arg slice "$ARTIFACT_SLICE" \
   --argjson caseCount "$CASE_COUNT" \
@@ -133,6 +152,9 @@ jq -n \
   --argjson v3014BehaviorCaseCount "$V3014_BEHAVIOR_CASE_COUNT" \
   --argjson v3014BehaviorPassed "$V3014_BEHAVIOR_PASSED" \
   --argjson v3014BehaviorSkipped "$V3014_BEHAVIOR_SKIPPED" \
+  --argjson v3014VisualCaseCount "$V3014_VISUAL_CASE_COUNT" \
+  --argjson v3014VisualPassed "$V3014_VISUAL_PASSED" \
+  --argjson v3014VisualSkipped "$V3014_VISUAL_SKIPPED" \
   '{
     schemaVersion: 2,
     slice: $slice,
@@ -155,14 +177,21 @@ jq -n \
     v3014BehaviorCaseCount: $v3014BehaviorCaseCount,
     v3014BehaviorPassed: $v3014BehaviorPassed,
     v3014BehaviorSkipped: $v3014BehaviorSkipped,
+    v3014VisualCorpusHash: $v3014VisualCorpusHash,
+    v3014VisualOracleHash: $v3014VisualOracleHash,
+    v3014VisualCaseCount: $v3014VisualCaseCount,
+    v3014VisualPassed: $v3014VisualPassed,
+    v3014VisualSkipped: $v3014VisualSkipped,
     harness: "scripts/run-pdf-reader-differential.sh",
     differentialTest: "crates/pdf-reader-mcp-server/tests/pdf_reader_mcp_differential.rs#pdf_reader_mcp_differential_matches_ts_oracle",
     immutableInputOracle: "scripts/check-v3014-input-schema-oracle.ts",
     immutableBehaviorOracle: "scripts/differential/fixtures/v3014-behavior-oracle.json",
     immutableBehaviorDifferential: "scripts/differential/check-v3014-behavior-differential.ts",
+    immutableVisualOracle: "scripts/differential/fixtures/v3014-visual-oracle.json",
+    immutableVisualDifferential: "scripts/differential/check-v3014-visual-differential.ts",
     liveTextOracle: "scripts/differential/ts-vs-rust-text-oracle.ts",
     structuralConsistencyOracle: "scripts/differential/pdf-reader-mcp-oracle.ts",
-    nonClaims: ["full TS 3.0.14 behavioral parity", "visual parity", "Document Twin semantic parity"],
+    nonClaims: ["full TS 3.0.14 behavioral parity", "visual parity outside the immutable 7-case render/crop corpus", "Document Twin semantic parity"],
     retirementGate: "scripts/check-no-ts-stdio-backend.sh (runs only when dropInFor3014=true)"
   }' >"$ARTIFACT"
 

--- a/test/differentialHarness.matrix.test.ts
+++ b/test/differentialHarness.matrix.test.ts
@@ -20,6 +20,12 @@ describe('pdf-reader-mcp differential harness (rej-010)', () => {
       existsSync(path.join(repoRoot, 'scripts/differential/check-v3014-behavior-differential.ts'))
     ).toBe(true);
     expect(
+      existsSync(path.join(repoRoot, 'scripts/differential/fixtures/v3014-visual-oracle.json'))
+    ).toBe(true);
+    expect(
+      existsSync(path.join(repoRoot, 'scripts/differential/check-v3014-visual-differential.ts'))
+    ).toBe(true);
+    expect(
       existsSync(
         path.join(repoRoot, 'crates/pdf-reader-mcp-server/tests/pdf_reader_mcp_differential.rs')
       )
@@ -34,6 +40,8 @@ describe('pdf-reader-mcp differential harness (rej-010)', () => {
     expect(harness).toContain('pdf_reader_mcp_differential_matches_ts_oracle');
     expect(harness).toContain('claimed_subset_green');
     expect(harness).toContain('v3014-behavior-result.json');
+    expect(harness).toContain('v3014-visual-result.json');
+    expect(harness).toContain('check-v3014-visual-differential.ts');
     expect(harness).toContain('check-no-ts-stdio-backend.sh');
     expect(harness).toContain('--slice');
     expect(harness).toContain('tool.search_pdf|tool.pdf_evidence');

--- a/test/fixtures/differential/v3014-visual-v1.pdf
+++ b/test/fixtures/differential/v3014-visual-v1.pdf
@@ -1,0 +1,59 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R 5 0 R 7 0 R] /Count 3 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 120 80] /Resources << >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 100 >>
+stream
+1 0 0 rg 0 0 60 40 re f
+0 1 0 rg 60 0 60 40 re f
+0 0 1 rg 0 40 60 40 re f
+1 1 0 rg 60 40 60 40 re f
+endstream
+endobj
+5 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 80 120] /Resources << >> /Contents 6 0 R >>
+endobj
+6 0 obj
+<< /Length 29 >>
+stream
+0 0.8 0.8 rg 0 0 80 120 re f
+endstream
+endobj
+7 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 120 80] /Rotate 90 /Resources << >> /Contents 8 0 R >>
+endobj
+8 0 obj
+<< /Length 49 >>
+stream
+1 0 1 rg 0 0 60 80 re f
+0 0 0 rg 60 0 60 80 re f
+endstream
+endobj
+9 0 obj
+<< /Title (Visual Parity Corpus V1) /Creator (fixture-generator-v1) /Producer (fixture-generator-v1) >>
+endobj
+xref
+0 10
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000133 00000 n 
+0000000236 00000 n 
+0000000386 00000 n 
+0000000489 00000 n 
+0000000567 00000 n 
+0000000681 00000 n 
+0000000779 00000 n 
+trailer
+<< /Size 10 /Root 1 0 R /Info 9 0 R >>
+startxref
+898
+%%EOF

--- a/test/integration/http-transport.test.ts
+++ b/test/integration/http-transport.test.ts
@@ -233,6 +233,46 @@ describe('MCP Server HTTP Transport Integration (Rust rmcp)', () => {
     }
   });
 
+  it('should return bounded PNG evidence over HTTP', async () => {
+    const client = createMcpHttpClient();
+    await client.initializeSession();
+    const testPdfPath = path.resolve(__dirname, '../fixtures/sample.pdf');
+
+    const response = await client.sendRequest(
+      'tools/call',
+      {
+        name: 'pdf_evidence',
+        arguments: {
+          operation: 'render_page',
+          sources: [{ path: testPdfPath, pages: [1] }],
+          scale: 1,
+          max_pages: 1,
+        },
+      },
+      4
+    );
+
+    expect(response.error).toBeUndefined();
+    const result = response.result as
+      | {
+          isError?: boolean;
+          content?: Array<{ type?: string; text?: string; data?: string; mimeType?: string }>;
+        }
+      | undefined;
+    expect(result?.isError).not.toBe(true);
+    expect(result?.content?.[0]?.type).toBe('text');
+    expect(result?.content?.[1]?.type).toBe('image');
+    expect(result?.content?.[1]?.mimeType).toBe('image/png');
+    const imageData = result?.content?.[1]?.data ?? '';
+    expect(Buffer.from(imageData, 'base64').subarray(0, 8)).toEqual(
+      Buffer.from('\x89PNG\r\n\x1a\n', 'binary')
+    );
+    const payload = JSON.parse(result?.content?.[0]?.text ?? '{}') as {
+      results?: Array<{ rendered_pages?: Array<{ image_content_index?: number }> }>;
+    };
+    expect(payload.results?.[0]?.rendered_pages?.[0]?.image_content_index).toBe(1);
+  });
+
   const goldenPath = path.resolve(__dirname, '../fixtures/read-pdf-golden.json');
   const golden = JSON.parse(fs.readFileSync(goldenPath, 'utf8')) as {
     cases: Array<{

--- a/test/integration/mcp-server.test.ts
+++ b/test/integration/mcp-server.test.ts
@@ -200,7 +200,7 @@ describe('MCP Server Integration', () => {
     }
   });
 
-  mcpIt('should fail closed for unavailable pdf_evidence render_page', async () => {
+  mcpIt('should render bounded PNG evidence through pdf_evidence render_page', async () => {
     const testPdfPath = path.resolve(__dirname, '../fixtures/sample.pdf');
 
     const callRequest = createRequest(5, 'tools/call', {
@@ -225,13 +225,38 @@ describe('MCP Server Integration', () => {
 
     expect(response.id).toBe(5);
 
-    expect(response.error || response.result?.isError).toBeTruthy();
-    expect(response.error?.message || response.result?.content?.[0]?.text).toContain(
-      "pdf_evidence operation 'render_page' is not available in the pure-Rust engine yet"
+    expect(response.error).toBeUndefined();
+    expect(response.result?.isError).not.toBe(true);
+    expect(response.result?.content?.[0]?.type).toBe('text');
+    expect(response.result?.content?.[1]?.type).toBe('image');
+    expect(response.result?.content?.[1]?.mimeType).toBe('image/png');
+    const imageData = response.result?.content?.[1]?.data ?? '';
+    expect(imageData.startsWith('data:')).toBe(false);
+    expect(Buffer.from(imageData, 'base64').subarray(0, 8)).toEqual(
+      Buffer.from('\x89PNG\r\n\x1a\n', 'binary')
+    );
+    const payload = JSON.parse(response.result?.content?.[0]?.text ?? '{}') as {
+      profile?: string;
+      rendered_pages?: unknown;
+      results?: Array<{
+        success?: boolean;
+        rendered_pages?: Array<{
+          data?: string;
+          image_content_index?: number;
+          byte_length?: number;
+        }>;
+      }>;
+    };
+    expect(payload.profile).toBe('page_render_evidence');
+    expect(payload.results?.[0]?.success).toBe(true);
+    expect(payload.results?.[0]?.rendered_pages?.[0]?.data).toBeUndefined();
+    expect(payload.results?.[0]?.rendered_pages?.[0]?.image_content_index).toBe(1);
+    expect(payload.results?.[0]?.rendered_pages?.[0]?.byte_length).toBe(
+      Buffer.from(imageData, 'base64').byteLength
     );
   });
 
-  mcpIt('should fail closed for unavailable pdf_evidence extract_regions', async () => {
+  mcpIt('should crop bounded PNG evidence through pdf_evidence extract_regions', async () => {
     const testPdfPath = path.resolve(__dirname, '../fixtures/sample.pdf');
 
     const callRequest = createRequest(6, 'tools/call', {
@@ -267,10 +292,37 @@ describe('MCP Server Integration', () => {
 
     expect(response.id).toBe(6);
 
-    expect(response.error || response.result?.isError).toBeTruthy();
-    expect(response.error?.message || response.result?.content?.[0]?.text).toContain(
-      "pdf_evidence operation 'extract_regions' is not available in the pure-Rust engine yet"
+    expect(response.error).toBeUndefined();
+    expect(response.result?.isError).not.toBe(true);
+    expect(response.result?.content?.[0]?.type).toBe('text');
+    expect(response.result?.content?.[1]?.type).toBe('image');
+    expect(response.result?.content?.[1]?.mimeType).toBe('image/png');
+    const imageData = response.result?.content?.[1]?.data ?? '';
+    expect(imageData.startsWith('data:')).toBe(false);
+    expect(Buffer.from(imageData, 'base64').subarray(0, 8)).toEqual(
+      Buffer.from('\x89PNG\r\n\x1a\n', 'binary')
     );
+    const payload = JSON.parse(response.result?.content?.[0]?.text ?? '{}') as {
+      profile?: string;
+      results?: Array<{
+        success?: boolean;
+        regions?: Array<{
+          region_id?: string;
+          data?: string;
+          image_content_index?: number;
+          crop_pixels?: { width?: number; height?: number };
+        }>;
+      }>;
+    };
+    expect(payload.profile).toBe('region_crop_evidence');
+    expect(payload.results?.[0]?.success).toBe(true);
+    expect(payload.results?.[0]?.regions?.[0]?.region_id).toBe('bottom-left');
+    expect(payload.results?.[0]?.regions?.[0]?.data).toBeUndefined();
+    expect(payload.results?.[0]?.regions?.[0]?.image_content_index).toBe(1);
+    expect(payload.results?.[0]?.regions?.[0]?.crop_pixels).toMatchObject({
+      width: 100,
+      height: 100,
+    });
   });
 
   mcpIt('should fail closed for unavailable pdf_evidence analyze_regions', async () => {

--- a/test/production/capabilityParity.contract.test.ts
+++ b/test/production/capabilityParity.contract.test.ts
@@ -153,7 +153,7 @@ describe.skipIf(!pureRustEnabled)('experimental pure-Rust capability contract', 
     expect(failures).toEqual([]);
   }, 600_000);
 
-  test('auto balanced twin returns core agent document twin layers', async () => {
+  test('auto balanced twin matches v3.0.14 depth without full text', async () => {
     const response = await callTool(
       proc,
       nextId(),
@@ -168,8 +168,8 @@ describe.skipIf(!pureRustEnabled)('experimental pure-Rust capability contract', 
     const payload = parseToolPayload(response);
     expect(payload.isError).toBe(false);
     const parsed = JSON.parse(payload.text) as unknown;
+    const missing: string[] = [];
     for (const field of [
-      'full_text',
       'markdown',
       'chunks',
       'document_map',
@@ -177,8 +177,10 @@ describe.skipIf(!pureRustEnabled)('experimental pure-Rust capability contract', 
       'trust_report',
       'accessibility_report',
     ]) {
-      expect(deepHasKey(parsed, field)).toBe(true);
+      if (!deepHasKey(parsed, field)) missing.push(field);
     }
+    expect(missing).toEqual([]);
+    expect(deepHasKey(parsed, 'full_text')).toBe(false);
   }, 120_000);
 
   test('search_pdf public options remain available', async () => {
@@ -201,7 +203,7 @@ describe.skipIf(!pureRustEnabled)('experimental pure-Rust capability contract', 
     }
   }, 180_000);
 
-  test('pdf_evidence inspect remains available; visual ops fail closed with guidance', async () => {
+  test('pdf_evidence inspect and bounded visual ops work; provider ops fail closed', async () => {
     const inspect = await callTool(
       proc,
       nextId(),
@@ -216,7 +218,7 @@ describe.skipIf(!pureRustEnabled)('experimental pure-Rust capability contract', 
       true
     );
 
-    for (const operation of ['render_page', 'extract_regions', 'ocr_pages', 'analyze_regions']) {
+    for (const operation of ['render_page', 'extract_regions']) {
       const response = await callTool(
         proc,
         nextId(),
@@ -244,12 +246,43 @@ describe.skipIf(!pureRustEnabled)('experimental pure-Rust capability contract', 
         60_000
       );
       const payload = parseToolPayload(response);
-      // Must not hang/crash. Either structured guidance error or success with empty image.
-      expect(payload.text.length).toBeGreaterThan(0);
-      if (!payload.isError) {
-        // If success path exists, it must still be parseable JSON.
-        expect(() => JSON.parse(payload.text)).not.toThrow();
-      }
+      expect(payload.isError).toBe(false);
+      const result = JSON.parse(payload.text) as unknown;
+      expect(deepHasKey(result, operation === 'render_page' ? 'rendered_pages' : 'regions')).toBe(
+        true
+      );
+    }
+
+    for (const operation of ['ocr_pages', 'analyze_regions']) {
+      const response = await callTool(
+        proc,
+        nextId(),
+        'pdf_evidence',
+        {
+          operation,
+          sources: [
+            {
+              path: samplePdf,
+              regions:
+                operation === 'analyze_regions'
+                  ? [
+                      {
+                        id: 'r1',
+                        page: 1,
+                        bounding_box: { left: 0, bottom: 0, right: 100, top: 100 },
+                      },
+                    ]
+                  : undefined,
+            },
+          ],
+          max_pages: 1,
+          max_regions: 1,
+        },
+        60_000
+      );
+      const payload = parseToolPayload(response);
+      expect(payload.isError).toBe(true);
+      expect(payload.text).toContain(`'${operation}' is not available`);
     }
   }, 240_000);
 });


### PR DESCRIPTION
## Outcome

Adds a bounded pure-Rust `pdf_evidence` render/crop slice without claiming full TS 3.0.14 drop-in parity or lifting the publish freeze.

- parse-once Hayro page rendering and PNG region crops
- TS v3.0.14-compatible defaults, selection, warnings, ordering, crop formula, MCP image blocks and indexes
- truthful Hayro provenance; exact pdf.js pixels/antialiasing explicitly nonclaimed
- 32-source and request-wide 64-page / 200-region / 256M planned-pixel work admission, charged before render/crop and retained across late failures
- stdio and HTTP success-path coverage
- immutable detached `v3.0.14` 7-case visual oracle plus exact-candidate CI binding
- honest matrix remains `dropInFor3014:false`, `publishFreeze:true`; OCR/analyze remain fail-closed

## Independent review

- R1: **FAIL** (0.96) — found missing request-wide CPU/work bounds
- root cause fixed with pre-I/O source admission and non-refundable request work accounting
- R2: **PASS** (0.97), no remaining P0-P3 findings

## Verification

- `cargo test --workspace -- --test-threads=1`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bun run typecheck`
- `bun run check`
- `bun run check:production-contract`
- `PDF_READER_ENGINE_MODE=pure-rust RUN_PURE_RUST_CAPABILITY=1 bun run test:capability-parity` (4/4)
- `bun run test:cov` (489 pass, 0 fail; capability suite separately enabled above)
- `bash scripts/run-pdf-reader-differential.sh` (10/10 behavior, 7/7 visual, 0 skipped)
- `bunx vitest run test/integration/http-transport.test.ts` (17/17)
- `actionlint .github/workflows/rust-parity-differential.yml`

## Nonclaims

This is not the Rust release candidate. It does not add OCR/analyze, full Document Twin/COS/geometry parity, cross-platform npm native packaging, or publish authorization.
