### PR TITLE
fix(ci): align project control after gate retirement

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -117,7 +117,7 @@
       "Validate Code Quality"
     ],
     "deployPath": "No hosted deploy path is declared. Package release is Changesets-driven through .github/workflows/release.yml using a GitHub App release token and npm credentials.",
-    "productionProof": "Required CI context, typecheck/test/check/build/docs evidence as applicable, GroundAtlas package dogfood JSON/Markdown evidence for project-control boundaries, benchmark evidence for performance claims, Changesets release intent for package changes, and npm package readback after publication.",
+    "productionProof": "Required CI context, typecheck/test/check/build/docs evidence as applicable, local project-manifest readback for boundary changes, benchmark evidence for performance claims, Changesets release intent for package changes, and npm package readback after publication.",
     "recoveryClass": "forward-fix-only",
     "packageRelease": {
       "publishesPackages": true,

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -60,10 +60,12 @@ self-hosted runners. Package release is Changesets-driven through the repo
 release workflow, which mints a GitHub App token before creating version PRs or
 publishing to npm.
 
-The GroundAtlas package dogfood gate proves the project-control boundary from
-generated JSON and Markdown evidence, but those generated files are not source
-of truth. `project.manifest.json` remains the vendor-neutral control file and
-`.doctrine/project.json` remains the Sylphx Doctrine adapter.
+Control Plane ADR-0014 retired the in-repository GroundAtlas package dogfood
+gate and assigned repository-intelligence ownership to Control Plane Repository
+Ingestion. `project.manifest.json` remains the vendor-neutral control file and
+`.doctrine/project.json` remains the Sylphx Doctrine adapter. This repository
+does not treat the ownership decision as proof of a live central ingestion
+receipt; generated inventory and reports remain read models only.
 
 Docs-only boundary changes do not alter runtime behavior, provider dispatch,
 credentials, package output, npm release, or customer data handling. MCP schema,
@@ -77,8 +79,3 @@ through clean packaging, benchmarks, trust, compatibility, and separately owned
 hosted/enterprise products. Pricing, hosted document intelligence, enterprise
 packaging, or roadmap changes require decision records backed by market and
 customer analysis.
-
-
-## GroundAtlas
-
-GroundAtlas package dogfood is **retired** (Control Plane ADR-0014). Do not re-add required groundatlas CI jobs.

--- a/docs/adr/0003-groundatlas-013-scorecard-gate.md
+++ b/docs/adr/0003-groundatlas-013-scorecard-gate.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Superseded by Control Plane ADR-0014.
 
 ## Context
 
@@ -50,3 +50,11 @@ evidence/read models only. They are not project-control source of truth.
 - Dependabot PR #360 is superseded because it only bumped the action reference;
   this ADR requires the package spec, assertions, and artifact upload to move
   together.
+
+## Supersession
+
+Control Plane ADR-0014 retired repository-local GroundAtlas package dogfood in
+favor of central Repository Ingestion. The historical evidence above remains
+part of the decision record, but it is no longer a current CI requirement.
+`project.manifest.json` and `.doctrine/project.json` remain local semantic
+authorities; central inventory and reports remain derived read models.

--- a/docs/specs/project-control-gate.md
+++ b/docs/specs/project-control-gate.md
@@ -1,4 +1,4 @@
-# Project Control Gate
+# Project Control Ingestion
 
 PDF Reader MCP keeps project-control facts in two source files:
 
@@ -7,35 +7,23 @@ PDF Reader MCP keeps project-control facts in two source files:
 - `.doctrine/project.json` is the Sylphx Doctrine adapter and local governance
   catalog.
 
-Generated `.groundatlas*` outputs plus GroundAtlas JSON and Markdown reports are
-evidence/read models only. They must not be edited or treated as source of
-truth.
+Generated inventory and reports are evidence/read models only. They must not be
+edited or treated as source of truth.
 
-## Required CI Behavior
+## Current Control
 
-The CI workflow must run a single GroundAtlas dogfood job on pull requests,
-merge-group candidates, and `main` pushes. That job must use:
+Control Plane ADR-0014 retired the repository-local GroundAtlas package dogfood
+job and assigned repository-intelligence ownership to Control Plane Repository
+Ingestion. Do not re-add a required GroundAtlas package/action job to this
+repository. The ownership decision is not a live central ingestion receipt.
 
-- `SylphxAI/groundatlas@v0.1.3`;
-- `groundatlas@0.1.3`;
-- `require-atlas: "true"`;
-- `strict: "true"`.
+The local contract is:
 
-The assertion step must prove:
-
-- selected manifest path is `project.manifest.json`;
-- selected manifest `adapter=false`;
-- `.doctrine/project.json` remains an adapter with `adapter=true`;
-- fleet summary is `1 adopted, 0 warning, 0 blocked, 1 total`;
-- Markdown scorecard includes `# GroundAtlas fleet adoption report`;
-- Markdown scorecard includes
-  `Summary: 1 adopted, 0 warning, 0 blocked, 1 total.`
-
-The `groundatlas-package-dogfood` artifact must include:
-
-- `groundatlas-manifest.json`;
-- `groundatlas-fleet.json`;
-- `groundatlas-fleet.md`.
+- keep both manifest files valid JSON and semantically aligned through focused
+  local readback;
+- keep `project.manifest.json` vendor-neutral;
+- keep `.doctrine/project.json` as the Sylphx Doctrine adapter;
+- fail tests if the retired package gate is reintroduced.
 
 ## Validation
 
@@ -43,9 +31,5 @@ Control-plane-only changes should run:
 
 ```bash
 bun test test/project-control.test.ts
-npm exec --yes --package groundatlas@0.1.3 -- ga audit --out .groundatlas-pilot
-npm exec --yes --package groundatlas@0.1.3 -- ga manifest --out .groundatlas-pilot --json
-npm exec --yes --package groundatlas@0.1.3 -- ga fleet . --out .groundatlas-pilot --require-atlas --strict --json
-npm exec --yes --package groundatlas@0.1.3 -- ga fleet . --out .groundatlas-pilot --require-atlas --strict
 git diff --check
 ```

--- a/project.manifest.json
+++ b/project.manifest.json
@@ -61,7 +61,7 @@
       "type": "workflow",
       "name": "CI",
       "path": ".github/workflows/ci.yml",
-      "description": "Code quality, package smoke, tests, docs, release evidence, secret scan, and GroundAtlas package dogfood."
+      "description": "Code quality, package smoke, tests, docs, release evidence, and secret scan."
     },
     {
       "type": "website",
@@ -104,6 +104,6 @@
   ],
   "adoption": {
     "status": "adopted",
-    "notes": "Vendor-neutral GroundAtlas manifest for package/action dogfooding. .doctrine/project.json remains the Sylphx Doctrine adapter and local governance catalog. Generated .groundatlas* outputs plus GroundAtlas JSON and Markdown reports are evidence/read models only."
+    "notes": "Vendor-neutral project metadata. GroundAtlas package/action dogfood was retired by Control Plane ADR-0014. .doctrine/project.json remains the Sylphx Doctrine adapter and local governance catalog; generated inventory and reports are read models only."
   }
 }

--- a/test/project-control.test.ts
+++ b/test/project-control.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 const readJson = (path: string) => JSON.parse(readFileSync(path, 'utf8'));
 const readText = (path: string) => readFileSync(path, 'utf8');
 
-describe('GroundAtlas project control', () => {
+describe('project control after GroundAtlas package-gate retirement', () => {
   it('keeps the vendor-neutral manifest separate from the Doctrine adapter', () => {
     const manifest = readJson('project.manifest.json');
     const doctrine = readJson('.doctrine/project.json');
@@ -26,19 +26,30 @@ describe('GroundAtlas project control', () => {
         }),
       ])
     );
-    expect(doctrine.delivery.productionProof).toContain('GroundAtlas package dogfood');
+    expect(doctrine.delivery.productionProof).toContain('local project-manifest readback');
+    expect(doctrine.delivery.productionProof).not.toContain('ingested centrally');
   });
 
-  it('dogfoods GroundAtlas 0.1.3 JSON and Markdown scorecard outputs in CI', () => {
+  it('keeps the retired package gate out of CI without inventing central proof', () => {
     const workflow = readText('.github/workflows/ci.yml');
+    const project = readText('PROJECT.md');
+    const specification = readText('docs/specs/project-control-gate.md');
+    const historicalAdr = readText('docs/adr/0003-groundatlas-013-scorecard-gate.md');
+    const manifest = readJson('project.manifest.json');
+    const doctrine = readJson('.doctrine/project.json');
 
-    expect(workflow).toContain('uses: SylphxAI/groundatlas@v0.1.3');
-    expect(workflow).toContain('package-spec: groundatlas@0.1.3');
-    expect(workflow).toContain('fleet-markdown-report-path');
-    expect(workflow).toContain('groundatlas-package-dogfood');
-    expect(workflow).toContain('project.manifest.json');
-    expect(workflow).toContain('.doctrine/project.json');
-    expect(workflow).toContain('# GroundAtlas fleet adoption report');
-    expect(workflow).toContain('Summary: 1 adopted, 0 warning, 0 blocked, 1 total.');
+    expect(workflow).not.toContain('SylphxAI/groundatlas');
+    expect(workflow).not.toContain('groundatlas-package-dogfood');
+    expect(project).toContain('Control Plane ADR-0014');
+    expect(project).toContain('does not treat the ownership decision as proof');
+    expect(specification).not.toContain('SylphxAI/groundatlas@');
+    expect(specification).toContain('Do not re-add a required');
+    expect(historicalAdr).toContain('Superseded by Control Plane ADR-0014.');
+    expect(
+      manifest.surfaces.find((surface: { name: string }) => surface.name === 'CI').description
+    ).not.toContain('GroundAtlas package dogfood');
+    expect(manifest.adoption.notes).not.toContain('for package/action dogfooding');
+    expect(manifest.adoption.notes).toContain('retired by Control Plane ADR-0014');
+    expect(doctrine.delivery.productionProof).not.toContain('GroundAtlas package dogfood');
   });
 });


### PR DESCRIPTION
## Root cause

Main Release run 29627640582 failed before the intentional publish freeze because #408 removed the GroundAtlas package dogfood job under Control Plane ADR-0014 but left the test, PROJECT, both manifests, spec, and historical ADR asserting the retired gate.

## Fix

- align all current project-control authorities with the retired local gate
- preserve ADR 0003 history and mark it superseded by Control Plane ADR-0014
- retain local vendor-neutral/Doctrine manifest boundaries
- explicitly avoid claiming a live central ingestion receipt without readback proof
- fence stale package/action dogfood prose and workflow reintroduction

## Independent review

- R1: FAIL (0.98) — productionProof invented central live evidence; adoption note and validation claim were stale
- corrected all findings
- R2: PASS (0.99), no remaining concrete findings

## Verification

- `bun test test/project-control.test.ts test/releaseGate.test.ts` (4/4)
- `jq empty project.manifest.json .doctrine/project.json`
- `bun run check` (exit 0; one pre-existing noDelete warning)
- `git diff --check`
- `python3 /Users/kyle/doctrine/scripts/project-control-plane-audit.py --local . --fail-on-drift --json` → PRESENT, no findings
