### PR TITLE
feat(rust): add bounded region analysis provider

### DIFF
--- a/.github/workflows/rust-parity-differential.yml
+++ b/.github/workflows/rust-parity-differential.yml
@@ -147,7 +147,7 @@ jobs:
           jq -e --arg sha "$CANDIDATE_SHA" '
             .profile == "pdf_reader_v3014_visual_result" and
             .candidateSha == $sha and .pass == true and
-            .caseCount == 10 and .passed == 10 and .skipped == 0
+            .caseCount == 14 and .passed == 14 and .skipped == 0
           ' "$VISUAL_ARTIFACT" >/dev/null || {
             echo "::error::v3.0.14 visual result is incomplete, failing, or not SHA-bound"
             exit 1

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Pure-Rust is a **work in progress**, not the published product.
 | Selectable-text extract / search | Partial |
 | Full Document Twin (geometry, outline, COS structure) | **Not yet** |
 | Evidence `render_page` / `extract_regions` | Partial: bounded Hayro PNG render/crop in the source experiment |
-| Evidence OCR / analyze | **Not yet** (fail-closed) |
+| Evidence OCR / analyze | Partial: bounded opt-in command adapters; OCR TSV and analyze HTTP/presets are not yet available |
 | Cross-platform npm binary | **Not yet** |
 | Drop-in for 3.0.14 | **No** |
 

--- a/crates/pdf-reader-mcp-server/src/command_provider.rs
+++ b/crates/pdf-reader-mcp-server/src/command_provider.rs
@@ -1,0 +1,130 @@
+//! Shared bounded execution for opt-in local command providers.
+
+use std::process::Stdio;
+use std::thread;
+use std::time::Duration;
+
+use command_group::AsyncCommandGroup;
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::process::Command;
+
+#[derive(Clone)]
+pub struct CommandInvocation {
+    pub command: String,
+    pub args: Vec<String>,
+    pub timeout_ms: u64,
+    pub max_stdout_bytes: usize,
+    pub failure_message: String,
+    pub timeout_message: String,
+}
+
+#[derive(Debug)]
+pub struct CommandRunError {
+    pub message: String,
+    /// Provider stdout bytes to charge to the request aggregate. When a timed
+    /// out/read-failed invocation cannot report the exact count, this is the
+    /// per-call maximum so failure paths cannot bypass aggregate admission.
+    pub charge_bytes: usize,
+}
+
+impl CommandRunError {
+    pub fn new(message: String, charge_bytes: usize) -> Self {
+        Self {
+            message,
+            charge_bytes,
+        }
+    }
+}
+
+async fn read_bounded<R: AsyncRead + Unpin>(reader: R, maximum: usize) -> std::io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    reader
+        .take(u64::try_from(maximum).unwrap_or(u64::MAX).saturating_add(1))
+        .read_to_end(&mut bytes)
+        .await?;
+    Ok(bytes)
+}
+
+async fn run_async(invocation: CommandInvocation) -> Result<String, CommandRunError> {
+    let mut command = Command::new(&invocation.command);
+    command
+        .args(&invocation.args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command
+        .group_spawn()
+        .map_err(|_| CommandRunError::new(invocation.failure_message.clone(), 0))?;
+    let stdout = child
+        .inner()
+        .stdout
+        .take()
+        .ok_or_else(|| CommandRunError::new(invocation.failure_message.clone(), 0))?;
+    let stderr = child
+        .inner()
+        .stderr
+        .take()
+        .ok_or_else(|| CommandRunError::new(invocation.failure_message.clone(), 0))?;
+    let execution = async {
+        tokio::join!(
+            child.inner().wait(),
+            read_bounded(stdout, invocation.max_stdout_bytes),
+            read_bounded(stderr, 64 * 1024)
+        )
+    };
+    let (status, stdout, stderr) =
+        match tokio::time::timeout(Duration::from_millis(invocation.timeout_ms), execution).await {
+            Ok(results) => results,
+            Err(_) => {
+                // Dropping the timed-out read futures closes their pipe handles. Tree
+                // termination and leader reaping stay best-effort and bounded so an
+                // escaped descendant cannot extend the request deadline.
+                let _ = child.start_kill();
+                let _ = tokio::time::timeout(Duration::from_secs(2), child.inner().wait()).await;
+                return Err(CommandRunError::new(
+                    invocation.timeout_message,
+                    invocation.max_stdout_bytes,
+                ));
+            }
+        };
+    // Terminate any helper left in the process group/job after the leader exits.
+    let _ = child.start_kill();
+    let status = status.map_err(|_| {
+        CommandRunError::new(
+            invocation.failure_message.clone(),
+            invocation.max_stdout_bytes,
+        )
+    })?;
+    let stdout = stdout.map_err(|_| {
+        CommandRunError::new(
+            invocation.failure_message.clone(),
+            invocation.max_stdout_bytes,
+        )
+    })?;
+    let _stderr = stderr
+        .map_err(|_| CommandRunError::new(invocation.failure_message.clone(), stdout.len()))?;
+    if !status.success() || stdout.len() > invocation.max_stdout_bytes {
+        return Err(CommandRunError::new(
+            invocation.failure_message,
+            stdout.len(),
+        ));
+    }
+    Ok(String::from_utf8_lossy(&stdout).into_owned())
+}
+
+pub fn run(invocation: CommandInvocation) -> Result<String, CommandRunError> {
+    thread::spawn(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|_| {
+                CommandRunError::new(
+                    "Failed to start bounded command provider runtime.".into(),
+                    0,
+                )
+            })?
+            .block_on(run_async(invocation))
+    })
+    .join()
+    .map_err(|_| CommandRunError::new("Command provider worker failed.".into(), 0))?
+}

--- a/crates/pdf-reader-mcp-server/src/lib.rs
+++ b/crates/pdf-reader-mcp-server/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod cli_bridge;
+mod command_provider;
 pub mod evidence;
 pub mod http_transport;
 mod ocr_evidence;
 pub mod pdf_evidence;
 pub mod read_pdf;
+mod region_analysis_evidence;
 pub mod schema;
 pub mod search;
 pub mod tool_routes;
@@ -25,7 +27,7 @@ pub const SERVER_VERSION: &str = "0.0.0-pure-rust-experimental";
 pub const SERVER_INSTRUCTIONS: &str =
     "Experimental pure-Rust PDF MCP engine (not the published npm latest). \
 Supported depth: selectable-text read_pdf, search_pdf, and focused pdf_evidence operations. \
-Bounded Hayro render/crop and opt-in command-provider OCR are available; analyze_regions fails closed. \
+Bounded Hayro render/crop and opt-in command-provider OCR/region analysis are available. \
 For production drop-in use @sylphx/pdf-reader-mcp@3.0.14 (TypeScript).";
 
 fn omit_absent_optional_fields(value: Value) -> Value {
@@ -107,7 +109,7 @@ impl PdfReaderMcp {
     }
 
     #[tool(
-        description = "Focused PDF evidence operations. Pure-Rust supports inspect, bounded page rendering/crops, and opt-in command-provider OCR; analyze_regions fails closed with guidance."
+        description = "Focused PDF evidence operations. Pure-Rust supports inspect, bounded page rendering/crops, and opt-in bounded command-provider OCR and region analysis. HTTP/preset region providers are not yet available."
     )]
     pub async fn pdf_evidence(
         &self,
@@ -115,7 +117,10 @@ impl PdfReaderMcp {
     ) -> Result<rmcp::model::CallToolResult, ErrorData> {
         args.validate()
             .map_err(|message| ErrorData::invalid_params(message, None))?;
-        let provider_operation = matches!(args.operation, PdfEvidenceOperation::OcrPages);
+        let provider_operation = matches!(
+            args.operation,
+            PdfEvidenceOperation::OcrPages | PdfEvidenceOperation::AnalyzeRegions
+        );
         let value = serde_json::to_value(args)
             .map(omit_absent_optional_fields)
             .map_err(|error| {
@@ -128,7 +133,7 @@ impl PdfReaderMcp {
             tokio::task::spawn_blocking(move || pdf_evidence::pdf_evidence(value))
                 .await
                 .map_err(|error| {
-                    ErrorData::internal_error(format!("OCR worker failed: {error}"), None)
+                    ErrorData::internal_error(format!("Provider worker failed: {error}"), None)
                 })?
         } else {
             pdf_evidence::pdf_evidence(value)

--- a/crates/pdf-reader-mcp-server/src/ocr_evidence.rs
+++ b/crates/pdf-reader-mcp-server/src/ocr_evidence.rs
@@ -1,18 +1,14 @@
 //! Optional command-provider OCR over the bounded pure-Rust page renderer.
 
 use std::env;
-use std::process::Stdio;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::thread;
 use std::time::{Duration, Instant};
 
-use command_group::AsyncCommandGroup;
 use rmcp::model::{CallToolResult, Content};
 use serde_json::{json, Value};
 use tempfile::TempDir;
-use tokio::io::{AsyncRead, AsyncReadExt};
-use tokio::process::Command;
 
+use crate::command_provider::{self, CommandInvocation, CommandRunError};
 use crate::schema::PdfEvidenceArgs;
 use crate::visual_evidence;
 
@@ -90,6 +86,10 @@ impl RequestOcrBudget {
             ));
         }
         Ok(())
+    }
+
+    fn charge_failed_provider(&mut self, provider_bytes: usize) -> Result<(), String> {
+        self.charge(provider_bytes, 0)
     }
 }
 
@@ -211,85 +211,6 @@ fn replace_placeholders(
         )
 }
 
-async fn read_bounded<R: AsyncRead + Unpin>(reader: R, maximum: usize) -> std::io::Result<Vec<u8>> {
-    let mut bytes = Vec::new();
-    reader
-        .take(u64::try_from(maximum).unwrap_or(u64::MAX).saturating_add(1))
-        .read_to_end(&mut bytes)
-        .await?;
-    Ok(bytes)
-}
-
-async fn run_provider_async(
-    config: ProviderConfig,
-    png: Vec<u8>,
-    page: u64,
-    source: String,
-    languages: Vec<String>,
-    timeout_ms: u64,
-    max_output_chars: usize,
-) -> Result<String, String> {
-    let temp = TempDir::with_prefix("pdf-reader-mcp-ocr-")
-        .map_err(|_| "Failed to create OCR provider workspace.".to_string())?;
-    let input = temp.path().join(format!("page-{page}.png"));
-    std::fs::write(&input, png)
-        .map_err(|_| "Failed to write OCR provider input image.".to_string())?;
-    let input = input.to_string_lossy();
-    let args = config
-        .args_template
-        .iter()
-        .map(|arg| replace_placeholders(arg, &input, page, &source, &languages))
-        .collect::<Vec<_>>();
-    let mut command = Command::new(&config.command);
-    command
-        .args(args)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    let mut child = command
-        .group_spawn()
-        .map_err(|_| format!("OCR provider command failed for page {page}."))?;
-    let maximum = max_output_chars.saturating_mul(4).max(1024 * 1024);
-    let stdout = child
-        .inner()
-        .stdout
-        .take()
-        .ok_or_else(|| "OCR provider stdout was unavailable.".to_string())?;
-    let stderr = child
-        .inner()
-        .stderr
-        .take()
-        .ok_or_else(|| "OCR provider stderr was unavailable.".to_string())?;
-    let execution = async {
-        tokio::join!(
-            child.inner().wait(),
-            read_bounded(stdout, maximum),
-            read_bounded(stderr, 64 * 1024)
-        )
-    };
-    let (status, stdout, stderr) =
-        match tokio::time::timeout(Duration::from_millis(timeout_ms), execution).await {
-            Ok(results) => results,
-            Err(_) => {
-                // The timed-out read futures are cancelled and their local pipe handles drop
-                // before this branch. Tree termination and leader reaping are both best-effort
-                // and bounded, so an escaped Unix descendant cannot extend the request deadline.
-                let _ = child.start_kill();
-                let _ = tokio::time::timeout(Duration::from_secs(2), child.inner().wait()).await;
-                return Err(format!("OCR provider command timed out for page {page}."));
-            }
-        };
-    // Terminate any helper left in the process group/job after the leader and pipes close.
-    let _ = child.start_kill();
-    let status = status.map_err(|_| format!("OCR provider command failed for page {page}."))?;
-    let stdout = stdout.map_err(|_| "OCR provider stdout reader failed.".to_string())?;
-    let _stderr = stderr.map_err(|_| "OCR provider stderr reader failed.".to_string())?;
-    if !status.success() || stdout.len() > maximum {
-        return Err(format!("OCR provider command failed for page {page}."));
-    }
-    Ok(String::from_utf8_lossy(&stdout).into_owned())
-}
-
 fn run_provider(
     config: &ProviderConfig,
     png: &[u8],
@@ -298,28 +219,27 @@ fn run_provider(
     languages: &[String],
     timeout_ms: u64,
     max_output_chars: usize,
-) -> Result<String, String> {
-    let config = config.clone();
-    let png = png.to_vec();
-    let source = source.to_string();
-    let languages = languages.to_vec();
-    thread::spawn(move || {
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|_| "Failed to start bounded OCR provider runtime.".to_string())?
-            .block_on(run_provider_async(
-                config,
-                png,
-                page,
-                source,
-                languages,
-                timeout_ms,
-                max_output_chars,
-            ))
+) -> Result<String, CommandRunError> {
+    let temp = TempDir::with_prefix("pdf-reader-mcp-ocr-")
+        .map_err(|_| CommandRunError::new("Failed to create OCR provider workspace.".into(), 0))?;
+    let input = temp.path().join(format!("page-{page}.png"));
+    std::fs::write(&input, png)
+        .map_err(|_| CommandRunError::new("Failed to write OCR provider input image.".into(), 0))?;
+    let input = input.to_string_lossy();
+    let args = config
+        .args_template
+        .iter()
+        .map(|arg| replace_placeholders(arg, &input, page, source, languages))
+        .collect::<Vec<_>>();
+    let maximum = max_output_chars.saturating_mul(4).max(1024 * 1024);
+    command_provider::run(CommandInvocation {
+        command: config.command.clone(),
+        args,
+        timeout_ms,
+        max_stdout_bytes: maximum,
+        failure_message: format!("OCR provider command failed for page {page}."),
+        timeout_message: format!("OCR provider command timed out for page {page}."),
     })
-    .join()
-    .map_err(|_| "OCR provider worker failed.".to_string())?
 }
 
 fn normalize_confidence(value: &Value) -> Option<f64> {
@@ -543,7 +463,7 @@ pub fn ocr_pages(value: Value) -> Result<CallToolResult, rmcp::ErrorData> {
                         "Request exceeds OCR provider time limit of {MAX_REQUEST_OCR_TIMEOUT_MS} milliseconds."
                     ));
                 }
-                let stdout = run_provider(
+                let stdout = match run_provider(
                     &config,
                     &png,
                     page_number,
@@ -551,7 +471,13 @@ pub fn ocr_pages(value: Value) -> Result<CallToolResult, rmcp::ErrorData> {
                     &languages,
                     timeout_ms.min(remaining_ms),
                     max_output_chars,
-                )?;
+                ) {
+                    Ok(stdout) => stdout,
+                    Err(error) => {
+                        request_budget.charge_failed_provider(error.charge_bytes)?;
+                        return Err(error.message);
+                    }
+                };
                 let mut normalized = normalize_output(&stdout, max_output_chars, &languages, scale);
                 let output_chars = normalized["text"]
                     .as_str()

--- a/crates/pdf-reader-mcp-server/src/pdf_evidence.rs
+++ b/crates/pdf-reader-mcp-server/src/pdf_evidence.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 
 use crate::evidence::attach_evidence;
 use crate::ocr_evidence;
+use crate::region_analysis_evidence;
 use crate::schema::PdfSource;
 use crate::visual_evidence;
 
@@ -24,17 +25,7 @@ pub fn pdf_evidence(args: Value) -> Result<CallToolResult, rmcp::ErrorData> {
         "render_page" => visual_evidence::render_pages(args),
         "extract_regions" => visual_evidence::extract_regions(args),
         "ocr_pages" => ocr_evidence::ocr_pages(args),
-        "analyze_regions" => {
-            // Pure-Rust v1: return structured, non-crashing guidance rather than silent no-op.
-            // inspect covers the default agent routing path; visual ops need providers/native render.
-            Err(rmcp::ErrorData::invalid_request(
-                format!(
-                    "pdf_evidence operation '{operation}' is not available in the pure-Rust engine yet. \
-                     Use operation=inspect, render_page, or extract_regions, or use read_pdf for text extraction."
-                ),
-                None,
-            ))
-        }
+        "analyze_regions" => region_analysis_evidence::analyze_regions(args),
         other => Err(rmcp::ErrorData::invalid_params(
             format!("Unsupported pdf_evidence operation: {other}"),
             None,

--- a/crates/pdf-reader-mcp-server/src/region_analysis_evidence.rs
+++ b/crates/pdf-reader-mcp-server/src/region_analysis_evidence.rs
@@ -1,0 +1,860 @@
+//! Optional command-provider analysis over bounded pure-Rust region crops.
+
+use std::env;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use rmcp::model::{CallToolResult, Content};
+use serde_json::{json, Map, Value};
+use tempfile::TempDir;
+
+use crate::command_provider::{self, CommandInvocation, CommandRunError};
+use crate::schema::PdfEvidenceArgs;
+use crate::visual_evidence;
+
+const DEFAULT_TIMEOUT_MS: u64 = 60_000;
+const DEFAULT_MAX_OUTPUT_CHARS: usize = 200_000;
+const COMMAND_ENV: &str = "MCP_PDF_REGION_ANALYSIS_COMMAND";
+const ARGS_ENV: &str = "MCP_PDF_REGION_ANALYSIS_ARGS_JSON";
+const HTTP_ENV: &str = "MCP_PDF_REGION_ANALYSIS_HTTP_URL";
+const PRESET_ENV: &str = "MCP_PDF_REGION_ANALYSIS_PRESET";
+const MAX_SOURCES_PER_REQUEST: usize = 32;
+const MAX_REQUEST_TIMEOUT_MS: u64 = 600_000;
+const MAX_REQUEST_OUTPUT_CHARS: usize = 2_000_000;
+const MAX_REQUEST_PROVIDER_BYTES: usize = 16 * 1024 * 1024;
+const MAX_CONCURRENT_REQUESTS: usize = 2;
+static ACTIVE_REQUESTS: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Debug)]
+struct RequestPermit;
+
+impl RequestPermit {
+    fn acquire() -> Result<Self, String> {
+        ACTIVE_REQUESTS
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |active| {
+                (active < MAX_CONCURRENT_REQUESTS).then_some(active + 1)
+            })
+            .map(|_| Self)
+            .map_err(|_| {
+                format!(
+                    "Region analysis provider concurrency limit of {MAX_CONCURRENT_REQUESTS} active requests reached; retry later."
+                )
+            })
+    }
+}
+
+impl Drop for RequestPermit {
+    fn drop(&mut self) {
+        ACTIVE_REQUESTS.fetch_sub(1, Ordering::Release);
+    }
+}
+
+#[derive(Default)]
+struct RequestBudget {
+    provider_bytes: usize,
+    output_chars: usize,
+    exhausted: Option<String>,
+}
+
+impl RequestBudget {
+    fn ensure_available(&self) -> Result<(), String> {
+        self.exhausted.clone().map_or(Ok(()), Err)
+    }
+
+    fn exhaust(&mut self, message: String) -> Result<(), String> {
+        self.exhausted = Some(message.clone());
+        Err(message)
+    }
+
+    fn charge(&mut self, provider_bytes: usize, output_chars: usize) -> Result<(), String> {
+        self.ensure_available()?;
+        self.provider_bytes = match self.provider_bytes.checked_add(provider_bytes) {
+            Some(value) => value,
+            None => {
+                return self.exhaust("Request region analysis provider byte count overflow.".into())
+            }
+        };
+        if self.provider_bytes > MAX_REQUEST_PROVIDER_BYTES {
+            return self.exhaust(format!(
+                "Request exceeds region analysis provider output limit of {MAX_REQUEST_PROVIDER_BYTES} bytes."
+            ));
+        }
+        self.output_chars = match self.output_chars.checked_add(output_chars) {
+            Some(value) => value,
+            None => {
+                return self
+                    .exhaust("Request region analysis output character count overflow.".into())
+            }
+        };
+        if self.output_chars > MAX_REQUEST_OUTPUT_CHARS {
+            return self.exhaust(format!(
+                "Request exceeds region analysis output limit of {MAX_REQUEST_OUTPUT_CHARS} characters."
+            ));
+        }
+        Ok(())
+    }
+
+    fn charge_failed_provider(&mut self, provider_bytes: usize) -> Result<(), String> {
+        self.charge(provider_bytes, 0)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ProviderConfig {
+    command: String,
+    args_template: Vec<String>,
+}
+
+fn parse_args(value: &Value) -> Result<PdfEvidenceArgs, rmcp::ErrorData> {
+    let args: PdfEvidenceArgs = serde_json::from_value(value.clone()).map_err(|error| {
+        rmcp::ErrorData::invalid_params(format!("Invalid pdf_evidence arguments: {error}"), None)
+    })?;
+    args.validate()
+        .map_err(|message| rmcp::ErrorData::invalid_params(message, None))?;
+    Ok(args)
+}
+
+fn provider_config_from(
+    command_value: Option<String>,
+    args_value: Option<String>,
+    http_value: Option<String>,
+    preset_value: Option<String>,
+) -> Result<ProviderConfig, String> {
+    let command = command_value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    if command.is_none()
+        && (http_value.is_some_and(|value| !value.trim().is_empty())
+            || preset_value.is_some_and(|value| !value.trim().is_empty()))
+    {
+        return Err("HTTP and preset region analysis providers are not available in the pure-Rust engine yet; set MCP_PDF_REGION_ANALYSIS_COMMAND for the bounded command adapter.".into());
+    }
+    let command = command.ok_or_else(|| {
+        "Region analysis provider is not configured. Set MCP_PDF_REGION_ANALYSIS_COMMAND to enable analyze_regions in the pure-Rust engine."
+            .to_string()
+    })?;
+    let args_template = match args_value {
+        None => vec!["{input}".into()],
+        Some(raw) => {
+            let value: Value = serde_json::from_str(&raw).map_err(|_| {
+                "MCP_PDF_REGION_ANALYSIS_ARGS_JSON must be a JSON string array.".to_string()
+            })?;
+            let values = value.as_array().ok_or_else(|| {
+                "MCP_PDF_REGION_ANALYSIS_ARGS_JSON must be a JSON string array.".to_string()
+            })?;
+            let args = values
+                .iter()
+                .map(|entry| {
+                    entry.as_str().map(ToOwned::to_owned).ok_or_else(|| {
+                        "MCP_PDF_REGION_ANALYSIS_ARGS_JSON must be a JSON string array.".to_string()
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            if !args.iter().any(|arg| arg.contains("{input}")) {
+                return Err("MCP_PDF_REGION_ANALYSIS_ARGS_JSON must include the {input} placeholder so the provider receives the cropped region image.".into());
+            }
+            args
+        }
+    };
+    Ok(ProviderConfig {
+        command,
+        args_template,
+    })
+}
+
+fn provider_config() -> Result<ProviderConfig, String> {
+    provider_config_from(
+        env::var(COMMAND_ENV).ok(),
+        env::var(ARGS_ENV).ok(),
+        env::var(HTTP_ENV).ok(),
+        env::var(PRESET_ENV).ok(),
+    )
+}
+
+fn js_number(value: f64) -> String {
+    if value.fract() == 0.0 {
+        format!("{value:.0}")
+    } else {
+        value.to_string()
+    }
+}
+
+fn replace_placeholders(
+    template: &str,
+    input: &str,
+    source: &str,
+    region: &Value,
+    languages: &[String],
+) -> String {
+    let box_ = &region["source_bounding_box"];
+    template
+        .replace("{input}", input)
+        .replace("{page}", &region["page"].as_u64().unwrap_or(0).to_string())
+        .replace("{source}", source)
+        .replace("{region_id}", region["region_id"].as_str().unwrap_or(""))
+        .replace(
+            "{evidence_id}",
+            region["evidence_id"].as_str().unwrap_or(""),
+        )
+        .replace("{left}", &js_number(box_["left"].as_f64().unwrap_or(0.0)))
+        .replace(
+            "{bottom}",
+            &js_number(box_["bottom"].as_f64().unwrap_or(0.0)),
+        )
+        .replace("{right}", &js_number(box_["right"].as_f64().unwrap_or(0.0)))
+        .replace("{top}", &js_number(box_["top"].as_f64().unwrap_or(0.0)))
+        .replace("{language}", languages.first().map_or("", String::as_str))
+        .replace("{languages}", &languages.join(","))
+}
+
+fn truncate_utf16(text: &str, maximum: usize) -> (String, bool) {
+    let mut units = 0usize;
+    let mut end = text.len();
+    for (index, character) in text.char_indices() {
+        let next = units + character.len_utf16();
+        if next > maximum {
+            end = index;
+            break;
+        }
+        units = next;
+    }
+    (
+        text[..end].to_string(),
+        text.encode_utf16().count() > maximum,
+    )
+}
+
+fn normalized_string(value: Option<&Value>, maximum: usize) -> Option<String> {
+    let trimmed = value?.as_str()?.trim();
+    (!trimmed.is_empty()).then(|| truncate_utf16(trimmed, maximum).0)
+}
+
+fn confidence(value: Option<&Value>) -> Option<f64> {
+    let value = value?.as_f64()?;
+    value.is_finite().then(|| {
+        let normalized = if value > 1.0 { value / 100.0 } else { value };
+        normalized.clamp(0.0, 1.0)
+    })
+}
+
+fn positive_integer(value: Option<&Value>) -> Option<u64> {
+    value?.as_u64().filter(|value| *value > 0)
+}
+
+fn zero_integer(value: Option<&Value>) -> Option<u64> {
+    value?.as_u64()
+}
+
+fn bounding_box(value: Option<&Value>) -> Option<Value> {
+    let object = value?.as_object()?;
+    let left = object.get("left")?.as_f64()?;
+    let bottom = object.get("bottom")?.as_f64()?;
+    let right = object.get("right")?.as_f64()?;
+    let top = object.get("top")?.as_f64()?;
+    ([left, bottom, right, top]
+        .iter()
+        .all(|value| value.is_finite())
+        && right > left
+        && top > bottom)
+        .then(|| json!({"left": left, "bottom": bottom, "right": right, "top": top}))
+}
+
+fn rows(value: Option<&Value>) -> Option<Vec<Value>> {
+    let rows = value?
+        .as_array()?
+        .iter()
+        .filter_map(|row| {
+            let cells = row.as_array()?;
+            (!cells.is_empty()).then(|| {
+                Value::Array(
+                    cells
+                        .iter()
+                        .map(|cell| match cell {
+                            Value::Null => Value::String(String::new()),
+                            Value::String(value) => Value::String(value.clone()),
+                            Value::Number(value) => Value::String(value.to_string()),
+                            Value::Bool(value) => Value::String(value.to_string()),
+                            _ => Value::String(String::new()),
+                        })
+                        .collect(),
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+    (!rows.is_empty()).then_some(rows)
+}
+
+fn table_cells(value: Option<&Value>, maximum: usize) -> Option<Vec<Value>> {
+    let cells = value?
+        .as_array()?
+        .iter()
+        .filter_map(|cell| {
+            let cell = cell.as_object()?;
+            let row = zero_integer(cell.get("row_index").or_else(|| cell.get("row")))?;
+            let column = zero_integer(cell.get("column_index").or_else(|| cell.get("column")))?;
+            let mut output = json!({
+                "text": normalized_string(cell.get("text"), maximum).unwrap_or_default(),
+                "row_index": row,
+                "column_index": column,
+            });
+            if let Some(value) =
+                positive_integer(cell.get("row_span").or_else(|| cell.get("rowspan")))
+            {
+                output["row_span"] = json!(value);
+            }
+            if let Some(value) =
+                positive_integer(cell.get("column_span").or_else(|| cell.get("colspan")))
+            {
+                output["column_span"] = json!(value);
+            }
+            if let Some(value) = confidence(cell.get("confidence")) {
+                output["confidence"] = json!(value);
+            }
+            if let Some(value) = bounding_box(cell.get("bounding_box").or_else(|| cell.get("bbox")))
+            {
+                output["bounding_box"] = value;
+            }
+            Some(output)
+        })
+        .collect::<Vec<_>>();
+    (!cells.is_empty()).then_some(cells)
+}
+
+fn normalize_table(value: Option<&Value>, maximum: usize) -> Option<Value> {
+    let candidate = value?.as_object()?;
+    let rows = rows(candidate.get("rows"));
+    let cells = table_cells(candidate.get("cells"), maximum);
+    let row_count = positive_integer(
+        candidate
+            .get("row_count")
+            .or_else(|| candidate.get("rowCount")),
+    )
+    .or_else(|| rows.as_ref().map(|rows| rows.len() as u64))
+    .or_else(|| {
+        cells.as_ref().and_then(|cells| {
+            cells
+                .iter()
+                .filter_map(|cell| {
+                    Some(
+                        cell["row_index"].as_u64()?
+                            + cell.get("row_span").and_then(Value::as_u64).unwrap_or(1),
+                    )
+                })
+                .max()
+        })
+    });
+    let column_count = positive_integer(
+        candidate
+            .get("column_count")
+            .or_else(|| candidate.get("columnCount"))
+            .or_else(|| candidate.get("col_count")),
+    )
+    .or_else(|| {
+        rows.as_ref().and_then(|rows| {
+            rows.iter()
+                .filter_map(|row| row.as_array().map(|row| row.len() as u64))
+                .max()
+        })
+    })
+    .or_else(|| {
+        cells.as_ref().and_then(|cells| {
+            cells
+                .iter()
+                .filter_map(|cell| {
+                    Some(
+                        cell["column_index"].as_u64()?
+                            + cell.get("column_span").and_then(Value::as_u64).unwrap_or(1),
+                    )
+                })
+                .max()
+        })
+    });
+    let markdown = normalized_string(candidate.get("markdown"), maximum);
+    let csv = normalized_string(candidate.get("csv"), maximum);
+    let confidence = confidence(candidate.get("confidence"));
+    if rows.is_none()
+        && cells.is_none()
+        && markdown.is_none()
+        && csv.is_none()
+        && row_count.is_none()
+        && column_count.is_none()
+        && confidence.is_none()
+    {
+        return None;
+    }
+    let mut output = Map::new();
+    if let Some(value) = rows {
+        output.insert("rows".into(), Value::Array(value));
+    }
+    if let Some(value) = markdown {
+        output.insert("markdown".into(), json!(value));
+    }
+    if let Some(value) = csv {
+        output.insert("csv".into(), json!(value));
+    }
+    if let Some(value) = row_count {
+        output.insert("row_count".into(), json!(value));
+    }
+    if let Some(value) = column_count {
+        output.insert("column_count".into(), json!(value));
+    }
+    if let Some(value) = cells {
+        output.insert("cells".into(), Value::Array(value));
+    }
+    if let Some(value) = confidence {
+        output.insert("confidence".into(), json!(value));
+    }
+    Some(Value::Object(output))
+}
+
+fn normalize_formula(value: Option<&Value>, maximum: usize) -> Option<Value> {
+    let candidate = value?.as_object()?;
+    let mut output = Map::new();
+    for (source, target) in [
+        ("latex", "latex"),
+        ("mathml", "mathml"),
+        ("asciimath", "asciimath"),
+        ("text", "text"),
+    ] {
+        if let Some(value) = normalized_string(candidate.get(source), maximum) {
+            output.insert(target.into(), json!(value));
+        }
+    }
+    if !output.contains_key("asciimath") {
+        if let Some(value) = normalized_string(candidate.get("ascii_math"), maximum) {
+            output.insert("asciimath".into(), json!(value));
+        }
+    }
+    if let Some(value) = confidence(candidate.get("confidence")) {
+        output.insert("confidence".into(), json!(value));
+    }
+    (!output.is_empty()).then_some(Value::Object(output))
+}
+
+fn data_points(value: Option<&Value>) -> Option<Value> {
+    let points = value?
+        .as_array()?
+        .iter()
+        .filter_map(|point| {
+            let point = point.as_object()?;
+            let output = point
+                .iter()
+                .filter(|(_, value)| {
+                    matches!(
+                        value,
+                        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_)
+                    )
+                })
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect::<Map<_, _>>();
+            (!output.is_empty()).then_some(Value::Object(output))
+        })
+        .collect::<Vec<_>>();
+    (!points.is_empty()).then_some(Value::Array(points))
+}
+
+fn chart_axis(value: Option<&Value>, maximum: usize) -> Option<Value> {
+    let candidate = value?.as_object()?;
+    let mut output = Map::new();
+    for key in ["label", "unit"] {
+        if let Some(value) = normalized_string(candidate.get(key), maximum) {
+            output.insert(key.into(), json!(value));
+        }
+    }
+    for key in ["min", "max"] {
+        if candidate
+            .get(key)
+            .and_then(Value::as_f64)
+            .is_some_and(f64::is_finite)
+        {
+            output.insert(key.into(), candidate[key].clone());
+        }
+    }
+    (!output.is_empty()).then_some(Value::Object(output))
+}
+
+fn chart_series(value: Option<&Value>, maximum: usize) -> Option<Value> {
+    let series = value?
+        .as_array()?
+        .iter()
+        .filter_map(|entry| {
+            let entry = entry.as_object()?;
+            let points = data_points(entry.get("data_points").or_else(|| entry.get("points")))?;
+            let mut output = Map::new();
+            if let Some(value) = normalized_string(entry.get("name"), maximum) {
+                output.insert("name".into(), json!(value));
+            }
+            output.insert("data_points".into(), points);
+            if let Some(value) = confidence(entry.get("confidence")) {
+                output.insert("confidence".into(), json!(value));
+            }
+            Some(Value::Object(output))
+        })
+        .collect::<Vec<_>>();
+    (!series.is_empty()).then_some(Value::Array(series))
+}
+
+fn normalize_chart(value: Option<&Value>, maximum: usize) -> Option<Value> {
+    let candidate = value?.as_object()?;
+    let mut output = Map::new();
+    for key in ["title", "summary"] {
+        if let Some(value) = normalized_string(candidate.get(key), maximum) {
+            output.insert(key.into(), json!(value));
+        }
+    }
+    if let Some(value) = data_points(candidate.get("data_points")) {
+        output.insert("data_points".into(), value);
+    }
+    if let Some(value) = chart_axis(candidate.get("x_axis"), maximum) {
+        output.insert("x_axis".into(), value);
+    }
+    if let Some(value) = chart_axis(candidate.get("y_axis"), maximum) {
+        output.insert("y_axis".into(), value);
+    }
+    if let Some(value) = chart_series(candidate.get("series"), maximum) {
+        output.insert("series".into(), value);
+    }
+    if let Some(value) = confidence(candidate.get("confidence")) {
+        output.insert("confidence".into(), json!(value));
+    }
+    (!output.is_empty()).then_some(Value::Object(output))
+}
+
+fn normalize_output(stdout: &str, maximum: usize) -> Value {
+    let trimmed = stdout.trim();
+    let parsed = serde_json::from_str::<Value>(trimmed)
+        .ok()
+        .filter(Value::is_object);
+    let Some(parsed) = parsed else {
+        let (description, truncated) = truncate_utf16(trimmed, maximum);
+        let mut output = json!({"kind": "unknown", "description": description});
+        if truncated {
+            output["warnings"] = json!([format!(
+                "Region analysis output truncated to {maximum} characters."
+            )]);
+        }
+        return output;
+    };
+    let object = parsed.as_object().expect("checked object");
+    let mut warnings = object
+        .get("warnings")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|warning| {
+            warning
+                .as_str()
+                .map(str::trim)
+                .filter(|warning| !warning.is_empty())
+                .map(str::to_string)
+        })
+        .collect::<Vec<_>>();
+    let kind = object
+        .get("kind")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .unwrap_or_else(|| "unknown".into());
+    let kind = if matches!(
+        kind.as_str(),
+        "text" | "table" | "figure" | "chart" | "formula" | "image" | "diagram" | "unknown"
+    ) {
+        kind
+    } else {
+        warnings.push(format!(
+            "Unsupported region analysis kind \"{kind}\"; normalized to \"unknown\"."
+        ));
+        "unknown".into()
+    };
+    let mut output = Map::from_iter([("kind".into(), json!(kind))]);
+    for key in ["description", "text", "markdown"] {
+        if let Some(value) = normalized_string(object.get(key), maximum) {
+            output.insert(key.into(), json!(value));
+        }
+    }
+    if let Some(value) = confidence(object.get("confidence")) {
+        output.insert("confidence".into(), json!(value));
+    }
+    if let Some(value) = normalize_table(object.get("table"), maximum) {
+        output.insert("table".into(), value);
+    }
+    if let Some(value) = normalize_formula(object.get("formula"), maximum) {
+        output.insert("formula".into(), value);
+    }
+    if let Some(value) = normalize_chart(object.get("chart"), maximum) {
+        output.insert("chart".into(), value);
+    }
+    if !warnings.is_empty() {
+        output.insert("warnings".into(), json!(warnings));
+    }
+    Value::Object(output)
+}
+
+fn run_provider(
+    config: &ProviderConfig,
+    png: &[u8],
+    source: &str,
+    region: &Value,
+    languages: &[String],
+    timeout_ms: u64,
+    max_output_chars: usize,
+) -> Result<String, CommandRunError> {
+    let page = region["page"].as_u64().unwrap_or(0);
+    let region_id = region["region_id"].as_str().unwrap_or("unknown");
+    let temp = TempDir::with_prefix("pdf-reader-mcp-region-analysis-").map_err(|_| {
+        CommandRunError::new(
+            "Failed to create region analysis provider workspace.".into(),
+            0,
+        )
+    })?;
+    let input = temp.path().join(format!("region-{page}.png"));
+    std::fs::write(&input, png).map_err(|_| {
+        CommandRunError::new(
+            "Failed to write region analysis provider input image.".into(),
+            0,
+        )
+    })?;
+    let input = input.to_string_lossy();
+    let args = config
+        .args_template
+        .iter()
+        .map(|arg| replace_placeholders(arg, &input, source, region, languages))
+        .collect();
+    command_provider::run(CommandInvocation {
+        command: config.command.clone(),
+        args,
+        timeout_ms,
+        max_stdout_bytes: max_output_chars.saturating_mul(4).max(1024 * 1024),
+        failure_message: format!(
+            "Region analysis provider command failed for page {page} region {region_id}."
+        ),
+        timeout_message: format!(
+            "Region analysis provider command timed out for page {page} region {region_id}."
+        ),
+    })
+}
+
+fn text_result(payload: Value) -> CallToolResult {
+    let text = serde_json::to_string_pretty(&payload).unwrap_or_else(|_| payload.to_string());
+    CallToolResult {
+        content: vec![Content::text(text)],
+        structured_content: Some(payload),
+        is_error: Some(false),
+        meta: None,
+    }
+}
+
+fn error_result(message: String) -> CallToolResult {
+    CallToolResult::error(vec![Content::text(message)])
+}
+
+pub fn analyze_regions(value: Value) -> Result<CallToolResult, rmcp::ErrorData> {
+    let args = parse_args(&value)?;
+    if args.sources.len() > MAX_SOURCES_PER_REQUEST {
+        return Err(rmcp::ErrorData::invalid_params(
+            format!("pdf_evidence accepts at most {MAX_SOURCES_PER_REQUEST} sources per request."),
+            None,
+        ));
+    }
+    if args.sources.is_empty() {
+        return Ok(error_result(
+            "All PDF sources failed region analysis: ".into(),
+        ));
+    }
+    let config = match provider_config() {
+        Ok(config) => config,
+        Err(message) => {
+            return Ok(error_result(format!(
+                "All PDF sources failed region analysis: {message}"
+            )))
+        }
+    };
+    let _permit = match RequestPermit::acquire() {
+        Ok(permit) => permit,
+        Err(message) => {
+            return Ok(error_result(format!(
+                "All PDF sources failed region analysis: {message}"
+            )))
+        }
+    };
+    let scale = args.scale.unwrap_or(2.0);
+    let max_regions = args.max_regions.unwrap_or(20);
+    let max_pixels = args.max_pixels_per_page.unwrap_or(16_000_000);
+    let timeout_ms = u64::from(args.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS as u32));
+    let max_output_chars = args
+        .max_output_chars
+        .map_or(DEFAULT_MAX_OUTPUT_CHARS, |value| value as usize);
+    let languages_provided = args.languages.is_some();
+    let languages = args.languages.unwrap_or_default();
+    let request_deadline = Instant::now() + Duration::from_millis(MAX_REQUEST_TIMEOUT_MS);
+    let mut request_budget = RequestBudget::default();
+    let mut crop_input = value;
+    crop_input["operation"] = json!("extract_regions");
+    crop_input["include_image"] = json!(true);
+    let cropped = visual_evidence::extract_regions(crop_input)?;
+    let encoded = serde_json::to_value(&cropped).map_err(|error| {
+        rmcp::ErrorData::internal_error(format!("Failed to encode crop evidence: {error}"), None)
+    })?;
+    let Some(payload) = cropped.structured_content else {
+        let message = encoded["content"][0]["text"]
+            .as_str()
+            .unwrap_or("All PDF sources failed region analysis.");
+        return Ok(error_result(
+            message.replace("failed region extraction", "failed region analysis"),
+        ));
+    };
+    let mut results = Vec::new();
+    for source in payload["results"].as_array().into_iter().flatten() {
+        let source_label = source["source"].as_str().unwrap_or("unknown source");
+        if source["success"] != true {
+            results
+                .push(json!({"source": source_label, "success": false, "error": source["error"]}));
+            continue;
+        }
+        let output = (|| -> Result<Value, String> {
+            let mut analyses = Vec::new();
+            for region in source["regions"].as_array().into_iter().flatten() {
+                request_budget.ensure_available()?;
+                let index = region["image_content_index"].as_u64().ok_or_else(|| {
+                    "Cropped region analysis input image index is missing.".to_string()
+                })?;
+                let data = encoded["content"][index as usize]["data"]
+                    .as_str()
+                    .ok_or_else(|| "Cropped region analysis input image is missing.".to_string())?;
+                let png = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, data)
+                    .map_err(|_| "Cropped region analysis input image is invalid.".to_string())?;
+                let remaining_ms = u64::try_from(
+                    request_deadline
+                        .saturating_duration_since(Instant::now())
+                        .as_millis(),
+                )
+                .unwrap_or(u64::MAX);
+                if remaining_ms == 0 {
+                    return Err(format!("Request exceeds region analysis provider time limit of {MAX_REQUEST_TIMEOUT_MS} milliseconds."));
+                }
+                let stdout = match run_provider(
+                    &config,
+                    &png,
+                    source_label,
+                    region,
+                    &languages,
+                    timeout_ms.min(remaining_ms),
+                    max_output_chars,
+                ) {
+                    Ok(stdout) => stdout,
+                    Err(error) => {
+                        request_budget.charge_failed_provider(error.charge_bytes)?;
+                        return Err(error.message);
+                    }
+                };
+                let mut normalized = normalize_output(&stdout, max_output_chars);
+                let output_chars = serde_json::to_string(&normalized)
+                    .map_or(0, |value| value.encode_utf16().count());
+                request_budget.charge(stdout.len(), output_chars)?;
+                normalized["region_id"] = region["region_id"].clone();
+                normalized["page"] = region["page"].clone();
+                normalized["provider"] = json!("command");
+                normalized["source_crop_evidence_id"] = region["evidence_id"].clone();
+                normalized["source_bounding_box"] = region["source_bounding_box"].clone();
+                normalized["crop_pixels"] = region["crop_pixels"].clone();
+                normalized["scale"] = region["scale"].clone();
+                normalized["provenance"] =
+                    json!({"engine": "external-command", "source": "region-analysis-provider"});
+                analyses.push(normalized);
+            }
+            let mut result = json!({"source": source_label, "success": true, "num_pages": source["num_pages"], "region_analyses": analyses});
+            if source.get("warnings").is_some() {
+                result["warnings"] = source["warnings"].clone();
+            }
+            Ok(result)
+        })();
+        results.push(output.unwrap_or_else(
+            |error| json!({"source": source_label, "success": false, "error": error}),
+        ));
+    }
+    if results.iter().all(|result| result["success"] != true) {
+        let errors = results
+            .iter()
+            .filter_map(|result| result["error"].as_str())
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Ok(error_result(format!(
+            "All PDF sources failed region analysis: {errors}"
+        )));
+    }
+    let mut options = json!({"scale": scale, "max_regions": max_regions, "max_pixels_per_page": max_pixels, "timeout_ms": timeout_ms, "max_output_chars": max_output_chars});
+    if languages_provided {
+        options["languages"] = json!(languages);
+    }
+    Ok(text_result(
+        json!({"profile": "region_analysis", "analysis_options": options, "results": results}),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_rich_aliases_and_unknown_kind_like_v3014() {
+        let value = normalize_output(
+            r#"{
+          "kind":" SPREADSHEET ", "description":"  report  ", "confidence":87,
+          "warnings":[" note ", 3],
+          "table":{"rows":[["A",2,true,null]],"cells":[{"text":"x","row":1,"column":2,"rowspan":2,"colspan":3,"confidence":50,"bbox":{"left":1,"bottom":2,"right":3,"top":4}}]},
+          "formula":{"ascii_math":"x^2","confidence":150},
+          "chart":{"title":" T ","data_points":[{"x":1,"nested":{}}],"x_axis":{"label":" X ","min":0},"series":[{"name":"S","points":[{"y":2}],"confidence":90}]}
+        }"#,
+            200_000,
+        );
+        assert_eq!(value["kind"], "unknown");
+        assert_eq!(value["description"], "report");
+        assert_eq!(value["confidence"], 0.87);
+        assert_eq!(value["table"]["row_count"], 1);
+        assert_eq!(value["table"]["column_count"], 4);
+        assert_eq!(value["table"]["cells"][0]["row_span"], 2);
+        assert_eq!(value["formula"]["asciimath"], "x^2");
+        assert_eq!(value["formula"]["confidence"], 1.0);
+        assert_eq!(value["chart"]["series"][0]["confidence"], 0.9);
+        assert_eq!(value["warnings"][0], "note");
+        assert!(value["warnings"][1]
+            .as_str()
+            .unwrap()
+            .contains("Unsupported"));
+    }
+
+    #[test]
+    fn plain_text_truncates_by_utf16_units() {
+        let value = normalize_output(" A😀B ", 3);
+        assert_eq!(value["description"], "A😀");
+        assert_eq!(
+            value["warnings"][0],
+            "Region analysis output truncated to 3 characters."
+        );
+    }
+
+    #[test]
+    fn rejects_non_command_configuration_and_missing_input_placeholder() {
+        assert!(
+            provider_config_from(None, None, Some("http://localhost".into()), None)
+                .unwrap_err()
+                .contains("not available")
+        );
+        assert!(provider_config_from(
+            Some("provider".into()),
+            Some(r#"["--flag"]"#.into()),
+            None,
+            None
+        )
+        .unwrap_err()
+        .contains("{input}"));
+    }
+
+    #[test]
+    fn request_budget_exhaustion_is_sticky() {
+        let mut budget = RequestBudget::default();
+        budget.charge(MAX_REQUEST_PROVIDER_BYTES - 1, 0).unwrap();
+        assert!(budget.charge(2, 0).unwrap_err().contains("bytes"));
+        assert!(budget.ensure_available().unwrap_err().contains("bytes"));
+    }
+}

--- a/docs/performance/why-rust.md
+++ b/docs/performance/why-rust.md
@@ -118,9 +118,10 @@ Pure-Rust text extraction currently uses the selectable text layer. Geometry,
 OCR, visual evidence, and full Document Twin parity remain open work. Empty
 placeholder arrays prove only response shape; they do not prove capability.
 
-Visual `pdf_evidence` operations (`render_page`, `extract_regions`, `ocr_pages`,
-`analyze_regions`) currently fail closed. That is safer than silent success but
-is not TS 3.0.14 parity.
+Visual `pdf_evidence` operations now have bounded Hayro render/crop plus opt-in
+command-provider OCR and region-analysis subsets. They remain partial: OCR TSV,
+region-analysis HTTP/presets, broader renderer fixtures, and full Document Twin
+fusion are open. Unavailable paths fail closed; this is not TS 3.0.14 parity.
 
 ## Install
 

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -67,20 +67,20 @@
       "render_page": "PARTIAL",
       "extract_regions": "PARTIAL",
       "ocr_pages": "PARTIAL",
-      "analyze_regions": "FAIL_CLOSED"
+      "analyze_regions": "PARTIAL"
     }
   },
   "claimedForDifferential": [
     "exact 10-case immutable TS v3.0.14 behavior subset: full text, page selection/order/duplicates, metadata, literal search, case sensitivity, whole word, Unicode, UTF-16 offsets, missing and malformed inputs, and mixed-source partial success",
-    "exact 10-case immutable TS v3.0.14 render/crop/command-OCR semantic subset over stdio: defaults, page selection and warnings, region ordering, padding and fractional bounds, rotated pages, mixed-source partial success, all-source failure, MCP image indexing, OCR JSON normalization and truthful provenance; exact pdf.js pixels and antialiasing are not claimed",
+    "exact 14-case immutable TS v3.0.14 render/crop/command-provider semantic subset over stdio: defaults, page selection and warnings, region ordering, padding and fractional bounds, rotated pages, mixed-source and late-provider partial success, all-source failure, MCP image indexing, OCR normalization, rich region-analysis normalization, plain-text truncation, and truthful provenance; exact pdf.js pixels and antialiasing are not claimed",
     "DNS-pinned URL fetch: one resolution per redirect hop, reject mixed public/non-public answers, disable ambient proxies, and revalidate every redirect; still PARTIAL because resolver timeout and TLS-SNI fixtures remain open",
     "auto off when include_* keys are present"
   ],
   "explicitlyNotClaimed": [
     "complete TS 3.0.14 semantic parity outside the immutable 10-case subset",
     "text/search geometry, geometry-perfect pdf.js boxes, and general bounding-box parity",
-    "render/crop/OCR semantic parity outside the immutable 10-case subset, including exact pdf.js pixels and antialiasing",
-    "OCR success paths outside the opt-in command JSON/plain-text subset, including tesseract-tsv; analyze success path",
+    "render/crop/OCR/analyze semantic parity outside the immutable 14-case subset, including exact pdf.js pixels and antialiasing",
+    "OCR success paths outside the opt-in command JSON/plain-text subset, including tesseract-tsv; analyze_regions HTTP and preset providers",
     "COS outline/annotations/forms",
     "cross-platform npm native binary",
     "npm library exports for pure-Rust",

--- a/scripts/differential/capture-v3014-visual-oracle.ts
+++ b/scripts/differential/capture-v3014-visual-oracle.ts
@@ -13,6 +13,7 @@ const oraclePath = join(scriptDir, 'fixtures/v3014-visual-oracle.json');
 const fixtureDir = join(repoRoot, 'test/fixtures/differential');
 const runnerSource = join(scriptDir, 'v3014-visual-baseline-runner.ts');
 const providerPath = join(scriptDir, 'reference-ocr-provider.ts');
+const regionProviderPath = join(scriptDir, 'reference-region-analysis-provider.ts');
 const refresh = process.argv.includes('--refresh');
 const oracle = JSON.parse(readFileSync(oraclePath, 'utf8')) as {
   baseline: { tag: string; commit: string };
@@ -41,7 +42,12 @@ try {
   run('bun', ['install', '--frozen-lockfile'], worktree);
   const runner = join(worktree, 'v3014-visual-baseline-runner.ts');
   writeFileSync(runner, readFileSync(runnerSource));
-  const stdout = run('bun', [runner, corpusPath, fixtureDir, providerPath], worktree, true);
+  const stdout = run(
+    'bun',
+    [runner, corpusPath, fixtureDir, providerPath, regionProviderPath],
+    worktree,
+    true
+  );
   const expectations = JSON.parse(stdout) as Record<string, unknown>;
   if (refresh) {
     writeFileSync(oraclePath, `${JSON.stringify({ ...oracle, expectations }, null, 2)}\n`);

--- a/scripts/differential/check-v3014-visual-differential.ts
+++ b/scripts/differential/check-v3014-visual-differential.ts
@@ -18,6 +18,7 @@ const corpusPath = join(scriptDir, 'fixtures/v3014-visual-corpus.json');
 const oraclePath = join(scriptDir, 'fixtures/v3014-visual-oracle.json');
 const fixtureManifestPath = join(scriptDir, 'fixtures/v3014-visual-fixtures.json');
 const providerPath = join(scriptDir, 'reference-ocr-provider.ts');
+const regionProviderPath = join(scriptDir, 'reference-region-analysis-provider.ts');
 const serverPath = join(repoRoot, 'target/release/pdf-reader-mcp-server');
 const outputFlag = process.argv.indexOf('--output');
 const outputPath = outputFlag >= 0 ? process.argv[outputFlag + 1] : undefined;
@@ -35,6 +36,7 @@ const oracle = JSON.parse(readFileSync(oraclePath, 'utf8')) as {
   };
   expectations: Record<string, Json>;
   providerSha256: string;
+  regionProviderSha256: string;
 };
 const fixtureManifest = JSON.parse(readFileSync(fixtureManifestPath, 'utf8')) as {
   fixtures: Array<{ path: string; bytes: number; sha256: string }>;
@@ -68,11 +70,14 @@ function verifyAuthority(): Record<string, string> {
     }
   }
   const ids = corpus.cases.map((entry) => entry.id);
-  if (ids.length !== 10 || new Set(ids).size !== ids.length) {
-    throw new Error(`visual/OCR corpus must contain 10 unique cases (got ${ids.length})`);
+  if (ids.length !== 14 || new Set(ids).size !== ids.length) {
+    throw new Error(`visual/OCR/analysis corpus must contain 14 unique cases (got ${ids.length})`);
   }
   if (sha256(readFileSync(providerPath)) !== oracle.providerSha256) {
     throw new Error('reference OCR provider digest mismatch');
+  }
+  if (sha256(readFileSync(regionProviderPath)) !== oracle.regionProviderSha256) {
+    throw new Error('reference region analysis provider digest mismatch');
   }
   if (JSON.stringify(ids.sort()) !== JSON.stringify(Object.keys(oracle.expectations).sort())) {
     throw new Error('visual corpus and oracle IDs differ');
@@ -258,12 +263,48 @@ function canonicalize(result: ToolResult): Json {
         };
       });
     }
+    if (Array.isArray(source.region_analyses)) {
+      output.region_analyses = source.region_analyses.map((region: Record<string, unknown>) => {
+        const provenance = region.provenance as Record<string, unknown>;
+        if (
+          provenance?.engine !== 'external-command' ||
+          provenance?.source !== 'region-analysis-provider'
+        ) {
+          throw new Error('Rust region analysis provider provenance is not truthful');
+        }
+        return {
+          region_id: region.region_id,
+          page: region.page,
+          kind: region.kind,
+          description: region.description ?? null,
+          text: region.text ?? null,
+          markdown: region.markdown ?? null,
+          confidence: region.confidence ?? null,
+          table: region.table ?? null,
+          formula: region.formula ?? null,
+          chart: region.chart ?? null,
+          warnings: region.warnings ?? [],
+          provider: region.provider,
+          source_crop_evidence_id: region.source_crop_evidence_id,
+          source_bounding_box: region.source_bounding_box,
+          crop_pixels: region.crop_pixels,
+          scale: region.scale,
+          provenance: region.provenance,
+        };
+      });
+    }
     return output;
   });
   return {
     outcome: 'success',
     profile: (payload.profile ?? null) as Json,
-    options: (payload.render_options ?? payload.crop_options ?? payload.ocr_options ?? null) as Json,
+    options: (
+      payload.render_options ??
+      payload.crop_options ??
+      payload.ocr_options ??
+      payload.analysis_options ??
+      null
+    ) as Json,
     content_count: result.content.length,
     results: results as Json,
   };
@@ -284,6 +325,15 @@ async function main() {
         providerPath,
         '{input}',
         '{page}',
+        '{languages}',
+      ]),
+      MCP_PDF_REGION_ANALYSIS_COMMAND: process.execPath,
+      MCP_PDF_REGION_ANALYSIS_ARGS_JSON: JSON.stringify([
+        regionProviderPath,
+        '{input}',
+        '{page}',
+        '{region_id}',
+        '{evidence_id}',
         '{languages}',
       ]),
     },

--- a/scripts/differential/fixtures/v3014-visual-corpus.json
+++ b/scripts/differential/fixtures/v3014-visual-corpus.json
@@ -138,6 +138,113 @@
         "scale": 1,
         "max_pages": 1
       }
+    },
+    {
+      "id": "analyze-command-rich-normalization",
+      "input": {
+        "operation": "analyze_regions",
+        "sources": [
+          {
+            "fixture": "v3014-visual-v1.pdf",
+            "regions": [
+              {
+                "id": "rich",
+                "page": 1,
+                "bounding_box": { "left": 0, "bottom": 0, "right": 30, "top": 20 }
+              }
+            ]
+          }
+        ],
+        "scale": 2,
+        "max_regions": 1,
+        "languages": ["fra", "eng"]
+      }
+    },
+    {
+      "id": "analyze-order-and-plain-truncation",
+      "input": {
+        "operation": "analyze_regions",
+        "sources": [
+          {
+            "fixture": "v3014-visual-v1.pdf",
+            "regions": [
+              {
+                "id": "formula",
+                "page": 2,
+                "bounding_box": { "left": 0, "bottom": 0, "right": 20, "top": 30 }
+              },
+              {
+                "id": "plain",
+                "page": 1,
+                "bounding_box": { "left": 0, "bottom": 0, "right": 30, "top": 20 }
+              }
+            ]
+          }
+        ],
+        "scale": 1,
+        "max_regions": 2,
+        "max_output_chars": 1000
+      }
+    },
+    {
+      "id": "analyze-mixed-source-partial",
+      "input": {
+        "operation": "analyze_regions",
+        "sources": [
+          {
+            "fixture": "missing-visual.pdf",
+            "regions": [
+              {
+                "id": "missing",
+                "page": 1,
+                "bounding_box": { "left": 0, "bottom": 0, "right": 20, "top": 20 }
+              }
+            ]
+          },
+          {
+            "fixture": "v3014-visual-v1.pdf",
+            "regions": [
+              {
+                "id": "formula",
+                "page": 2,
+                "bounding_box": { "left": 0, "bottom": 0, "right": 20, "top": 30 }
+              }
+            ]
+          }
+        ],
+        "scale": 1,
+        "max_regions": 1
+      }
+    },
+    {
+      "id": "analyze-late-provider-failure-partial",
+      "input": {
+        "operation": "analyze_regions",
+        "sources": [
+          {
+            "fixture": "v3014-visual-v1.pdf",
+            "regions": [
+              {
+                "id": "formula",
+                "page": 2,
+                "bounding_box": { "left": 0, "bottom": 0, "right": 20, "top": 30 }
+              }
+            ]
+          },
+          {
+            "fixture": "v3014-visual-v1.pdf",
+            "regions": [
+              {
+                "id": "fail",
+                "page": 1,
+                "bounding_box": { "left": 0, "bottom": 0, "right": 30, "top": 20 }
+              }
+            ]
+          }
+        ],
+        "scale": 1,
+        "max_regions": 1
+      }
     }
   ]
 }

--- a/scripts/differential/fixtures/v3014-visual-oracle.json
+++ b/scripts/differential/fixtures/v3014-visual-oracle.json
@@ -2,6 +2,7 @@
   "schemaVersion": 1,
   "profile": "pdf_reader_v3014_visual_oracle",
   "providerSha256": "86ab98b7ad9729da32b18326c728eaa3c87d33b2786c813b7e82e619db32c4b6",
+  "regionProviderSha256": "7f766456549bb2e40547bf12340d62b86af507d479e84bfc911c2ebbaa47b5ba",
   "baseline": {
     "tag": "v3.0.14",
     "commit": "92651c79c6ce8d10dfa3c76332176c26f222bd78",
@@ -12,7 +13,9 @@
       "src/handlers/renderPage.ts": "7c0b57658eca56ec995c376a4a20455cc967f13a807a1194a1d746d23db89e7a",
       "src/handlers/extractRegions.ts": "a125e4fa3b9c3aee1087f7e60a5092ce2354d918d2b1d01bc70f222d42219c33",
       "src/handlers/ocrPages.ts": "3ecca45d73471c422b225bba1a2bfee704d316826bf9f509ccf8d860f2ea6ac4",
+      "src/handlers/analyzeRegions.ts": "b84d5e9741ff8a6ea0ac37ee3b764ec94f08229662b51d0552f6ebddf3723dc8",
       "src/pdf/ocr.ts": "9c2f89afb8426fea801501f7a2264a90e536609c7f5d64e7257945d4038041ee",
+      "src/pdf/regionAnalysis.ts": "26ffb87a2af378665fdb59b9b9c8f6b9060b1015083da8c898479157bd1d80ef",
       "src/pdf/renderer.ts": "29cf9917feaa470d3e3dafea5b432439fe0450eaee90b350458fb1e41bfe75a8",
       "src/pdf/regions.ts": "f7bc3c939e57fd33260d1bf5d8210c0bde0f7cb3ea756c4912b371c1997e4f91"
     }
@@ -710,6 +713,360 @@
               }
             }
           ]
+        }
+      ]
+    },
+    "analyze-command-rich-normalization": {
+      "outcome": "success",
+      "profile": "region_analysis",
+      "options": {
+        "scale": 2,
+        "max_regions": 1,
+        "max_pixels_per_page": 16000000,
+        "timeout_ms": 60000,
+        "max_output_chars": 200000,
+        "languages": [
+          "fra",
+          "eng"
+        ]
+      },
+      "content_count": 1,
+      "results": [
+        {
+          "source": "v3014-visual-v1.pdf",
+          "success": true,
+          "num_pages": 3,
+          "warnings": [],
+          "region_analyses": [
+            {
+              "region_id": "rich",
+              "page": 1,
+              "kind": "unknown",
+              "description": "region rich languages fra,eng",
+              "text": "extracted table",
+              "markdown": "|A|B|",
+              "confidence": 0.87,
+              "table": {
+                "rows": [
+                  [
+                    "A",
+                    "2",
+                    "true",
+                    ""
+                  ],
+                  [
+                    "C",
+                    ""
+                  ]
+                ],
+                "markdown": "|A|2|",
+                "csv": "A,2",
+                "row_count": 2,
+                "column_count": 4,
+                "cells": [
+                  {
+                    "text": "value",
+                    "row_index": 1,
+                    "column_index": 2,
+                    "row_span": 2,
+                    "column_span": 3,
+                    "confidence": 0.5,
+                    "bounding_box": {
+                      "left": 1,
+                      "bottom": 2,
+                      "right": 3,
+                      "top": 4
+                    }
+                  }
+                ],
+                "confidence": 0.92
+              },
+              "formula": {
+                "asciimath": "x^2",
+                "confidence": 1
+              },
+              "chart": {
+                "title": "Sales",
+                "summary": "Trend",
+                "data_points": [
+                  {
+                    "x": 1,
+                    "y": 2
+                  }
+                ],
+                "x_axis": {
+                  "label": "Quarter",
+                  "unit": "q",
+                  "min": 0,
+                  "max": 4
+                },
+                "y_axis": {
+                  "label": "Revenue",
+                  "unit": "GBP"
+                },
+                "series": [
+                  {
+                    "name": "Main",
+                    "data_points": [
+                      {
+                        "x": 1,
+                        "y": 2
+                      }
+                    ],
+                    "confidence": 0.9
+                  }
+                ],
+                "confidence": 0.88
+              },
+              "warnings": [
+                "provider note",
+                "Unsupported region analysis kind \"spreadsheet\"; normalized to \"unknown\"."
+              ],
+              "provider": "command",
+              "source_crop_evidence_id": "page-1-rich-crop-scale-2",
+              "source_bounding_box": {
+                "left": 0,
+                "bottom": 0,
+                "right": 30,
+                "top": 20
+              },
+              "crop_pixels": {
+                "left": 0,
+                "top": 120,
+                "width": 60,
+                "height": 40
+              },
+              "scale": 2,
+              "provenance": {
+                "engine": "external-command",
+                "source": "region-analysis-provider"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "analyze-order-and-plain-truncation": {
+      "outcome": "success",
+      "profile": "region_analysis",
+      "options": {
+        "scale": 1,
+        "max_regions": 2,
+        "max_pixels_per_page": 16000000,
+        "timeout_ms": 60000,
+        "max_output_chars": 1000
+      },
+      "content_count": 1,
+      "results": [
+        {
+          "source": "v3014-visual-v1.pdf",
+          "success": true,
+          "num_pages": 3,
+          "warnings": [],
+          "region_analyses": [
+            {
+              "region_id": "formula",
+              "page": 2,
+              "kind": "formula",
+              "description": "page 2 page-2-formula-crop-scale-1",
+              "text": null,
+              "markdown": null,
+              "confidence": null,
+              "table": null,
+              "formula": {
+                "latex": "x^2 + y^2",
+                "asciimath": "x^2+y^2",
+                "confidence": 0.95
+              },
+              "chart": null,
+              "warnings": [
+                "check notation"
+              ],
+              "provider": "command",
+              "source_crop_evidence_id": "page-2-formula-crop-scale-1",
+              "source_bounding_box": {
+                "left": 0,
+                "bottom": 0,
+                "right": 20,
+                "top": 30
+              },
+              "crop_pixels": {
+                "left": 0,
+                "top": 90,
+                "width": 20,
+                "height": 30
+              },
+              "scale": 1,
+              "provenance": {
+                "engine": "external-command",
+                "source": "region-analysis-provider"
+              }
+            },
+            {
+              "region_id": "plain",
+              "page": 1,
+              "kind": "unknown",
+              "description": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              "text": null,
+              "markdown": null,
+              "confidence": null,
+              "table": null,
+              "formula": null,
+              "chart": null,
+              "warnings": [
+                "Region analysis output truncated to 1000 characters."
+              ],
+              "provider": "command",
+              "source_crop_evidence_id": "page-1-plain-crop-scale-1",
+              "source_bounding_box": {
+                "left": 0,
+                "bottom": 0,
+                "right": 30,
+                "top": 20
+              },
+              "crop_pixels": {
+                "left": 0,
+                "top": 60,
+                "width": 30,
+                "height": 20
+              },
+              "scale": 1,
+              "provenance": {
+                "engine": "external-command",
+                "source": "region-analysis-provider"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "analyze-mixed-source-partial": {
+      "outcome": "success",
+      "profile": "region_analysis",
+      "options": {
+        "scale": 1,
+        "max_regions": 1,
+        "max_pixels_per_page": 16000000,
+        "timeout_ms": 60000,
+        "max_output_chars": 200000
+      },
+      "content_count": 1,
+      "results": [
+        {
+          "source": "missing-visual.pdf",
+          "success": false,
+          "category": "file_not_found"
+        },
+        {
+          "source": "v3014-visual-v1.pdf",
+          "success": true,
+          "num_pages": 3,
+          "warnings": [],
+          "region_analyses": [
+            {
+              "region_id": "formula",
+              "page": 2,
+              "kind": "formula",
+              "description": "page 2 page-2-formula-crop-scale-1",
+              "text": null,
+              "markdown": null,
+              "confidence": null,
+              "table": null,
+              "formula": {
+                "latex": "x^2 + y^2",
+                "asciimath": "x^2+y^2",
+                "confidence": 0.95
+              },
+              "chart": null,
+              "warnings": [
+                "check notation"
+              ],
+              "provider": "command",
+              "source_crop_evidence_id": "page-2-formula-crop-scale-1",
+              "source_bounding_box": {
+                "left": 0,
+                "bottom": 0,
+                "right": 20,
+                "top": 30
+              },
+              "crop_pixels": {
+                "left": 0,
+                "top": 90,
+                "width": 20,
+                "height": 30
+              },
+              "scale": 1,
+              "provenance": {
+                "engine": "external-command",
+                "source": "region-analysis-provider"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "analyze-late-provider-failure-partial": {
+      "outcome": "success",
+      "profile": "region_analysis",
+      "options": {
+        "scale": 1,
+        "max_regions": 1,
+        "max_pixels_per_page": 16000000,
+        "timeout_ms": 60000,
+        "max_output_chars": 200000
+      },
+      "content_count": 1,
+      "results": [
+        {
+          "source": "v3014-visual-v1.pdf",
+          "success": true,
+          "num_pages": 3,
+          "warnings": [],
+          "region_analyses": [
+            {
+              "region_id": "formula",
+              "page": 2,
+              "kind": "formula",
+              "description": "page 2 page-2-formula-crop-scale-1",
+              "text": null,
+              "markdown": null,
+              "confidence": null,
+              "table": null,
+              "formula": {
+                "latex": "x^2 + y^2",
+                "asciimath": "x^2+y^2",
+                "confidence": 0.95
+              },
+              "chart": null,
+              "warnings": [
+                "check notation"
+              ],
+              "provider": "command",
+              "source_crop_evidence_id": "page-2-formula-crop-scale-1",
+              "source_bounding_box": {
+                "left": 0,
+                "bottom": 0,
+                "right": 20,
+                "top": 30
+              },
+              "crop_pixels": {
+                "left": 0,
+                "top": 90,
+                "width": 20,
+                "height": 30
+              },
+              "scale": 1,
+              "provenance": {
+                "engine": "external-command",
+                "source": "region-analysis-provider"
+              }
+            }
+          ]
+        },
+        {
+          "source": "v3014-visual-v1.pdf",
+          "success": false,
+          "category": "unknown_error"
         }
       ]
     }

--- a/scripts/differential/reference-region-analysis-provider.ts
+++ b/scripts/differential/reference-region-analysis-provider.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env bun
+
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+
+const [
+  input,
+  page = '',
+  regionId = '',
+  evidenceId = '',
+  languages = '',
+  mode = 'success',
+  marker = '',
+] = process.argv.slice(2);
+if (!input) process.exit(2);
+readFileSync(input);
+if (mode === 'fail' || regionId === 'fail') process.exit(7);
+if (mode === 'sleep') await Bun.sleep(60_000);
+if (mode === 'escaped-descendant') {
+  if (marker) writeFileSync(marker, input);
+  const command =
+    process.platform === 'win32'
+      ? [process.execPath, '-e', 'await Bun.sleep(5_000)']
+      : ['python3', '-c', 'import os,time; os.setsid(); time.sleep(5)'];
+  const descendant = Bun.spawn({
+    cmd: command,
+    stdin: 'ignore',
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+  descendant.unref();
+  process.exit(0);
+}
+if (mode === 'oversize') {
+  if (marker) appendFileSync(marker, `${regionId}\n`);
+  if (regionId !== 'rich-first') {
+    await new Promise<void>((resolve) => {
+      process.stdout.write('B'.repeat(1024 * 1024 + 1), () => resolve());
+    });
+    process.exit(0);
+  }
+}
+
+if (regionId === 'plain') {
+  process.stdout.write(` ${'A'.repeat(1002)} `);
+} else if (regionId === 'formula') {
+  process.stdout.write(
+    JSON.stringify({
+      kind: 'FORMULA',
+      description: ` page ${page} ${evidenceId} `,
+      formula: { latex: ' x^2 + y^2 ', ascii_math: ' x^2+y^2 ', confidence: 95 },
+      warnings: [' check notation ', '', 3],
+    })
+  );
+} else {
+  process.stdout.write(
+    JSON.stringify({
+      kind: ' SPREADSHEET ',
+      description: ` region ${regionId} languages ${languages} `,
+      text: ' extracted table ',
+      markdown: ' |A|B| ',
+      confidence: 87,
+      warnings: [' provider note ', '', 3],
+      table: {
+        rows: [
+          ['A', 2, true, null],
+          ['C', { ignored: true }],
+        ],
+        markdown: ' |A|2| ',
+        csv: ' A,2 ',
+        cells: [
+          {
+            text: ' value ',
+            row: 1,
+            column: 2,
+            rowspan: 2,
+            colspan: 3,
+            confidence: 50,
+            bbox: { left: 1, bottom: 2, right: 3, top: 4 },
+          },
+          { text: 'invalid', row: -1, column: 0 },
+        ],
+        confidence: 92,
+      },
+      formula: { ascii_math: ' x^2 ', confidence: 150 },
+      chart: {
+        title: ' Sales ',
+        summary: ' Trend ',
+        data_points: [{ x: 1, y: 2, nested: { ignored: true } }, null],
+        x_axis: { label: ' Quarter ', unit: ' q ', min: 0, max: 4 },
+        y_axis: { label: ' Revenue ', unit: ' GBP ' },
+        series: [{ name: ' Main ', points: [{ x: 1, y: 2 }], confidence: 90 }],
+        confidence: 88,
+      },
+    })
+  );
+}

--- a/scripts/differential/v3014-visual-baseline-runner.ts
+++ b/scripts/differential/v3014-visual-baseline-runner.ts
@@ -8,15 +8,24 @@ import { pdfEvidence } from './src/handlers/pdfEvidence.ts';
 type Content = { type: string; text?: string; data?: string; mimeType?: string };
 type ToolResult = { content: Content[]; isError?: boolean };
 
-const [corpusPath, fixtureDir, providerPath] = process.argv.slice(2);
-if (!corpusPath || !fixtureDir || !providerPath) {
-  throw new Error('usage: runner <corpus.json> <fixture-dir> <provider.ts>');
+const [corpusPath, fixtureDir, providerPath, regionProviderPath] = process.argv.slice(2);
+if (!corpusPath || !fixtureDir || !providerPath || !regionProviderPath) {
+  throw new Error('usage: runner <corpus.json> <fixture-dir> <ocr-provider.ts> <region-provider.ts>');
 }
 process.env['MCP_PDF_OCR_COMMAND'] = process.execPath;
 process.env['MCP_PDF_OCR_ARGS_JSON'] = JSON.stringify([
   providerPath,
   '{input}',
   '{page}',
+  '{languages}',
+]);
+process.env['MCP_PDF_REGION_ANALYSIS_COMMAND'] = process.execPath;
+process.env['MCP_PDF_REGION_ANALYSIS_ARGS_JSON'] = JSON.stringify([
+  regionProviderPath,
+  '{input}',
+  '{page}',
+  '{region_id}',
+  '{evidence_id}',
   '{languages}',
 ]);
 const corpus = JSON.parse(readFileSync(corpusPath, 'utf8')) as {
@@ -167,12 +176,37 @@ function canonicalize(result: ToolResult): Record<string, unknown> {
         provenance: page.provenance,
       }));
     }
+    if (Array.isArray(source.region_analyses)) {
+      output.region_analyses = source.region_analyses.map((region: Record<string, unknown>) => ({
+        region_id: region.region_id,
+        page: region.page,
+        kind: region.kind,
+        description: region.description ?? null,
+        text: region.text ?? null,
+        markdown: region.markdown ?? null,
+        confidence: region.confidence ?? null,
+        table: region.table ?? null,
+        formula: region.formula ?? null,
+        chart: region.chart ?? null,
+        warnings: region.warnings ?? [],
+        provider: region.provider,
+        source_crop_evidence_id: region.source_crop_evidence_id,
+        source_bounding_box: region.source_bounding_box,
+        crop_pixels: region.crop_pixels,
+        scale: region.scale,
+        provenance: region.provenance,
+      }));
+    }
     return output;
   });
   return {
     outcome: 'success',
     profile: payload.profile,
-    options: payload.render_options ?? payload.crop_options ?? payload.ocr_options,
+    options:
+      payload.render_options ??
+      payload.crop_options ??
+      payload.ocr_options ??
+      payload.analysis_options,
     content_count: result.content.length,
     results,
   };

--- a/scripts/run-pdf-reader-differential.sh
+++ b/scripts/run-pdf-reader-differential.sh
@@ -77,7 +77,7 @@ echo "--- deterministic v3.0.14 visual fixture + baseline replay ---" | tee -a "
 bun "$REPO_ROOT/scripts/differential/generate-v3014-visual-fixtures.ts" 2>&1 | tee -a "$LOG"
 bun "$REPO_ROOT/scripts/differential/capture-v3014-visual-oracle.ts" 2>&1 | tee -a "$LOG"
 
-echo "--- immutable v3.0.14 render/crop/OCR differential (10 semantic cases) ---" | tee -a "$LOG"
+echo "--- immutable v3.0.14 render/crop/OCR/analyze differential (14 semantic cases) ---" | tee -a "$LOG"
 bun "$REPO_ROOT/scripts/differential/check-v3014-visual-differential.ts" \
   --output "$V3014_VISUAL_JSON" >>"$LOG"
 
@@ -191,7 +191,7 @@ jq -n \
     immutableVisualDifferential: "scripts/differential/check-v3014-visual-differential.ts",
     liveTextOracle: "scripts/differential/ts-vs-rust-text-oracle.ts",
     structuralConsistencyOracle: "scripts/differential/pdf-reader-mcp-oracle.ts",
-    nonClaims: ["full TS 3.0.14 behavioral parity", "visual/provider parity outside the immutable 10-case render/crop/OCR corpus", "Tesseract TSV parity", "Document Twin semantic parity"],
+    nonClaims: ["full TS 3.0.14 behavioral parity", "visual/provider parity outside the immutable 14-case render/crop/OCR/analyze corpus", "Tesseract TSV parity", "analyze_regions HTTP/preset provider parity", "Document Twin semantic parity"],
     retirementGate: "scripts/check-no-ts-stdio-backend.sh (runs only when dropInFor3014=true)"
   }' >"$ARTIFACT"
 

--- a/test/integration/http-transport.test.ts
+++ b/test/integration/http-transport.test.ts
@@ -12,6 +12,10 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 const repoRoot = path.resolve(__dirname, '../..');
 const binWrapper = path.join(repoRoot, 'bin/pdf-reader-mcp');
 const ocrProvider = path.join(repoRoot, 'scripts/differential/reference-ocr-provider.ts');
+const regionProvider = path.join(
+  repoRoot,
+  'scripts/differential/reference-region-analysis-provider.ts'
+);
 const RUST_HTTP_READY = 'Streamable HTTP MCP listening on http://';
 
 const TEST_HOST = '127.0.0.1';
@@ -149,6 +153,15 @@ describe('MCP Server HTTP Transport Integration (Rust rmcp)', () => {
         MCP_HTTP_HOST: TEST_HOST,
         MCP_PDF_OCR_COMMAND: process.execPath,
         MCP_PDF_OCR_ARGS_JSON: JSON.stringify([ocrProvider, '{input}', '{page}', '{languages}']),
+        MCP_PDF_REGION_ANALYSIS_COMMAND: process.execPath,
+        MCP_PDF_REGION_ANALYSIS_ARGS_JSON: JSON.stringify([
+          regionProvider,
+          '{input}',
+          '{page}',
+          '{region_id}',
+          '{evidence_id}',
+          '{languages}',
+        ]),
       },
     });
 
@@ -310,6 +323,52 @@ describe('MCP Server HTTP Transport Integration (Rust rmcp)', () => {
       language: 'eng',
       provider: 'command',
       provenance: { engine: 'external-command', source: 'ocr-provider' },
+    });
+  });
+
+  it('should return normalized command-provider region analysis over HTTP', async () => {
+    const client = createMcpHttpClient();
+    await client.initializeSession();
+    const fixture = path.resolve(__dirname, '../fixtures/differential/v3014-visual-v1.pdf');
+    const response = await client.sendRequest(
+      'tools/call',
+      {
+        name: 'pdf_evidence',
+        arguments: {
+          operation: 'analyze_regions',
+          sources: [
+            {
+              path: fixture,
+              regions: [
+                {
+                  id: 'formula',
+                  page: 2,
+                  bounding_box: { left: 0, bottom: 0, right: 20, top: 30 },
+                },
+              ],
+            },
+          ],
+          scale: 1,
+          max_regions: 1,
+        },
+      },
+      6
+    );
+    expect(response.error).toBeUndefined();
+    const result = response.result as {
+      isError?: boolean;
+      content?: Array<{ type?: string; text?: string }>;
+    };
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content?.[0]?.text ?? '{}') as {
+      results?: Array<{ region_analyses?: Array<Record<string, unknown>> }>;
+    };
+    expect(payload.results?.[0]?.region_analyses?.[0]).toMatchObject({
+      region_id: 'formula',
+      page: 2,
+      kind: 'formula',
+      provider: 'command',
+      provenance: { engine: 'external-command', source: 'region-analysis-provider' },
     });
   });
 

--- a/test/integration/mcp-region-analysis-provider.test.ts
+++ b/test/integration/mcp-region-analysis-provider.test.ts
@@ -1,0 +1,277 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import type { ChildProcess } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  callTool,
+  ensureProductionArtifacts,
+  initializeSession,
+  parseToolPayload,
+  spawnProductionMcp,
+} from '../production/mcpContract.helpers.js';
+
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+const fixture = path.join(repoRoot, 'test/fixtures/differential/v3014-visual-v1.pdf');
+const provider = path.join(repoRoot, 'scripts/differential/reference-region-analysis-provider.ts');
+const providerArgs = (mode?: string, marker?: string) =>
+  JSON.stringify([
+    provider,
+    '{input}',
+    '{page}',
+    '{region_id}',
+    '{evidence_id}',
+    '{languages}',
+    ...(mode ? [mode] : []),
+    ...(marker ? [marker] : []),
+  ]);
+
+describe('pure-Rust command region analysis provider integration', () => {
+  let proc: ChildProcess;
+  let failingProc: ChildProcess;
+  let timeoutProc: ChildProcess;
+  let descendantProc: ChildProcess;
+  let aggregateProc: ChildProcess;
+  const workspace = mkdtempSync(path.join(tmpdir(), 'pdf-reader-analyze-provider-'));
+  const descendantMarker = path.join(workspace, 'descendant-input.txt');
+  const invocationMarker = path.join(workspace, 'aggregate-invocations.txt');
+
+  beforeAll(async () => {
+    ensureProductionArtifacts('pure-rust');
+    proc = spawnProductionMcp({
+      PDF_READER_ENGINE_MODE: 'pure-rust',
+      MCP_PDF_REGION_ANALYSIS_COMMAND: process.execPath,
+      MCP_PDF_REGION_ANALYSIS_ARGS_JSON: providerArgs(),
+    });
+    await initializeSession(proc, 'rust-region-analysis-provider-contract');
+    failingProc = spawnProductionMcp({
+      PDF_READER_ENGINE_MODE: 'pure-rust',
+      MCP_PDF_REGION_ANALYSIS_COMMAND: process.execPath,
+      MCP_PDF_REGION_ANALYSIS_ARGS_JSON: providerArgs('fail'),
+    });
+    await initializeSession(failingProc, 'rust-region-analysis-provider-failure-contract');
+    timeoutProc = spawnProductionMcp({
+      PDF_READER_ENGINE_MODE: 'pure-rust',
+      MCP_PDF_REGION_ANALYSIS_COMMAND: process.execPath,
+      MCP_PDF_REGION_ANALYSIS_ARGS_JSON: providerArgs('sleep'),
+    });
+    await initializeSession(timeoutProc, 'rust-region-analysis-provider-timeout-contract');
+    descendantProc = spawnProductionMcp({
+      PDF_READER_ENGINE_MODE: 'pure-rust',
+      MCP_PDF_REGION_ANALYSIS_COMMAND: process.execPath,
+      MCP_PDF_REGION_ANALYSIS_ARGS_JSON: providerArgs('escaped-descendant', descendantMarker),
+    });
+    await initializeSession(descendantProc, 'rust-region-analysis-provider-descendant-contract');
+    aggregateProc = spawnProductionMcp({
+      PDF_READER_ENGINE_MODE: 'pure-rust',
+      MCP_PDF_REGION_ANALYSIS_COMMAND: process.execPath,
+      MCP_PDF_REGION_ANALYSIS_ARGS_JSON: providerArgs('oversize', invocationMarker),
+    });
+    await initializeSession(aggregateProc, 'rust-region-analysis-provider-aggregate-contract');
+  }, 420_000);
+
+  afterAll(() => {
+    proc?.kill('SIGTERM');
+    failingProc?.kill('SIGTERM');
+    timeoutProc?.kill('SIGTERM');
+    descendantProc?.kill('SIGTERM');
+    aggregateProc?.kill('SIGTERM');
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  test('crops a bounded region and returns exact rich normalized provider data', async () => {
+    const response = await callTool(
+      proc,
+      51,
+      'pdf_evidence',
+      {
+        operation: 'analyze_regions',
+        sources: [
+          {
+            path: fixture,
+            regions: [
+              {
+                id: 'rich',
+                page: 1,
+                bounding_box: { left: 0, bottom: 0, right: 30, top: 20 },
+              },
+            ],
+          },
+        ],
+        scale: 2,
+        max_regions: 1,
+        languages: ['fra', 'eng'],
+      },
+      90_000
+    );
+    const payload = parseToolPayload(response);
+    expect(payload.isError).toBe(false);
+    expect(response.result?.content).toHaveLength(1);
+    const result = JSON.parse(payload.text) as {
+      profile: string;
+      results: Array<{ region_analyses: Array<Record<string, unknown>> }>;
+    };
+    expect(result.profile).toBe('region_analysis');
+    expect(result.results[0]?.region_analyses[0]).toMatchObject({
+      region_id: 'rich',
+      page: 1,
+      kind: 'unknown',
+      description: 'region rich languages fra,eng',
+      confidence: 0.87,
+      provider: 'command',
+      source_crop_evidence_id: 'page-1-rich-crop-scale-2',
+      crop_pixels: { left: 0, top: 120, width: 60, height: 40 },
+      provenance: { engine: 'external-command', source: 'region-analysis-provider' },
+      table: { row_count: 2, column_count: 4, confidence: 0.92 },
+      formula: { asciimath: 'x^2', confidence: 1 },
+      chart: { title: 'Sales', confidence: 0.88 },
+    });
+  }, 120_000);
+
+  test('fails closed when the command provider exits unsuccessfully', async () => {
+    const response = await callTool(
+      failingProc,
+      52,
+      'pdf_evidence',
+      {
+        operation: 'analyze_regions',
+        sources: [
+          {
+            path: fixture,
+            regions: [
+              {
+                id: 'rich',
+                page: 1,
+                bounding_box: { left: 0, bottom: 0, right: 30, top: 20 },
+              },
+            ],
+          },
+        ],
+        scale: 1,
+        max_regions: 1,
+      },
+      30_000
+    );
+    const payload = parseToolPayload(response);
+    expect(payload.isError).toBe(true);
+    expect(payload.text).toContain('All PDF sources failed region analysis');
+    expect(payload.text).toContain('command failed for page 1 region rich');
+  });
+
+  test('bounds provider timeout', async () => {
+    const started = Date.now();
+    const response = await callTool(
+      timeoutProc,
+      53,
+      'pdf_evidence',
+      {
+        operation: 'analyze_regions',
+        sources: [
+          {
+            path: fixture,
+            regions: [
+              {
+                id: 'rich',
+                page: 1,
+                bounding_box: { left: 0, bottom: 0, right: 30, top: 20 },
+              },
+            ],
+          },
+        ],
+        scale: 1,
+        max_regions: 1,
+        timeout_ms: 1_000,
+      },
+      30_000
+    );
+    const payload = parseToolPayload(response);
+    expect(payload.isError).toBe(true);
+    expect(payload.text).toContain('command timed out for page 1 region rich');
+    expect(Date.now() - started).toBeLessThan(4_000);
+  }, 30_000);
+
+  test('bounds escaped inherited-pipe descendants and cleans the temporary crop', async () => {
+    const started = Date.now();
+    const response = await callTool(
+      descendantProc,
+      54,
+      'pdf_evidence',
+      {
+        operation: 'analyze_regions',
+        sources: [
+          {
+            path: fixture,
+            regions: [
+              {
+                id: 'rich',
+                page: 1,
+                bounding_box: { left: 0, bottom: 0, right: 30, top: 20 },
+              },
+            ],
+          },
+        ],
+        scale: 1,
+        max_regions: 1,
+        timeout_ms: 1_000,
+      },
+      30_000
+    );
+    const payload = parseToolPayload(response);
+    expect(payload.isError).toBe(true);
+    expect(payload.text).toContain('command timed out for page 1 region rich');
+    expect(Date.now() - started).toBeLessThan(4_000);
+    const temporaryInput = readFileSync(descendantMarker, 'utf8');
+    expect(existsSync(temporaryInput)).toBe(false);
+  }, 30_000);
+
+  test('charges failed oversized stdout, keeps exhaustion sticky, and preserves early success', async () => {
+    const regionSource = (id: string) => ({
+      path: fixture,
+      regions: [
+        {
+          id,
+          page: 1,
+          bounding_box: { left: 0, bottom: 0, right: 30, top: 20 },
+        },
+      ],
+    });
+    const response = await callTool(
+      aggregateProc,
+      55,
+      'pdf_evidence',
+      {
+        operation: 'analyze_regions',
+        sources: [
+          regionSource('rich-first'),
+          ...Array.from({ length: 16 }, (_, index) => regionSource(`oversize-${index + 1}`)),
+          regionSource('must-not-run'),
+        ],
+        scale: 1,
+        max_regions: 1,
+        max_output_chars: 1_000,
+      },
+      120_000
+    );
+    const payload = parseToolPayload(response);
+    expect(payload.isError).toBe(false);
+    const result = JSON.parse(payload.text) as {
+      results: Array<{
+        success: boolean;
+        region_analyses?: Array<{ region_id: string }>;
+        error?: string;
+      }>;
+    };
+    expect(result.results[0]).toMatchObject({
+      success: true,
+      region_analyses: [{ region_id: 'rich-first' }],
+    });
+    expect(result.results.at(-1)).toMatchObject({
+      success: false,
+      error: expect.stringContaining('Request exceeds region analysis provider output limit'),
+    });
+    const invocations = readFileSync(invocationMarker, 'utf8').trim().split('\n');
+    expect(invocations).toHaveLength(17);
+    expect(invocations[0]).toBe('rich-first');
+    expect(invocations).not.toContain('must-not-run');
+  }, 120_000);
+});

--- a/test/integration/mcp-server.test.ts
+++ b/test/integration/mcp-server.test.ts
@@ -325,7 +325,7 @@ describe('MCP Server Integration', () => {
     });
   });
 
-  mcpIt('should fail closed for unavailable pdf_evidence analyze_regions', async () => {
+  mcpIt('should fail closed when pdf_evidence analyze_regions has no provider', async () => {
     const testPdfPath = path.resolve(__dirname, '../fixtures/sample.pdf');
 
     const callRequest = createRequest(7, 'tools/call', {
@@ -361,7 +361,7 @@ describe('MCP Server Integration', () => {
 
     expect(response.error || response.result?.isError).toBeTruthy();
     expect(response.error?.message || response.result?.content?.[0]?.text).toContain(
-      "pdf_evidence operation 'analyze_regions' is not available in the pure-Rust engine yet"
+      'Region analysis provider is not configured'
     );
   });
 

--- a/test/production/capabilityParity.contract.test.ts
+++ b/test/production/capabilityParity.contract.test.ts
@@ -285,7 +285,7 @@ describe.skipIf(!pureRustEnabled)('experimental pure-Rust capability contract', 
       expect(payload.text).toContain(
         operation === 'ocr_pages'
           ? 'OCR provider is not configured'
-          : "'analyze_regions' is not available"
+          : 'Region analysis provider is not configured'
       );
     }
   }, 240_000);


### PR DESCRIPTION
Adds a bounded opt-in command-provider success path for pure-Rust analyze_regions while keeping the publish freeze and dropInFor3014=false.

Proof:
- immutable detached TS v3.0.14 render/crop/OCR/analyze differential: 14/14, 0 skipped
- stdio and HTTP provider success
- direct failure/timeout and escaped-descendant temp cleanup
- failed oversized stdout is charged to the request-wide aggregate; sticky exhaustion prevents later invocations
- workspace cargo tests and clippy green
- production TS 3.0.14 contract remains green

Independent review: R1 FAIL on aggregate failure accounting and cleanup fences; fixed. R2 PASS at confidence 0.97.

Explicit nonclaims: HTTP/preset analyze providers, OCR TSV, full Document Twin parity, cross-platform npm native packaging, and drop-in readiness. Publish freeze remains true.