### PR TITLE
feat(rust): add bounded command OCR provider

### DIFF
--- a/.github/workflows/rust-parity-differential.yml
+++ b/.github/workflows/rust-parity-differential.yml
@@ -147,7 +147,7 @@ jobs:
           jq -e --arg sha "$CANDIDATE_SHA" '
             .profile == "pdf_reader_v3014_visual_result" and
             .candidateSha == $sha and .pass == true and
-            .caseCount == 7 and .passed == 7 and .skipped == 0
+            .caseCount == 10 and .passed == 10 and .skipped == 0
           ' "$VISUAL_ARTIFACT" >/dev/null || {
             echo "::error::v3.0.14 visual result is incomplete, failing, or not SHA-bound"
             exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "command-group"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68fa787550392a9d58f44c21a3022cfb3ea3e2458b7f85d3b399d0ceeccf409"
+dependencies = [
+ "async-trait",
+ "nix",
+ "tokio",
+ "winapi",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,6 +1196,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,6 +1319,7 @@ dependencies = [
  "axum",
  "base64",
  "chrono",
+ "command-group",
  "pdf-reader-core",
  "rmcp",
  "schemars",
@@ -1303,6 +1327,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "subtle",
+ "tempfile",
  "tokio",
  "tokio-util",
 ]
@@ -2337,6 +2362,28 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/crates/pdf-reader-mcp-server/Cargo.toml
+++ b/crates/pdf-reader-mcp-server/Cargo.toml
@@ -23,6 +23,7 @@ anyhow = "1"
 axum = "0.8"
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
+command-group = { version = "5", features = ["with-tokio"] }
 pdf-reader-core = { path = "../pdf-reader-core", version = "3.1.1" }
 rmcp = { version = "0.16.0", features = ["server", "transport-io", "transport-streamable-http-server"] }
 schemars = { version = "1", features = ["derive"] }
@@ -30,5 +31,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 subtle = "2"
+tempfile = "3"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }

--- a/crates/pdf-reader-mcp-server/src/lib.rs
+++ b/crates/pdf-reader-mcp-server/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cli_bridge;
 pub mod evidence;
 pub mod http_transport;
+mod ocr_evidence;
 pub mod pdf_evidence;
 pub mod read_pdf;
 pub mod schema;
@@ -15,7 +16,7 @@ use rmcp::{
     tool, tool_handler, tool_router, ErrorData, ServerHandler,
 };
 
-use crate::schema::{PdfEvidenceArgs, ReadPdfArgs, SearchPdfArgs};
+use crate::schema::{PdfEvidenceArgs, PdfEvidenceOperation, ReadPdfArgs, SearchPdfArgs};
 use serde_json::Value;
 
 pub const SERVER_NAME: &str = "pdf-reader-mcp";
@@ -23,8 +24,8 @@ pub const SERVER_NAME: &str = "pdf-reader-mcp";
 pub const SERVER_VERSION: &str = "0.0.0-pure-rust-experimental";
 pub const SERVER_INSTRUCTIONS: &str =
     "Experimental pure-Rust PDF MCP engine (not the published npm latest). \
-Supported depth: selectable-text read_pdf, search_pdf, pdf_evidence inspect. \
-Bounded page render and region crop are available with Hayro provenance; OCR/analyze fail closed. \
+Supported depth: selectable-text read_pdf, search_pdf, and focused pdf_evidence operations. \
+Bounded Hayro render/crop and opt-in command-provider OCR are available; analyze_regions fails closed. \
 For production drop-in use @sylphx/pdf-reader-mcp@3.0.14 (TypeScript).";
 
 fn omit_absent_optional_fields(value: Value) -> Value {
@@ -106,14 +107,15 @@ impl PdfReaderMcp {
     }
 
     #[tool(
-        description = "Focused PDF evidence operations. Pure-Rust supports inspect, bounded page rendering, and region crops; OCR/analyze fail closed with guidance."
+        description = "Focused PDF evidence operations. Pure-Rust supports inspect, bounded page rendering/crops, and opt-in command-provider OCR; analyze_regions fails closed with guidance."
     )]
-    pub fn pdf_evidence(
+    pub async fn pdf_evidence(
         &self,
         Parameters(args): Parameters<PdfEvidenceArgs>,
     ) -> Result<rmcp::model::CallToolResult, ErrorData> {
         args.validate()
             .map_err(|message| ErrorData::invalid_params(message, None))?;
+        let provider_operation = matches!(args.operation, PdfEvidenceOperation::OcrPages);
         let value = serde_json::to_value(args)
             .map(omit_absent_optional_fields)
             .map_err(|error| {
@@ -122,7 +124,15 @@ impl PdfReaderMcp {
                     None,
                 )
             })?;
-        pdf_evidence::pdf_evidence(value)
+        if provider_operation {
+            tokio::task::spawn_blocking(move || pdf_evidence::pdf_evidence(value))
+                .await
+                .map_err(|error| {
+                    ErrorData::internal_error(format!("OCR worker failed: {error}"), None)
+                })?
+        } else {
+            pdf_evidence::pdf_evidence(value)
+        }
     }
 }
 
@@ -280,8 +290,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn tool_entrypoints_reject_values_outside_v3_0_14_runtime_bounds() {
+    #[tokio::test]
+    async fn tool_entrypoints_reject_values_outside_v3_0_14_runtime_bounds() {
         let server = PdfReaderMcp::new();
         let read = serde_json::from_value(serde_json::json!({
             "sources": [{"path": "sample.pdf"}],
@@ -304,7 +314,7 @@ mod tests {
             "scale": 4.01
         }))
         .expect("structurally valid evidence args");
-        assert!(server.pdf_evidence(Parameters(evidence)).is_err());
+        assert!(server.pdf_evidence(Parameters(evidence)).await.is_err());
     }
 
     #[test]

--- a/crates/pdf-reader-mcp-server/src/ocr_evidence.rs
+++ b/crates/pdf-reader-mcp-server/src/ocr_evidence.rs
@@ -1,0 +1,697 @@
+//! Optional command-provider OCR over the bounded pure-Rust page renderer.
+
+use std::env;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use command_group::AsyncCommandGroup;
+use rmcp::model::{CallToolResult, Content};
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::process::Command;
+
+use crate::schema::PdfEvidenceArgs;
+use crate::visual_evidence;
+
+const DEFAULT_TIMEOUT_MS: u64 = 60_000;
+const DEFAULT_MAX_OUTPUT_CHARS: usize = 200_000;
+const OCR_COMMAND_ENV: &str = "MCP_PDF_OCR_COMMAND";
+const OCR_ARGS_ENV: &str = "MCP_PDF_OCR_ARGS_JSON";
+const OCR_PRESET_ENV: &str = "MCP_PDF_OCR_PRESET";
+const MAX_SOURCES_PER_REQUEST: usize = 32;
+const MAX_REQUEST_OCR_TIMEOUT_MS: u64 = 600_000;
+const MAX_REQUEST_OCR_OUTPUT_CHARS: usize = 2_000_000;
+const MAX_REQUEST_OCR_PROVIDER_BYTES: usize = 16 * 1024 * 1024;
+const MAX_CONCURRENT_OCR_REQUESTS: usize = 2;
+static ACTIVE_OCR_REQUESTS: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Debug)]
+struct OcrRequestPermit;
+
+impl OcrRequestPermit {
+    fn acquire() -> Result<Self, String> {
+        ACTIVE_OCR_REQUESTS
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |active| {
+                (active < MAX_CONCURRENT_OCR_REQUESTS).then_some(active + 1)
+            })
+            .map(|_| Self)
+            .map_err(|_| {
+                format!(
+                    "OCR provider concurrency limit of {MAX_CONCURRENT_OCR_REQUESTS} active requests reached; retry later."
+                )
+            })
+    }
+}
+
+impl Drop for OcrRequestPermit {
+    fn drop(&mut self) {
+        ACTIVE_OCR_REQUESTS.fetch_sub(1, Ordering::Release);
+    }
+}
+
+#[derive(Default)]
+struct RequestOcrBudget {
+    output_chars: usize,
+    provider_bytes: usize,
+    exhausted: Option<String>,
+}
+
+impl RequestOcrBudget {
+    fn ensure_available(&self) -> Result<(), String> {
+        self.exhausted.clone().map_or(Ok(()), Err)
+    }
+
+    fn exhaust(&mut self, message: String) -> Result<(), String> {
+        self.exhausted = Some(message.clone());
+        Err(message)
+    }
+
+    fn charge(&mut self, provider_bytes: usize, output_chars: usize) -> Result<(), String> {
+        self.ensure_available()?;
+        let Some(next_provider_bytes) = self.provider_bytes.checked_add(provider_bytes) else {
+            return self.exhaust("Request OCR provider byte count overflow.".to_string());
+        };
+        self.provider_bytes = next_provider_bytes;
+        if self.provider_bytes > MAX_REQUEST_OCR_PROVIDER_BYTES {
+            return self.exhaust(format!(
+                "Request exceeds OCR provider output limit of {MAX_REQUEST_OCR_PROVIDER_BYTES} bytes."
+            ));
+        }
+        let Some(next_output_chars) = self.output_chars.checked_add(output_chars) else {
+            return self.exhaust("Request OCR output character count overflow.".to_string());
+        };
+        self.output_chars = next_output_chars;
+        if self.output_chars > MAX_REQUEST_OCR_OUTPUT_CHARS {
+            return self.exhaust(format!(
+                "Request exceeds OCR output limit of {MAX_REQUEST_OCR_OUTPUT_CHARS} characters."
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct ProviderConfig {
+    command: String,
+    args_template: Vec<String>,
+}
+
+fn parse_args(value: &Value) -> Result<PdfEvidenceArgs, rmcp::ErrorData> {
+    let args: PdfEvidenceArgs = serde_json::from_value(value.clone()).map_err(|error| {
+        rmcp::ErrorData::invalid_params(format!("Invalid pdf_evidence arguments: {error}"), None)
+    })?;
+    args.validate()
+        .map_err(|message| rmcp::ErrorData::invalid_params(message, None))?;
+    Ok(args)
+}
+
+fn provider_config_from(
+    command_value: Option<String>,
+    preset_value: Option<String>,
+    args_value: Option<String>,
+) -> Result<ProviderConfig, String> {
+    let preset = preset_value
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty());
+    if preset
+        .as_deref()
+        .is_some_and(|value| !matches!(value, "tesseract" | "tesseract-tsv"))
+    {
+        return Err(
+            "Unsupported MCP_PDF_OCR_PRESET. Supported values: tesseract, tesseract-tsv.".into(),
+        );
+    }
+    if preset.as_deref() == Some("tesseract-tsv") {
+        return Err("MCP_PDF_OCR_PRESET=tesseract-tsv is not available in the pure-Rust engine yet; use tesseract plain text or a command provider that returns normalized JSON.".into());
+    }
+    let command = command_value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| preset.as_ref().map(|_| "tesseract".into()))
+        .ok_or_else(|| {
+            "OCR provider is not configured. Set MCP_PDF_OCR_COMMAND or MCP_PDF_OCR_PRESET=tesseract to enable ocr_pages."
+                .to_string()
+        })?;
+    let default_args = match preset.as_deref() {
+        Some("tesseract-tsv") => vec![
+            "{input}".into(),
+            "stdout".into(),
+            "-l".into(),
+            "{languages_tesseract}".into(),
+            "tsv".into(),
+        ],
+        Some("tesseract") => vec![
+            "{input}".into(),
+            "stdout".into(),
+            "-l".into(),
+            "{languages_tesseract}".into(),
+        ],
+        _ => vec!["{input}".into()],
+    };
+    let args_template = match args_value {
+        None => default_args,
+        Some(raw) => {
+            let value: Value = serde_json::from_str(&raw)
+                .map_err(|_| "MCP_PDF_OCR_ARGS_JSON must be a JSON string array.".to_string())?;
+            let array = value
+                .as_array()
+                .ok_or_else(|| "MCP_PDF_OCR_ARGS_JSON must be a JSON string array.".to_string())?;
+            let args = array
+                .iter()
+                .map(|entry| {
+                    entry.as_str().map(ToOwned::to_owned).ok_or_else(|| {
+                        "MCP_PDF_OCR_ARGS_JSON must be a JSON string array.".to_string()
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            if !args.iter().any(|arg| arg.contains("{input}")) {
+                return Err("MCP_PDF_OCR_ARGS_JSON must include the {input} placeholder so the OCR provider receives the rendered page image.".into());
+            }
+            args
+        }
+    };
+    Ok(ProviderConfig {
+        command,
+        args_template,
+    })
+}
+
+fn provider_config() -> Result<ProviderConfig, String> {
+    provider_config_from(
+        env::var(OCR_COMMAND_ENV).ok(),
+        env::var(OCR_PRESET_ENV).ok(),
+        env::var(OCR_ARGS_ENV).ok(),
+    )
+}
+
+fn replace_placeholders(
+    template: &str,
+    input: &str,
+    page: u64,
+    source: &str,
+    languages: &[String],
+) -> String {
+    template
+        .replace("{input}", input)
+        .replace("{page}", &page.to_string())
+        .replace("{source}", source)
+        .replace("{language}", languages.first().map_or("", String::as_str))
+        .replace("{languages}", &languages.join(","))
+        .replace(
+            "{languages_tesseract}",
+            if languages.is_empty() {
+                "eng".into()
+            } else {
+                languages.join("+")
+            }
+            .as_str(),
+        )
+}
+
+async fn read_bounded<R: AsyncRead + Unpin>(reader: R, maximum: usize) -> std::io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    reader
+        .take(u64::try_from(maximum).unwrap_or(u64::MAX).saturating_add(1))
+        .read_to_end(&mut bytes)
+        .await?;
+    Ok(bytes)
+}
+
+async fn run_provider_async(
+    config: ProviderConfig,
+    png: Vec<u8>,
+    page: u64,
+    source: String,
+    languages: Vec<String>,
+    timeout_ms: u64,
+    max_output_chars: usize,
+) -> Result<String, String> {
+    let temp = TempDir::with_prefix("pdf-reader-mcp-ocr-")
+        .map_err(|_| "Failed to create OCR provider workspace.".to_string())?;
+    let input = temp.path().join(format!("page-{page}.png"));
+    std::fs::write(&input, png)
+        .map_err(|_| "Failed to write OCR provider input image.".to_string())?;
+    let input = input.to_string_lossy();
+    let args = config
+        .args_template
+        .iter()
+        .map(|arg| replace_placeholders(arg, &input, page, &source, &languages))
+        .collect::<Vec<_>>();
+    let mut command = Command::new(&config.command);
+    command
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command
+        .group_spawn()
+        .map_err(|_| format!("OCR provider command failed for page {page}."))?;
+    let maximum = max_output_chars.saturating_mul(4).max(1024 * 1024);
+    let stdout = child
+        .inner()
+        .stdout
+        .take()
+        .ok_or_else(|| "OCR provider stdout was unavailable.".to_string())?;
+    let stderr = child
+        .inner()
+        .stderr
+        .take()
+        .ok_or_else(|| "OCR provider stderr was unavailable.".to_string())?;
+    let execution = async {
+        tokio::join!(
+            child.inner().wait(),
+            read_bounded(stdout, maximum),
+            read_bounded(stderr, 64 * 1024)
+        )
+    };
+    let (status, stdout, stderr) =
+        match tokio::time::timeout(Duration::from_millis(timeout_ms), execution).await {
+            Ok(results) => results,
+            Err(_) => {
+                // The timed-out read futures are cancelled and their local pipe handles drop
+                // before this branch. Tree termination and leader reaping are both best-effort
+                // and bounded, so an escaped Unix descendant cannot extend the request deadline.
+                let _ = child.start_kill();
+                let _ = tokio::time::timeout(Duration::from_secs(2), child.inner().wait()).await;
+                return Err(format!("OCR provider command timed out for page {page}."));
+            }
+        };
+    // Terminate any helper left in the process group/job after the leader and pipes close.
+    let _ = child.start_kill();
+    let status = status.map_err(|_| format!("OCR provider command failed for page {page}."))?;
+    let stdout = stdout.map_err(|_| "OCR provider stdout reader failed.".to_string())?;
+    let _stderr = stderr.map_err(|_| "OCR provider stderr reader failed.".to_string())?;
+    if !status.success() || stdout.len() > maximum {
+        return Err(format!("OCR provider command failed for page {page}."));
+    }
+    Ok(String::from_utf8_lossy(&stdout).into_owned())
+}
+
+fn run_provider(
+    config: &ProviderConfig,
+    png: &[u8],
+    page: u64,
+    source: &str,
+    languages: &[String],
+    timeout_ms: u64,
+    max_output_chars: usize,
+) -> Result<String, String> {
+    let config = config.clone();
+    let png = png.to_vec();
+    let source = source.to_string();
+    let languages = languages.to_vec();
+    thread::spawn(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|_| "Failed to start bounded OCR provider runtime.".to_string())?
+            .block_on(run_provider_async(
+                config,
+                png,
+                page,
+                source,
+                languages,
+                timeout_ms,
+                max_output_chars,
+            ))
+    })
+    .join()
+    .map_err(|_| "OCR provider worker failed.".to_string())?
+}
+
+fn normalize_confidence(value: &Value) -> Option<f64> {
+    let value = value.as_f64()?;
+    value.is_finite().then(|| {
+        let value = if value > 1.0 { value / 100.0 } else { value };
+        value.clamp(0.0, 1.0)
+    })
+}
+
+fn round_coordinate(value: f64) -> f64 {
+    (value * 100.0).round() / 100.0
+}
+
+fn normalize_words(value: &Value, scale: f64) -> Option<Vec<Value>> {
+    let words = value
+        .as_array()?
+        .iter()
+        .filter_map(|word| {
+            let word = word.as_object()?;
+            let text = word.get("text")?.as_str()?;
+            if text.trim().is_empty() {
+                return None;
+            }
+            let mut output = json!({"text": text});
+            if let Some(confidence) = word.get("confidence").and_then(normalize_confidence) {
+                output["confidence"] = json!(confidence);
+            }
+            if let Some(box_) = word.get("bounding_box").and_then(Value::as_object) {
+                let left = box_.get("left").and_then(Value::as_f64);
+                let bottom = box_.get("bottom").and_then(Value::as_f64);
+                let right = box_.get("right").and_then(Value::as_f64);
+                let top = box_.get("top").and_then(Value::as_f64);
+                if let (Some(left), Some(bottom), Some(right), Some(top)) =
+                    (left, bottom, right, top)
+                {
+                    if [left, bottom, right, top]
+                        .iter()
+                        .all(|value| value.is_finite())
+                        && right > left
+                        && top > bottom
+                    {
+                        output["bounding_box"] = json!({
+                            "left": round_coordinate(left / scale),
+                            "bottom": round_coordinate(bottom / scale),
+                            "right": round_coordinate(right / scale),
+                            "top": round_coordinate(top / scale),
+                        });
+                    }
+                }
+            }
+            Some(output)
+        })
+        .collect::<Vec<_>>();
+    (!words.is_empty()).then_some(words)
+}
+
+fn truncate_utf16(text: &str, maximum: usize) -> (String, bool) {
+    let mut units = 0usize;
+    let mut end = text.len();
+    for (index, character) in text.char_indices() {
+        let next = units + character.len_utf16();
+        if next > maximum {
+            end = index;
+            break;
+        }
+        units = next;
+    }
+    (
+        text[..end].to_string(),
+        text.encode_utf16().count() > maximum,
+    )
+}
+
+fn normalize_output(
+    stdout: &str,
+    max_output_chars: usize,
+    languages: &[String],
+    scale: f64,
+) -> Value {
+    let trimmed = stdout.trim();
+    let parsed = serde_json::from_str::<Value>(trimmed)
+        .ok()
+        .filter(Value::is_object);
+    let raw_text = parsed
+        .as_ref()
+        .and_then(|value| value.get("text"))
+        .and_then(Value::as_str)
+        .unwrap_or(trimmed);
+    let (text, truncated) = truncate_utf16(raw_text, max_output_chars);
+    let mut output = json!({"text": text});
+    if let Some(confidence) = parsed
+        .as_ref()
+        .and_then(|value| value.get("confidence"))
+        .and_then(normalize_confidence)
+    {
+        output["confidence"] = json!(confidence);
+    }
+    if let Some(words) = parsed
+        .as_ref()
+        .and_then(|value| value.get("words"))
+        .and_then(|value| normalize_words(value, scale))
+    {
+        output["words"] = json!(words);
+    }
+    if let Some(language) = parsed
+        .as_ref()
+        .and_then(|value| value.get("language"))
+        .and_then(Value::as_str)
+        .or_else(|| languages.first().map(String::as_str))
+    {
+        output["language"] = json!(language);
+    }
+    if truncated {
+        output["warnings"] = json!([format!(
+            "OCR output truncated to {max_output_chars} characters."
+        )]);
+    }
+    output
+}
+
+fn text_result(payload: Value) -> CallToolResult {
+    let text = serde_json::to_string_pretty(&payload).unwrap_or_else(|_| payload.to_string());
+    CallToolResult {
+        content: vec![Content::text(text)],
+        structured_content: Some(payload),
+        is_error: Some(false),
+        meta: None,
+    }
+}
+
+fn error_result(message: String) -> CallToolResult {
+    CallToolResult::error(vec![Content::text(message)])
+}
+
+pub fn ocr_pages(value: Value) -> Result<CallToolResult, rmcp::ErrorData> {
+    let args = parse_args(&value)?;
+    if args.sources.len() > MAX_SOURCES_PER_REQUEST {
+        return Err(rmcp::ErrorData::invalid_params(
+            format!("pdf_evidence accepts at most {MAX_SOURCES_PER_REQUEST} sources per request."),
+            None,
+        ));
+    }
+    if args.sources.is_empty() {
+        return Ok(error_result("All PDF sources failed OCR: ".into()));
+    }
+    let config = match provider_config() {
+        Ok(config) => config,
+        Err(message) => {
+            return Ok(error_result(format!(
+                "All PDF sources failed OCR: {message}"
+            )))
+        }
+    };
+    let _permit = match OcrRequestPermit::acquire() {
+        Ok(permit) => permit,
+        Err(message) => {
+            return Ok(error_result(format!(
+                "All PDF sources failed OCR: {message}"
+            )))
+        }
+    };
+    let scale = args.scale.unwrap_or(2.0);
+    let max_pages = args.max_pages.unwrap_or(5);
+    let max_pixels = args.max_pixels_per_page.unwrap_or(16_000_000);
+    let timeout_ms = u64::from(args.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS as u32));
+    let max_output_chars = args
+        .max_output_chars
+        .map_or(DEFAULT_MAX_OUTPUT_CHARS, |value| value as usize);
+    let languages_provided = args.languages.is_some();
+    let languages = args.languages.unwrap_or_default();
+    let request_deadline = Instant::now() + Duration::from_millis(MAX_REQUEST_OCR_TIMEOUT_MS);
+    let mut request_budget = RequestOcrBudget::default();
+    let mut render_input = value;
+    render_input["operation"] = json!("render_page");
+    render_input["include_image"] = json!(true);
+    let rendered = visual_evidence::render_pages(render_input)?;
+    let encoded = serde_json::to_value(&rendered).map_err(|error| {
+        rmcp::ErrorData::internal_error(format!("Failed to encode render evidence: {error}"), None)
+    })?;
+    let Some(payload) = rendered.structured_content else {
+        let message = encoded["content"][0]["text"]
+            .as_str()
+            .unwrap_or("All PDF sources failed OCR.");
+        return Ok(error_result(
+            message.replace("failed to render", "failed OCR"),
+        ));
+    };
+    let mut results = Vec::new();
+    for source in payload["results"].as_array().into_iter().flatten() {
+        let source_label = source["source"].as_str().unwrap_or("unknown source");
+        if source["success"] != true {
+            results.push(json!({
+                "source": source_label,
+                "success": false,
+                "error": source["error"],
+            }));
+            continue;
+        }
+        let output = (|| -> Result<Value, String> {
+            let mut ocr_pages = Vec::new();
+            for page in source["rendered_pages"].as_array().into_iter().flatten() {
+                request_budget.ensure_available()?;
+                let page_number = page["page"].as_u64().unwrap_or(0);
+                let index = page["image_content_index"]
+                    .as_u64()
+                    .ok_or_else(|| "Rendered OCR input image index is missing.".to_string())?;
+                let data = encoded["content"][index as usize]["data"]
+                    .as_str()
+                    .ok_or_else(|| "Rendered OCR input image is missing.".to_string())?;
+                let png = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, data)
+                    .map_err(|_| "Rendered OCR input image is invalid.".to_string())?;
+                let remaining_ms = u64::try_from(
+                    request_deadline
+                        .saturating_duration_since(Instant::now())
+                        .as_millis(),
+                )
+                .unwrap_or(u64::MAX);
+                if remaining_ms == 0 {
+                    return Err(format!(
+                        "Request exceeds OCR provider time limit of {MAX_REQUEST_OCR_TIMEOUT_MS} milliseconds."
+                    ));
+                }
+                let stdout = run_provider(
+                    &config,
+                    &png,
+                    page_number,
+                    source_label,
+                    &languages,
+                    timeout_ms.min(remaining_ms),
+                    max_output_chars,
+                )?;
+                let mut normalized = normalize_output(&stdout, max_output_chars, &languages, scale);
+                let output_chars = normalized["text"]
+                    .as_str()
+                    .map_or(0, |text| text.encode_utf16().count());
+                request_budget.charge(stdout.len(), output_chars)?;
+                normalized["page"] = json!(page_number);
+                normalized["provider"] = json!("command");
+                normalized["source_render_evidence_id"] = page["evidence_id"].clone();
+                normalized["source_render_scale"] = page["scale"].clone();
+                normalized["source_render_width"] = page["width"].clone();
+                normalized["source_render_height"] = page["height"].clone();
+                normalized["provenance"] =
+                    json!({"engine": "external-command", "source": "ocr-provider"});
+                ocr_pages.push(normalized);
+            }
+            let mut result = json!({
+                "source": source_label,
+                "success": true,
+                "num_pages": source["num_pages"],
+                "ocr_pages": ocr_pages,
+            });
+            if source.get("warnings").is_some() {
+                result["warnings"] = source["warnings"].clone();
+            }
+            Ok(result)
+        })();
+        results.push(output.unwrap_or_else(
+            |error| json!({"source": source_label, "success": false, "error": error}),
+        ));
+    }
+    if results.iter().all(|result| result["success"] != true) {
+        let errors = results
+            .iter()
+            .filter_map(|result| result["error"].as_str())
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Ok(error_result(format!(
+            "All PDF sources failed OCR: {errors}"
+        )));
+    }
+    let mut options = json!({
+        "scale": scale,
+        "max_pages": max_pages,
+        "max_pixels_per_page": max_pixels,
+        "timeout_ms": timeout_ms,
+        "max_output_chars": max_output_chars,
+    });
+    if languages_provided {
+        options["languages"] = json!(languages);
+    }
+    Ok(text_result(json!({
+        "profile": "ocr_text_layer",
+        "ocr_options": options,
+        "results": results,
+    })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_json_provider_output_and_utf16_truncation() {
+        let output = normalize_output(
+            r#"{"text":"A😀B","confidence":87,"language":"fra","words":[{"text":"A","confidence":50,"bounding_box":{"left":2,"bottom":4,"right":6,"top":8}}]}"#,
+            3,
+            &[],
+            2.0,
+        );
+        assert_eq!(output["text"], "A😀");
+        assert_eq!(output["confidence"], 0.87);
+        assert_eq!(output["language"], "fra");
+        assert_eq!(output["words"][0]["confidence"], 0.5);
+        assert_eq!(
+            output["words"][0]["bounding_box"],
+            json!({"left": 1.0, "bottom": 2.0, "right": 3.0, "top": 4.0})
+        );
+        assert_eq!(
+            output["warnings"][0],
+            "OCR output truncated to 3 characters."
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_provider_configuration_without_shell_parsing() {
+        let error = provider_config_from(
+            Some("provider".into()),
+            None,
+            Some(r#"["--no-input"]"#.into()),
+        )
+        .err()
+        .expect("invalid args");
+        assert!(error.contains("{input}"));
+        assert!(
+            provider_config_from(None, Some("tesseract-tsv".into()), None)
+                .err()
+                .expect("tsv fails closed")
+                .contains("not available")
+        );
+    }
+
+    #[test]
+    fn request_budget_is_request_wide_and_fail_closed() {
+        let mut budget = RequestOcrBudget::default();
+        budget
+            .charge(
+                MAX_REQUEST_OCR_PROVIDER_BYTES - 1,
+                MAX_REQUEST_OCR_OUTPUT_CHARS - 1,
+            )
+            .expect("within budget");
+        assert!(budget
+            .charge(2, 0)
+            .expect_err("byte overflow")
+            .contains("bytes"));
+
+        let mut budget = RequestOcrBudget::default();
+        budget
+            .charge(0, MAX_REQUEST_OCR_OUTPUT_CHARS - 1)
+            .expect("within budget");
+        assert!(budget
+            .charge(0, 2)
+            .expect_err("character overflow")
+            .contains("characters"));
+        assert!(budget
+            .ensure_available()
+            .expect_err("exhaustion is sticky")
+            .contains("characters"));
+    }
+
+    #[test]
+    fn provider_concurrency_admission_is_process_wide_and_recoverable() {
+        let first = OcrRequestPermit::acquire().expect("first permit");
+        let second = OcrRequestPermit::acquire().expect("second permit");
+        assert!(OcrRequestPermit::acquire()
+            .expect_err("third request rejected")
+            .contains("concurrency limit"));
+        drop(first);
+        let replacement = OcrRequestPermit::acquire().expect("released slot is reusable");
+        drop(second);
+        drop(replacement);
+        assert_eq!(ACTIVE_OCR_REQUESTS.load(Ordering::Acquire), 0);
+    }
+}

--- a/crates/pdf-reader-mcp-server/src/pdf_evidence.rs
+++ b/crates/pdf-reader-mcp-server/src/pdf_evidence.rs
@@ -6,6 +6,7 @@ use serde_json::{json, Value};
 use std::path::PathBuf;
 
 use crate::evidence::attach_evidence;
+use crate::ocr_evidence;
 use crate::schema::PdfSource;
 use crate::visual_evidence;
 
@@ -22,7 +23,8 @@ pub fn pdf_evidence(args: Value) -> Result<CallToolResult, rmcp::ErrorData> {
         "inspect" => inspect(args),
         "render_page" => visual_evidence::render_pages(args),
         "extract_regions" => visual_evidence::extract_regions(args),
-        "ocr_pages" | "analyze_regions" => {
+        "ocr_pages" => ocr_evidence::ocr_pages(args),
+        "analyze_regions" => {
             // Pure-Rust v1: return structured, non-crashing guidance rather than silent no-op.
             // inspect covers the default agent routing path; visual ops need providers/native render.
             Err(rmcp::ErrorData::invalid_request(

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -66,21 +66,21 @@
       "inspect": "PARTIAL",
       "render_page": "PARTIAL",
       "extract_regions": "PARTIAL",
-      "ocr_pages": "FAIL_CLOSED",
+      "ocr_pages": "PARTIAL",
       "analyze_regions": "FAIL_CLOSED"
     }
   },
   "claimedForDifferential": [
     "exact 10-case immutable TS v3.0.14 behavior subset: full text, page selection/order/duplicates, metadata, literal search, case sensitivity, whole word, Unicode, UTF-16 offsets, missing and malformed inputs, and mixed-source partial success",
-    "exact 7-case immutable TS v3.0.14 render/crop semantic subset over stdio: defaults, page selection and warnings, region ordering, padding and fractional bounds, rotated pages, mixed-source partial success, all-source failure, MCP image indexing, and truthful Hayro provenance; exact pdf.js pixels and antialiasing are not claimed",
+    "exact 10-case immutable TS v3.0.14 render/crop/command-OCR semantic subset over stdio: defaults, page selection and warnings, region ordering, padding and fractional bounds, rotated pages, mixed-source partial success, all-source failure, MCP image indexing, OCR JSON normalization and truthful provenance; exact pdf.js pixels and antialiasing are not claimed",
     "DNS-pinned URL fetch: one resolution per redirect hop, reject mixed public/non-public answers, disable ambient proxies, and revalidate every redirect; still PARTIAL because resolver timeout and TLS-SNI fixtures remain open",
     "auto off when include_* keys are present"
   ],
   "explicitlyNotClaimed": [
     "complete TS 3.0.14 semantic parity outside the immutable 10-case subset",
     "text/search geometry, geometry-perfect pdf.js boxes, and general bounding-box parity",
-    "render/crop semantic parity outside the immutable 7-case subset, including exact pdf.js pixels and antialiasing",
-    "OCR/analyze success path",
+    "render/crop/OCR semantic parity outside the immutable 10-case subset, including exact pdf.js pixels and antialiasing",
+    "OCR success paths outside the opt-in command JSON/plain-text subset, including tesseract-tsv; analyze success path",
     "COS outline/annotations/forms",
     "cross-platform npm native binary",
     "npm library exports for pure-Rust",

--- a/scripts/differential/capture-v3014-visual-oracle.ts
+++ b/scripts/differential/capture-v3014-visual-oracle.ts
@@ -12,6 +12,7 @@ const corpusPath = join(scriptDir, 'fixtures/v3014-visual-corpus.json');
 const oraclePath = join(scriptDir, 'fixtures/v3014-visual-oracle.json');
 const fixtureDir = join(repoRoot, 'test/fixtures/differential');
 const runnerSource = join(scriptDir, 'v3014-visual-baseline-runner.ts');
+const providerPath = join(scriptDir, 'reference-ocr-provider.ts');
 const refresh = process.argv.includes('--refresh');
 const oracle = JSON.parse(readFileSync(oraclePath, 'utf8')) as {
   baseline: { tag: string; commit: string };
@@ -40,7 +41,7 @@ try {
   run('bun', ['install', '--frozen-lockfile'], worktree);
   const runner = join(worktree, 'v3014-visual-baseline-runner.ts');
   writeFileSync(runner, readFileSync(runnerSource));
-  const stdout = run('bun', [runner, corpusPath, fixtureDir], worktree, true);
+  const stdout = run('bun', [runner, corpusPath, fixtureDir, providerPath], worktree, true);
   const expectations = JSON.parse(stdout) as Record<string, unknown>;
   if (refresh) {
     writeFileSync(oraclePath, `${JSON.stringify({ ...oracle, expectations }, null, 2)}\n`);

--- a/scripts/differential/check-v3014-visual-differential.ts
+++ b/scripts/differential/check-v3014-visual-differential.ts
@@ -17,6 +17,7 @@ const fixtureDir = join(repoRoot, 'test/fixtures/differential');
 const corpusPath = join(scriptDir, 'fixtures/v3014-visual-corpus.json');
 const oraclePath = join(scriptDir, 'fixtures/v3014-visual-oracle.json');
 const fixtureManifestPath = join(scriptDir, 'fixtures/v3014-visual-fixtures.json');
+const providerPath = join(scriptDir, 'reference-ocr-provider.ts');
 const serverPath = join(repoRoot, 'target/release/pdf-reader-mcp-server');
 const outputFlag = process.argv.indexOf('--output');
 const outputPath = outputFlag >= 0 ? process.argv[outputFlag + 1] : undefined;
@@ -33,6 +34,7 @@ const oracle = JSON.parse(readFileSync(oraclePath, 'utf8')) as {
     entrypointSha256: Record<string, string>;
   };
   expectations: Record<string, Json>;
+  providerSha256: string;
 };
 const fixtureManifest = JSON.parse(readFileSync(fixtureManifestPath, 'utf8')) as {
   fixtures: Array<{ path: string; bytes: number; sha256: string }>;
@@ -66,8 +68,11 @@ function verifyAuthority(): Record<string, string> {
     }
   }
   const ids = corpus.cases.map((entry) => entry.id);
-  if (ids.length !== 7 || new Set(ids).size !== ids.length) {
-    throw new Error(`visual corpus must contain 7 unique cases (got ${ids.length})`);
+  if (ids.length !== 10 || new Set(ids).size !== ids.length) {
+    throw new Error(`visual/OCR corpus must contain 10 unique cases (got ${ids.length})`);
+  }
+  if (sha256(readFileSync(providerPath)) !== oracle.providerSha256) {
+    throw new Error('reference OCR provider digest mismatch');
   }
   if (JSON.stringify(ids.sort()) !== JSON.stringify(Object.keys(oracle.expectations).sort())) {
     throw new Error('visual corpus and oracle IDs differ');
@@ -231,12 +236,34 @@ function canonicalize(result: ToolResult): Json {
         };
       });
     }
+    if (Array.isArray(source.ocr_pages)) {
+      output.ocr_pages = source.ocr_pages.map((page: Record<string, unknown>) => {
+        const provenance = page.provenance as Record<string, unknown>;
+        if (provenance?.engine !== 'external-command' || provenance?.source !== 'ocr-provider') {
+          throw new Error('Rust OCR provider provenance is not truthful');
+        }
+        return {
+          page: page.page,
+          text: page.text,
+          confidence: page.confidence ?? null,
+          language: page.language ?? null,
+          words: page.words ?? [],
+          provider: page.provider,
+          source_render_evidence_id: page.source_render_evidence_id,
+          source_render_scale: page.source_render_scale,
+          source_render_width: page.source_render_width,
+          source_render_height: page.source_render_height,
+          warnings: page.warnings ?? [],
+          provenance: page.provenance,
+        };
+      });
+    }
     return output;
   });
   return {
     outcome: 'success',
     profile: (payload.profile ?? null) as Json,
-    options: (payload.render_options ?? payload.crop_options ?? null) as Json,
+    options: (payload.render_options ?? payload.crop_options ?? payload.ocr_options ?? null) as Json,
     content_count: result.content.length,
     results: results as Json,
   };
@@ -248,7 +275,18 @@ async function main() {
   const child = spawn(serverPath, [], {
     cwd: repoRoot,
     stdio: ['pipe', 'pipe', 'inherit'],
-    env: { ...process.env, PDF_READER_MCP_TRANSPORT: '', MCP_TRANSPORT: '' },
+    env: {
+      ...process.env,
+      PDF_READER_MCP_TRANSPORT: '',
+      MCP_TRANSPORT: '',
+      MCP_PDF_OCR_COMMAND: process.execPath,
+      MCP_PDF_OCR_ARGS_JSON: JSON.stringify([
+        providerPath,
+        '{input}',
+        '{page}',
+        '{languages}',
+      ]),
+    },
   });
   let buffer = '';
   const pending = new Map<number, (value: Record<string, unknown>) => void>();

--- a/scripts/differential/fixtures/v3014-visual-corpus.json
+++ b/scripts/differential/fixtures/v3014-visual-corpus.json
@@ -107,6 +107,37 @@
         ],
         "scale": 1
       }
+    },
+    {
+      "id": "ocr-command-json-normalization",
+      "input": {
+        "operation": "ocr_pages",
+        "sources": [{ "fixture": "v3014-visual-v1.pdf", "pages": [1] }],
+        "scale": 2,
+        "max_pages": 1,
+        "languages": ["fra", "eng"]
+      }
+    },
+    {
+      "id": "ocr-selection-warnings",
+      "input": {
+        "operation": "ocr_pages",
+        "sources": [{ "fixture": "v3014-visual-v1.pdf", "pages": [2, 99, 1, 2] }],
+        "scale": 1,
+        "max_pages": 1
+      }
+    },
+    {
+      "id": "ocr-mixed-source-partial",
+      "input": {
+        "operation": "ocr_pages",
+        "sources": [
+          { "fixture": "missing-visual.pdf", "pages": [1] },
+          { "fixture": "v3014-visual-v1.pdf", "pages": [2] }
+        ],
+        "scale": 1,
+        "max_pages": 1
+      }
     }
   ]
 }

--- a/scripts/differential/fixtures/v3014-visual-oracle.json
+++ b/scripts/differential/fixtures/v3014-visual-oracle.json
@@ -1,6 +1,7 @@
 {
   "schemaVersion": 1,
   "profile": "pdf_reader_v3014_visual_oracle",
+  "providerSha256": "86ab98b7ad9729da32b18326c728eaa3c87d33b2786c813b7e82e619db32c4b6",
   "baseline": {
     "tag": "v3.0.14",
     "commit": "92651c79c6ce8d10dfa3c76332176c26f222bd78",
@@ -10,6 +11,8 @@
       "src/handlers/pdfEvidence.ts": "64f54e17c30de61c93ea2083d59b6463def08fcd08e100489e10380d72db1228",
       "src/handlers/renderPage.ts": "7c0b57658eca56ec995c376a4a20455cc967f13a807a1194a1d746d23db89e7a",
       "src/handlers/extractRegions.ts": "a125e4fa3b9c3aee1087f7e60a5092ce2354d918d2b1d01bc70f222d42219c33",
+      "src/handlers/ocrPages.ts": "3ecca45d73471c422b225bba1a2bfee704d316826bf9f509ccf8d860f2ea6ac4",
+      "src/pdf/ocr.ts": "9c2f89afb8426fea801501f7a2264a90e536609c7f5d64e7257945d4038041ee",
       "src/pdf/renderer.ts": "29cf9917feaa470d3e3dafea5b432439fe0450eaee90b350458fb1e41bfe75a8",
       "src/pdf/regions.ts": "f7bc3c939e57fd33260d1bf5d8210c0bde0f7cb3ea756c4912b371c1997e4f91"
     }
@@ -547,6 +550,168 @@
     "crop-degenerate-all-fail": {
       "outcome": "error",
       "category": "invalid_bounding_box"
+    },
+    "ocr-command-json-normalization": {
+      "outcome": "success",
+      "profile": "ocr_text_layer",
+      "options": {
+        "scale": 2,
+        "max_pages": 1,
+        "max_pixels_per_page": 16000000,
+        "timeout_ms": 60000,
+        "max_output_chars": 200000,
+        "languages": [
+          "fra",
+          "eng"
+        ]
+      },
+      "content_count": 1,
+      "results": [
+        {
+          "source": "v3014-visual-v1.pdf",
+          "success": true,
+          "num_pages": 3,
+          "warnings": [],
+          "ocr_pages": [
+            {
+              "page": 1,
+              "text": "Reference OCR page 1 at 240x160",
+              "confidence": 0.87,
+              "language": "fra",
+              "words": [
+                {
+                  "text": "Reference",
+                  "confidence": 0.91,
+                  "bounding_box": {
+                    "left": 10,
+                    "bottom": 5,
+                    "right": 50,
+                    "top": 15
+                  }
+                }
+              ],
+              "provider": "command",
+              "source_render_evidence_id": "page-1-render-scale-2",
+              "source_render_scale": 2,
+              "source_render_width": 240,
+              "source_render_height": 160,
+              "warnings": [],
+              "provenance": {
+                "engine": "external-command",
+                "source": "ocr-provider"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ocr-selection-warnings": {
+      "outcome": "success",
+      "profile": "ocr_text_layer",
+      "options": {
+        "scale": 1,
+        "max_pages": 1,
+        "max_pixels_per_page": 16000000,
+        "timeout_ms": 60000,
+        "max_output_chars": 200000
+      },
+      "content_count": 1,
+      "results": [
+        {
+          "source": "v3014-visual-v1.pdf",
+          "success": true,
+          "num_pages": 3,
+          "warnings": [
+            "Requested pages 99 exceed document page count 3.",
+            "Rendered first 1 selected pages; skipped 2 due to max_pages."
+          ],
+          "ocr_pages": [
+            {
+              "page": 1,
+              "text": "Reference OCR page 1 at 120x80",
+              "confidence": 0.87,
+              "language": null,
+              "words": [
+                {
+                  "text": "Reference",
+                  "confidence": 0.91,
+                  "bounding_box": {
+                    "left": 20,
+                    "bottom": 10,
+                    "right": 100,
+                    "top": 30
+                  }
+                }
+              ],
+              "provider": "command",
+              "source_render_evidence_id": "page-1-render-scale-1",
+              "source_render_scale": 1,
+              "source_render_width": 120,
+              "source_render_height": 80,
+              "warnings": [],
+              "provenance": {
+                "engine": "external-command",
+                "source": "ocr-provider"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "ocr-mixed-source-partial": {
+      "outcome": "success",
+      "profile": "ocr_text_layer",
+      "options": {
+        "scale": 1,
+        "max_pages": 1,
+        "max_pixels_per_page": 16000000,
+        "timeout_ms": 60000,
+        "max_output_chars": 200000
+      },
+      "content_count": 1,
+      "results": [
+        {
+          "source": "missing-visual.pdf",
+          "success": false,
+          "category": "file_not_found"
+        },
+        {
+          "source": "v3014-visual-v1.pdf",
+          "success": true,
+          "num_pages": 3,
+          "warnings": [],
+          "ocr_pages": [
+            {
+              "page": 2,
+              "text": "Reference OCR page 2 at 80x120",
+              "confidence": 0.87,
+              "language": null,
+              "words": [
+                {
+                  "text": "Reference",
+                  "confidence": 0.91,
+                  "bounding_box": {
+                    "left": 20,
+                    "bottom": 10,
+                    "right": 100,
+                    "top": 30
+                  }
+                }
+              ],
+              "provider": "command",
+              "source_render_evidence_id": "page-2-render-scale-1",
+              "source_render_scale": 1,
+              "source_render_width": 80,
+              "source_render_height": 120,
+              "warnings": [],
+              "provenance": {
+                "engine": "external-command",
+                "source": "ocr-provider"
+              }
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/scripts/differential/reference-ocr-provider.ts
+++ b/scripts/differential/reference-ocr-provider.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env bun
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { PNG } from 'pngjs';
+
+const [input, page = '0', languages = '', mode = 'success', marker = ''] = process.argv.slice(2);
+if (!input) throw new Error('usage: reference-ocr-provider <input.png> <page> <languages>');
+if (mode === 'fail') process.exit(7);
+if (mode === 'sleep') await Bun.sleep(5_000);
+if (mode === 'escaped-descendant') {
+  if (marker) writeFileSync(marker, input);
+  const command =
+    process.platform === 'win32'
+      ? [process.execPath, '-e', 'await Bun.sleep(5_000)']
+      : ['python3', '-c', 'import os,time; os.setsid(); time.sleep(5)'];
+  const descendant = Bun.spawn({
+    cmd: command,
+    stdin: 'ignore',
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+  descendant.unref();
+  process.exit(0);
+}
+const png = PNG.sync.read(readFileSync(input));
+
+process.stdout.write(
+  JSON.stringify({
+    text: `Reference OCR page ${page} at ${String(png.width)}x${String(png.height)}`,
+    confidence: 87,
+    words: [
+      {
+        text: 'Reference',
+        confidence: 91,
+        bounding_box: { left: 20, bottom: 10, right: 100, top: 30 },
+      },
+    ],
+    ...(languages ? { language: languages.split(',')[0] } : {}),
+  })
+);

--- a/scripts/differential/v3014-visual-baseline-runner.ts
+++ b/scripts/differential/v3014-visual-baseline-runner.ts
@@ -8,8 +8,17 @@ import { pdfEvidence } from './src/handlers/pdfEvidence.ts';
 type Content = { type: string; text?: string; data?: string; mimeType?: string };
 type ToolResult = { content: Content[]; isError?: boolean };
 
-const [corpusPath, fixtureDir] = process.argv.slice(2);
-if (!corpusPath || !fixtureDir) throw new Error('usage: runner <corpus.json> <fixture-dir>');
+const [corpusPath, fixtureDir, providerPath] = process.argv.slice(2);
+if (!corpusPath || !fixtureDir || !providerPath) {
+  throw new Error('usage: runner <corpus.json> <fixture-dir> <provider.ts>');
+}
+process.env['MCP_PDF_OCR_COMMAND'] = process.execPath;
+process.env['MCP_PDF_OCR_ARGS_JSON'] = JSON.stringify([
+  providerPath,
+  '{input}',
+  '{page}',
+  '{languages}',
+]);
 const corpus = JSON.parse(readFileSync(corpusPath, 'utf8')) as {
   cases: Array<{ id: string; input: Record<string, unknown> }>;
 };
@@ -142,12 +151,28 @@ function canonicalize(result: ToolResult): Record<string, unknown> {
         };
       });
     }
+    if (Array.isArray(source.ocr_pages)) {
+      output.ocr_pages = source.ocr_pages.map((page: Record<string, unknown>) => ({
+        page: page.page,
+        text: page.text,
+        confidence: page.confidence ?? null,
+        language: page.language ?? null,
+        words: page.words ?? [],
+        provider: page.provider,
+        source_render_evidence_id: page.source_render_evidence_id,
+        source_render_scale: page.source_render_scale,
+        source_render_width: page.source_render_width,
+        source_render_height: page.source_render_height,
+        warnings: page.warnings ?? [],
+        provenance: page.provenance,
+      }));
+    }
     return output;
   });
   return {
     outcome: 'success',
     profile: payload.profile,
-    options: payload.render_options ?? payload.crop_options,
+    options: payload.render_options ?? payload.crop_options ?? payload.ocr_options,
     content_count: result.content.length,
     results,
   };

--- a/scripts/run-pdf-reader-differential.sh
+++ b/scripts/run-pdf-reader-differential.sh
@@ -77,7 +77,7 @@ echo "--- deterministic v3.0.14 visual fixture + baseline replay ---" | tee -a "
 bun "$REPO_ROOT/scripts/differential/generate-v3014-visual-fixtures.ts" 2>&1 | tee -a "$LOG"
 bun "$REPO_ROOT/scripts/differential/capture-v3014-visual-oracle.ts" 2>&1 | tee -a "$LOG"
 
-echo "--- immutable v3.0.14 render/crop differential (7 semantic cases) ---" | tee -a "$LOG"
+echo "--- immutable v3.0.14 render/crop/OCR differential (10 semantic cases) ---" | tee -a "$LOG"
 bun "$REPO_ROOT/scripts/differential/check-v3014-visual-differential.ts" \
   --output "$V3014_VISUAL_JSON" >>"$LOG"
 
@@ -191,7 +191,7 @@ jq -n \
     immutableVisualDifferential: "scripts/differential/check-v3014-visual-differential.ts",
     liveTextOracle: "scripts/differential/ts-vs-rust-text-oracle.ts",
     structuralConsistencyOracle: "scripts/differential/pdf-reader-mcp-oracle.ts",
-    nonClaims: ["full TS 3.0.14 behavioral parity", "visual parity outside the immutable 7-case render/crop corpus", "Document Twin semantic parity"],
+    nonClaims: ["full TS 3.0.14 behavioral parity", "visual/provider parity outside the immutable 10-case render/crop/OCR corpus", "Tesseract TSV parity", "Document Twin semantic parity"],
     retirementGate: "scripts/check-no-ts-stdio-backend.sh (runs only when dropInFor3014=true)"
   }' >"$ARTIFACT"
 

--- a/test/integration/http-transport.test.ts
+++ b/test/integration/http-transport.test.ts
@@ -11,6 +11,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const repoRoot = path.resolve(__dirname, '../..');
 const binWrapper = path.join(repoRoot, 'bin/pdf-reader-mcp');
+const ocrProvider = path.join(repoRoot, 'scripts/differential/reference-ocr-provider.ts');
 const RUST_HTTP_READY = 'Streamable HTTP MCP listening on http://';
 
 const TEST_HOST = '127.0.0.1';
@@ -146,6 +147,8 @@ describe('MCP Server HTTP Transport Integration (Rust rmcp)', () => {
         MCP_TRANSPORT: 'http',
         MCP_HTTP_PORT: testPort.toString(),
         MCP_HTTP_HOST: TEST_HOST,
+        MCP_PDF_OCR_COMMAND: process.execPath,
+        MCP_PDF_OCR_ARGS_JSON: JSON.stringify([ocrProvider, '{input}', '{page}', '{languages}']),
       },
     });
 
@@ -271,6 +274,43 @@ describe('MCP Server HTTP Transport Integration (Rust rmcp)', () => {
       results?: Array<{ rendered_pages?: Array<{ image_content_index?: number }> }>;
     };
     expect(payload.results?.[0]?.rendered_pages?.[0]?.image_content_index).toBe(1);
+  });
+
+  it('should return normalized command-provider OCR over HTTP', async () => {
+    const client = createMcpHttpClient();
+    await client.initializeSession();
+    const fixture = path.resolve(__dirname, '../fixtures/differential/v3014-visual-v1.pdf');
+    const response = await client.sendRequest(
+      'tools/call',
+      {
+        name: 'pdf_evidence',
+        arguments: {
+          operation: 'ocr_pages',
+          sources: [{ path: fixture, pages: [1] }],
+          scale: 1,
+          max_pages: 1,
+          languages: ['eng'],
+        },
+      },
+      5
+    );
+    expect(response.error).toBeUndefined();
+    const result = response.result as {
+      isError?: boolean;
+      content?: Array<{ type?: string; text?: string }>;
+    };
+    expect(result.isError).not.toBe(true);
+    expect(result.content).toHaveLength(1);
+    const payload = JSON.parse(result.content?.[0]?.text ?? '{}') as {
+      results?: Array<{ ocr_pages?: Array<Record<string, unknown>> }>;
+    };
+    expect(payload.results?.[0]?.ocr_pages?.[0]).toMatchObject({
+      page: 1,
+      text: 'Reference OCR page 1 at 120x80',
+      language: 'eng',
+      provider: 'command',
+      provenance: { engine: 'external-command', source: 'ocr-provider' },
+    });
   });
 
   const goldenPath = path.resolve(__dirname, '../fixtures/read-pdf-golden.json');

--- a/test/integration/mcp-ocr-provider.test.ts
+++ b/test/integration/mcp-ocr-provider.test.ts
@@ -1,0 +1,193 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import type { ChildProcess } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  callTool,
+  ensureProductionArtifacts,
+  initializeSession,
+  parseToolPayload,
+  spawnProductionMcp,
+} from '../production/mcpContract.helpers.js';
+
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+const fixture = path.join(repoRoot, 'test/fixtures/differential/v3014-visual-v1.pdf');
+const provider = path.join(repoRoot, 'scripts/differential/reference-ocr-provider.ts');
+
+describe('pure-Rust command OCR provider integration', () => {
+  let proc: ChildProcess;
+  let failingProc: ChildProcess;
+  let timeoutProc: ChildProcess;
+  let descendantProc: ChildProcess;
+  const descendantWorkspace = mkdtempSync(path.join(tmpdir(), 'pdf-reader-ocr-descendant-'));
+  const descendantMarker = path.join(descendantWorkspace, 'input-path.txt');
+
+  beforeAll(async () => {
+    ensureProductionArtifacts('pure-rust');
+    proc = spawnProductionMcp({
+      PDF_READER_ENGINE_MODE: 'pure-rust',
+      MCP_PDF_OCR_COMMAND: process.execPath,
+      MCP_PDF_OCR_ARGS_JSON: JSON.stringify([provider, '{input}', '{page}', '{languages}']),
+    });
+    await initializeSession(proc, 'rust-ocr-provider-contract');
+
+    failingProc = spawnProductionMcp({
+      PDF_READER_ENGINE_MODE: 'pure-rust',
+      MCP_PDF_OCR_COMMAND: process.execPath,
+      MCP_PDF_OCR_ARGS_JSON: JSON.stringify([provider, '{input}', '{page}', '{languages}', 'fail']),
+    });
+    await initializeSession(failingProc, 'rust-ocr-provider-failure-contract');
+
+    timeoutProc = spawnProductionMcp({
+      PDF_READER_ENGINE_MODE: 'pure-rust',
+      MCP_PDF_OCR_COMMAND: process.execPath,
+      MCP_PDF_OCR_ARGS_JSON: JSON.stringify([
+        provider,
+        '{input}',
+        '{page}',
+        '{languages}',
+        'sleep',
+      ]),
+    });
+    await initializeSession(timeoutProc, 'rust-ocr-provider-timeout-contract');
+
+    descendantProc = spawnProductionMcp({
+      PDF_READER_ENGINE_MODE: 'pure-rust',
+      MCP_PDF_OCR_COMMAND: process.execPath,
+      MCP_PDF_OCR_ARGS_JSON: JSON.stringify([
+        provider,
+        '{input}',
+        '{page}',
+        '{languages}',
+        'escaped-descendant',
+        descendantMarker,
+      ]),
+    });
+    await initializeSession(descendantProc, 'rust-ocr-provider-descendant-contract');
+  }, 420_000);
+
+  afterAll(() => {
+    proc?.kill('SIGTERM');
+    failingProc?.kill('SIGTERM');
+    timeoutProc?.kill('SIGTERM');
+    descendantProc?.kill('SIGTERM');
+    rmSync(descendantWorkspace, { recursive: true, force: true });
+  });
+
+  test('renders a bounded page and returns normalized OCR provenance', async () => {
+    const response = await callTool(
+      proc,
+      41,
+      'pdf_evidence',
+      {
+        operation: 'ocr_pages',
+        sources: [{ path: fixture, pages: [1] }],
+        scale: 2,
+        max_pages: 1,
+        languages: ['fra', 'eng'],
+      },
+      90_000
+    );
+    const payload = parseToolPayload(response);
+    expect(payload.isError).toBe(false);
+    expect(response.result?.content).toHaveLength(1);
+    const result = JSON.parse(payload.text) as {
+      profile: string;
+      ocr_options: Record<string, unknown>;
+      results: Array<{
+        success: boolean;
+        ocr_pages: Array<Record<string, unknown>>;
+      }>;
+    };
+    expect(result.profile).toBe('ocr_text_layer');
+    expect(result.ocr_options).toMatchObject({
+      scale: 2,
+      max_pages: 1,
+      languages: ['fra', 'eng'],
+    });
+    expect(result.results[0]?.success).toBe(true);
+    expect(result.results[0]?.ocr_pages[0]).toMatchObject({
+      page: 1,
+      text: 'Reference OCR page 1 at 240x160',
+      confidence: 0.87,
+      language: 'fra',
+      provider: 'command',
+      source_render_evidence_id: 'page-1-render-scale-2',
+      source_render_scale: 2,
+      source_render_width: 240,
+      source_render_height: 160,
+      provenance: { engine: 'external-command', source: 'ocr-provider' },
+      words: [
+        {
+          text: 'Reference',
+          confidence: 0.91,
+          bounding_box: { left: 10, bottom: 5, right: 50, top: 15 },
+        },
+      ],
+    });
+  }, 120_000);
+
+  test('fails closed when the provider exits unsuccessfully', async () => {
+    const response = await callTool(
+      failingProc,
+      42,
+      'pdf_evidence',
+      {
+        operation: 'ocr_pages',
+        sources: [{ path: fixture, pages: [1] }],
+        scale: 1,
+        max_pages: 1,
+      },
+      30_000
+    );
+    const payload = parseToolPayload(response);
+    expect(payload.isError).toBe(true);
+    expect(payload.text).toContain('All PDF sources failed OCR');
+    expect(payload.text).toContain('OCR provider command failed for page 1');
+  });
+
+  test('kills and fails closed when the provider exceeds its timeout', async () => {
+    const started = Date.now();
+    const response = await callTool(
+      timeoutProc,
+      43,
+      'pdf_evidence',
+      {
+        operation: 'ocr_pages',
+        sources: [{ path: fixture, pages: [1] }],
+        scale: 1,
+        max_pages: 1,
+        timeout_ms: 1_000,
+      },
+      30_000
+    );
+    const payload = parseToolPayload(response);
+    expect(payload.isError).toBe(true);
+    expect(payload.text).toContain('OCR provider command timed out for page 1');
+    expect(Date.now() - started).toBeLessThan(4_000);
+  }, 30_000);
+
+  test('bounds escaped inherited-pipe descendants and cleans the temporary page', async () => {
+    const started = Date.now();
+    const response = await callTool(
+      descendantProc,
+      44,
+      'pdf_evidence',
+      {
+        operation: 'ocr_pages',
+        sources: [{ path: fixture, pages: [1] }],
+        scale: 1,
+        max_pages: 1,
+        timeout_ms: 1_000,
+      },
+      30_000
+    );
+    const payload = parseToolPayload(response);
+    expect(payload.isError).toBe(true);
+    expect(payload.text).toContain('OCR provider command timed out for page 1');
+    expect(Date.now() - started).toBeLessThan(4_000);
+    const temporaryInput = readFileSync(descendantMarker, 'utf8');
+    expect(existsSync(temporaryInput)).toBe(false);
+  }, 30_000);
+});

--- a/test/integration/mcp-server.test.ts
+++ b/test/integration/mcp-server.test.ts
@@ -365,7 +365,7 @@ describe('MCP Server Integration', () => {
     );
   });
 
-  mcpIt('should fail closed for unavailable pdf_evidence ocr_pages', async () => {
+  mcpIt('should fail closed when pdf_evidence ocr_pages has no provider', async () => {
     const testPdfPath = path.resolve(__dirname, '../fixtures/sample.pdf');
 
     const callRequest = createRequest(8, 'tools/call', {
@@ -390,7 +390,7 @@ describe('MCP Server Integration', () => {
 
     expect(response.error || response.result?.isError).toBeTruthy();
     expect(response.error?.message || response.result?.content?.[0]?.text).toContain(
-      "pdf_evidence operation 'ocr_pages' is not available in the pure-Rust engine yet"
+      'OCR provider is not configured. Set MCP_PDF_OCR_COMMAND or MCP_PDF_OCR_PRESET=tesseract'
     );
   });
 

--- a/test/production/capabilityParity.contract.test.ts
+++ b/test/production/capabilityParity.contract.test.ts
@@ -282,7 +282,11 @@ describe.skipIf(!pureRustEnabled)('experimental pure-Rust capability contract', 
       );
       const payload = parseToolPayload(response);
       expect(payload.isError).toBe(true);
-      expect(payload.text).toContain(`'${operation}' is not available`);
+      expect(payload.text).toContain(
+        operation === 'ocr_pages'
+          ? 'OCR provider is not configured'
+          : "'analyze_regions' is not available"
+      );
     }
   }, 240_000);
 });

--- a/test/production/mcpContract.helpers.ts
+++ b/test/production/mcpContract.helpers.ts
@@ -33,8 +33,8 @@ export const packageJson = JSON.parse(
   files?: string[];
 };
 
-export const ensureProductionArtifacts = () => {
-  const mode = process.env.PDF_READER_ENGINE_MODE;
+export const ensureProductionArtifacts = (requestedMode?: 'pure-rust' | 'rust') => {
+  const mode = requestedMode ?? process.env.PDF_READER_ENGINE_MODE;
   if (mode === 'pure-rust' || mode === 'rust') {
     execSync('bun run build:rust', { cwd: repoRoot, stdio: 'pipe', timeout: 300_000 });
     if (!fs.existsSync(path.join(repoRoot, 'bin/native/pdf-reader-mcp-server'))) {


### PR DESCRIPTION
## Outcome

Adds an opt-in pure-Rust command-provider success path for `pdf_evidence` `ocr_pages` over the already bounded Hayro renderer. This remains a PARTIAL capability; `dropInFor3014=false` and `publishFreeze=true`.

## Proof

- immutable detached TS v3.0.14 render/crop/OCR differential: 10/10 exact semantic cases, 0 skipped
- stdio OCR success, provider failure, direct timeout, and Unix `setsid` escaped inherited-pipe timeout/temp cleanup: 4/4
- configured OCR success over HTTP
- process-wide concurrency plus request-wide time/provider-byte/text budgets
- `cargo test --workspace`, clippy, TS production contract, pure-Rust capability contract, and matrix gate green

## Independent review

- R1 FAIL: inherited-pipe descendants and sticky budget gaps
- R2 FAIL: cleanup still unbounded on escaped descendants; test regenerated TS dist noise
- R3 PASS (confidence 0.96): cancellable async pipes, bounded cleanup, escaped-descendant regression, self-contained Rust artifact setup

## Explicit non-claims

No Tesseract TSV parity, `analyze_regions`, Document Twin OCR fusion, full TS 3.0.14 parity, cross-platform npm binary, benchmark claim, or publish authorization.