### PR TITLE
feat(rust): fuse bounded OCR into read_pdf

### DIFF
--- a/.github/workflows/rust-parity-differential.yml
+++ b/.github/workflows/rust-parity-differential.yml
@@ -147,7 +147,7 @@ jobs:
           jq -e --arg sha "$CANDIDATE_SHA" '
             .profile == "pdf_reader_v3014_visual_result" and
             .candidateSha == $sha and .pass == true and
-            .caseCount == 14 and .passed == 14 and .skipped == 0
+            .caseCount == 15 and .passed == 15 and .skipped == 0
           ' "$VISUAL_ARTIFACT" >/dev/null || {
             echo "::error::v3.0.14 visual result is incomplete, failing, or not SHA-bound"
             exit 1

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Pure-Rust is a **work in progress**, not the published product.
 | Full Document Twin (geometry, outline, COS structure) | **Not yet** |
 | Evidence `render_page` / `extract_regions` | Partial: bounded Hayro PNG render/crop in the source experiment |
 | Evidence OCR / analyze | Partial: bounded opt-in command adapters; OCR TSV and analyze HTTP/presets are not yet available |
+| `read_pdf` OCR fusion | Partial: command-provider OCR layer, map linkage, and MCP text parts; OCR-derived tables/AST and TSV remain open |
 | Cross-platform npm binary | **Not yet** |
 | Drop-in for 3.0.14 | **No** |
 

--- a/crates/pdf-reader-core/src/lib.rs
+++ b/crates/pdf-reader-core/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod document_twin;
 pub mod legacy;
+pub mod ocr_fusion;
 pub mod page_cache;
 pub mod read_pdf;
 pub mod render;
@@ -13,6 +14,10 @@ pub mod url_fetch;
 pub use ssrf::{assert_host_not_private, is_private_ip};
 
 pub use legacy::legacy_engine_allowed;
+pub use ocr_fusion::{
+    fuse_ocr_outcomes, OcrPage, OcrWord, SourceOcrOutcome, OCR_STRUCTURED_FUSION_GAP_WARNING,
+    OCR_STUB_WARNING,
+};
 pub use read_pdf::{
     read_pdf, read_pdf_from_value, ReadPdfError, ReadPdfErrorCode, ReadPdfInput, ReadPdfResponse,
     ReadPdfSource, ReadPdfSourceResult, READ_PDF_ROUTE,

--- a/crates/pdf-reader-core/src/ocr_fusion.rs
+++ b/crates/pdf-reader-core/src/ocr_fusion.rs
@@ -1,0 +1,454 @@
+//! Provider-neutral OCR text-layer fusion for `read_pdf`.
+//!
+//! Provider configuration and execution remain in the MCP server. This module
+//! owns only deterministic response semantics so every transport observes the
+//! same source-ordinal result.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::read_pdf::ReadPdfResponse;
+
+pub const OCR_STUB_WARNING: &str = "include_ocr_text_layer: provider execution is owned by pdf-reader-mcp-server; pdf-reader-core omits ocr_text_layer until a normalized provider outcome is fused.";
+pub const OCR_STRUCTURED_FUSION_GAP_WARNING: &str = "OCR text is available as a parallel text layer, but OCR word boxes are not yet fused into tables or document_ast on the pure-Rust path.";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OcrWord {
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bounding_box: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OcrPage {
+    pub page: u32,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub words: Option<Vec<OcrWord>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    pub provider: String,
+    pub source_render_evidence_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_render_scale: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_render_width: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_render_height: Option<u32>,
+    pub provenance: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warnings: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SourceOcrOutcome {
+    pub source_index: usize,
+    pub pages: Vec<OcrPage>,
+    pub warnings: Vec<String>,
+    pub error: Option<String>,
+}
+
+fn utf16_len(value: &str) -> usize {
+    value.encode_utf16().count()
+}
+
+fn round_ratio(value: f64) -> f64 {
+    (value * 100.0).round() / 100.0
+}
+
+fn append_unique_warning(warnings: &mut Option<Vec<String>>, warning: String) {
+    let values = warnings.get_or_insert_with(Vec::new);
+    if !values.contains(&warning) {
+        values.push(warning);
+    }
+}
+
+fn remove_stub_warning(warnings: &mut Option<Vec<String>>) {
+    if let Some(values) = warnings {
+        values.retain(|warning| warning != OCR_STUB_WARNING);
+        if values.is_empty() {
+            *warnings = None;
+        }
+    }
+}
+
+fn fuse_document_map(map: &mut Value, candidate_pages: &[u32], pages: &[OcrPage]) {
+    let Some(object) = map.as_object_mut() else {
+        return;
+    };
+    if !pages.is_empty() {
+        let layers = object
+            .entry("layers")
+            .or_insert_with(|| json!([]))
+            .as_array_mut();
+        if let Some(layers) = layers {
+            let layer = json!("ocr_text_layer");
+            if !layers.contains(&layer) {
+                layers.push(layer);
+            }
+        }
+    }
+
+    if let Some(map_pages) = object.get_mut("pages").and_then(Value::as_array_mut) {
+        for map_page in map_pages {
+            let Some(page_number) = map_page.get("page").and_then(Value::as_u64) else {
+                continue;
+            };
+            let Some(ocr_page) = pages
+                .iter()
+                .find(|page| u64::from(page.page) == page_number)
+            else {
+                continue;
+            };
+            let Some(page_object) = map_page.as_object_mut() else {
+                continue;
+            };
+            page_object.insert("ocr_text_chars".into(), json!(utf16_len(&ocr_page.text)));
+            page_object.insert(
+                "ocr_word_count".into(),
+                json!(ocr_page.words.as_ref().map_or(0, Vec::len)),
+            );
+            page_object.insert(
+                "ocr_source_render_evidence_id".into(),
+                json!(ocr_page.source_render_evidence_id),
+            );
+            if let Some(confidence) = ocr_page.confidence {
+                page_object.insert("ocr_confidence".into(), json!(confidence));
+            }
+        }
+    }
+
+    let routing = object.entry("routing").or_insert_with(|| json!({}));
+    if let Some(routing) = routing.as_object_mut() {
+        routing.insert("needs_ocr_pages".into(), json!(candidate_pages));
+        routing.insert(
+            "ocr_applied_pages".into(),
+            json!(pages.iter().map(|page| page.page).collect::<Vec<_>>()),
+        );
+    }
+    let summary = object.entry("summary").or_insert_with(|| json!({}));
+    if let Some(summary) = summary.as_object_mut() {
+        summary.insert("ocr_page_count".into(), json!(pages.len()));
+        summary.insert(
+            "ocr_text_chars".into(),
+            json!(pages
+                .iter()
+                .map(|page| utf16_len(&page.text))
+                .sum::<usize>()),
+        );
+    }
+}
+
+/// Fuse normalized provider outcomes into their matching read results.
+///
+/// Source identity is ordinal by design: duplicate source labels are valid.
+pub fn fuse_ocr_outcomes(response: &mut ReadPdfResponse, outcomes: Vec<SourceOcrOutcome>) {
+    for outcome in outcomes {
+        let Some(result) = response.results.get_mut(outcome.source_index) else {
+            continue;
+        };
+        let Some(data) = result.data.as_mut().filter(|_| result.success) else {
+            continue;
+        };
+        remove_stub_warning(&mut data.warnings);
+        data.ocr_text_layer = None;
+
+        if let Some(error) = outcome.error {
+            if let Some(map) = data.document_map.as_mut() {
+                fuse_document_map(map, &data.ocr_candidate_pages, &[]);
+            }
+            append_unique_warning(
+                &mut data.warnings,
+                format!("OCR text layer unavailable: {error}"),
+            );
+            continue;
+        }
+        if outcome.pages.is_empty() {
+            if let Some(map) = data.document_map.as_mut() {
+                fuse_document_map(map, &data.ocr_candidate_pages, &[]);
+            }
+            continue;
+        }
+
+        let page_warnings = outcome
+            .pages
+            .iter()
+            .flat_map(|page| page.warnings.clone().unwrap_or_default())
+            .collect::<Vec<_>>();
+        let mut layer_warnings = outcome.warnings.clone();
+        layer_warnings.extend(page_warnings);
+        let confidences = outcome
+            .pages
+            .iter()
+            .filter_map(|page| page.confidence)
+            .collect::<Vec<_>>();
+        let average_confidence = (!confidences.is_empty())
+            .then(|| round_ratio(confidences.iter().sum::<f64>() / confidences.len() as f64));
+        let source_render_count = outcome
+            .pages
+            .iter()
+            .map(|page| page.source_render_evidence_id.as_str())
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        let mut summary = json!({
+            "page_count": outcome.pages.len(),
+            "text_chars": outcome.pages.iter().map(|page| utf16_len(&page.text)).sum::<usize>(),
+            "word_count": outcome.pages.iter().map(|page| page.words.as_ref().map_or(0, Vec::len)).sum::<usize>(),
+            "words_with_bounding_boxes": outcome.pages.iter().flat_map(|page| page.words.as_deref().unwrap_or_default()).filter(|word| word.bounding_box.is_some()).count(),
+            "source_render_count": source_render_count,
+        });
+        if let Some(confidence) = average_confidence {
+            summary["average_confidence"] = json!(confidence);
+        }
+        let mut layer = json!({
+            "profile": "ocr_text_layer",
+            "pages": outcome.pages,
+            "summary": summary,
+        });
+        if !layer_warnings.is_empty() {
+            layer["warnings"] = json!(layer_warnings);
+        }
+        data.ocr_text_layer = Some(layer);
+        for warning in outcome.warnings {
+            append_unique_warning(&mut data.warnings, warning);
+        }
+
+        if let Some(map) = data.document_map.as_mut() {
+            fuse_document_map(map, &data.ocr_candidate_pages, &outcome.pages);
+        }
+        if data.tables.is_some() || data.document_ast.is_some() {
+            append_unique_warning(
+                &mut data.warnings,
+                OCR_STRUCTURED_FUSION_GAP_WARNING.to_string(),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::read_pdf::{EngineInfo, ReadPdfData, ReadPdfSourceResult};
+
+    fn response() -> ReadPdfResponse {
+        ReadPdfResponse {
+            profile: "agent_document_twin",
+            results: vec![ReadPdfSourceResult {
+                source: "duplicate.pdf".into(),
+                success: true,
+                error: None,
+                data: Some(ReadPdfData {
+                    num_pages: None,
+                    info: None,
+                    metadata: None,
+                    full_text: Some("selectable".into()),
+                    page_texts: None,
+                    markdown: None,
+                    html: None,
+                    chunks: None,
+                    elements: None,
+                    text_layer: None,
+                    tables: None,
+                    images: None,
+                    safety_findings: None,
+                    layout_diagnostics: None,
+                    document_map: Some(json!({"layers":[],"pages":[{"page":2}],"routing":{}})),
+                    document_ast: None,
+                    trust_report: None,
+                    accessibility_report: None,
+                    outline: None,
+                    annotations: None,
+                    form_fields: None,
+                    attachments: None,
+                    structure_trees: None,
+                    page_labels: None,
+                    page_geometry: None,
+                    permissions: None,
+                    ocr_text_layer: None,
+                    visual_enrichments: None,
+                    visual_enrichment_candidates: None,
+                    warnings: Some(vec![OCR_STUB_WARNING.into()]),
+                    route: "test".into(),
+                    engine: EngineInfo {
+                        name: "test",
+                        version: "test",
+                    },
+                    ocr_candidate_pages: vec![2],
+                }),
+            }],
+        }
+    }
+
+    #[test]
+    fn fuses_by_ordinal_and_preserves_selectable_text() {
+        let mut response = response();
+        fuse_ocr_outcomes(
+            &mut response,
+            vec![SourceOcrOutcome {
+                source_index: 0,
+                pages: vec![OcrPage {
+                    page: 2,
+                    text: "A😀".into(),
+                    confidence: Some(0.914),
+                    words: Some(vec![OcrWord {
+                        text: "A".into(),
+                        confidence: Some(0.9),
+                        bounding_box: Some(json!({"left":1,"bottom":2,"right":3,"top":4})),
+                    }]),
+                    language: None,
+                    provider: "command".into(),
+                    source_render_evidence_id: "render-2".into(),
+                    source_render_scale: Some(2.0),
+                    source_render_width: Some(100),
+                    source_render_height: Some(200),
+                    provenance: json!({"engine":"external-command","source":"ocr-provider"}),
+                    warnings: None,
+                }],
+                warnings: vec!["render warning".into()],
+                error: None,
+            }],
+        );
+        let data = response.results[0].data.as_ref().unwrap();
+        assert_eq!(data.full_text.as_deref(), Some("selectable"));
+        assert_eq!(
+            data.ocr_text_layer.as_ref().unwrap()["profile"],
+            "ocr_text_layer"
+        );
+        assert_eq!(
+            data.ocr_text_layer.as_ref().unwrap()["summary"]["text_chars"],
+            3
+        );
+        assert_eq!(
+            data.document_map.as_ref().unwrap()["routing"]["ocr_applied_pages"],
+            json!([2])
+        );
+        assert!(!data
+            .warnings
+            .as_ref()
+            .unwrap()
+            .iter()
+            .any(|warning| warning == OCR_STUB_WARNING));
+    }
+
+    #[test]
+    fn provider_failure_omits_layer_and_keeps_source_successful() {
+        let mut response = response();
+        fuse_ocr_outcomes(
+            &mut response,
+            vec![SourceOcrOutcome {
+                source_index: 0,
+                pages: Vec::new(),
+                warnings: Vec::new(),
+                error: Some("provider failed".into()),
+            }],
+        );
+        let result = &response.results[0];
+        assert!(result.success);
+        let data = result.data.as_ref().unwrap();
+        assert!(data.ocr_text_layer.is_none());
+        assert_eq!(
+            data.warnings.as_ref().unwrap(),
+            &["OCR text layer unavailable: provider failed"]
+        );
+        let map = data.document_map.as_ref().unwrap();
+        assert_eq!(map["routing"]["needs_ocr_pages"], json!([2]));
+        assert_eq!(map["routing"]["ocr_applied_pages"], json!([]));
+        assert!(!map["layers"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("ocr_text_layer")));
+    }
+
+    #[test]
+    fn repeated_fusion_replaces_layer_without_duplicate_map_or_warning_entries() {
+        let mut response = response();
+        let outcome = SourceOcrOutcome {
+            source_index: 0,
+            pages: vec![OcrPage {
+                page: 2,
+                text: "replacement".into(),
+                confidence: None,
+                words: None,
+                language: None,
+                provider: "command".into(),
+                source_render_evidence_id: "render-2".into(),
+                source_render_scale: None,
+                source_render_width: None,
+                source_render_height: None,
+                provenance: json!({"engine":"external-command","source":"ocr-provider"}),
+                warnings: None,
+            }],
+            warnings: vec!["render warning".into()],
+            error: None,
+        };
+        fuse_ocr_outcomes(&mut response, vec![outcome.clone()]);
+        fuse_ocr_outcomes(&mut response, vec![outcome]);
+        let data = response.results[0].data.as_ref().unwrap();
+        assert_eq!(
+            data.document_map.as_ref().unwrap()["layers"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter(|layer| **layer == "ocr_text_layer")
+                .count(),
+            1
+        );
+        assert_eq!(
+            data.warnings
+                .as_ref()
+                .unwrap()
+                .iter()
+                .filter(|warning| warning.as_str() == "render warning")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn structured_outputs_remain_unchanged_and_gap_is_explicit() {
+        let mut response = response();
+        let data = response.results[0].data.as_mut().unwrap();
+        data.tables = Some(json!([{"id":"selectable-table"}]));
+        data.document_ast = Some(json!({"root":{"id":"selectable-root"}}));
+        let tables_before = data.tables.clone();
+        let ast_before = data.document_ast.clone();
+        fuse_ocr_outcomes(
+            &mut response,
+            vec![SourceOcrOutcome {
+                source_index: 0,
+                pages: vec![OcrPage {
+                    page: 2,
+                    text: "OCR".into(),
+                    confidence: None,
+                    words: Some(vec![OcrWord {
+                        text: "cell".into(),
+                        confidence: None,
+                        bounding_box: Some(json!({"left":1,"bottom":1,"right":2,"top":2})),
+                    }]),
+                    language: None,
+                    provider: "command".into(),
+                    source_render_evidence_id: "render-2".into(),
+                    source_render_scale: Some(2.0),
+                    source_render_width: Some(100),
+                    source_render_height: Some(100),
+                    provenance: json!({"engine":"external-command","source":"ocr-provider"}),
+                    warnings: None,
+                }],
+                warnings: Vec::new(),
+                error: None,
+            }],
+        );
+        let data = response.results[0].data.as_ref().unwrap();
+        assert_eq!(data.tables, tables_before);
+        assert_eq!(data.document_ast, ast_before);
+        assert!(data
+            .warnings
+            .as_ref()
+            .unwrap()
+            .contains(&OCR_STRUCTURED_FUSION_GAP_WARNING.to_string()));
+    }
+}

--- a/crates/pdf-reader-core/src/read_pdf.rs
+++ b/crates/pdf-reader-core/src/read_pdf.rs
@@ -130,6 +130,9 @@ pub struct ReadPdfData {
     pub warnings: Option<Vec<String>>,
     pub route: String,
     pub engine: EngineInfo,
+    /// Selected OCR candidates used by the server-side provider boundary.
+    #[serde(skip)]
+    pub ocr_candidate_pages: Vec<u32>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -461,10 +464,7 @@ fn build_data(
         );
     }
     if want_ocr {
-        warnings.push(
-            "include_ocr_text_layer: no OCR provider configured on pure-Rust path; ocr_text_layer is empty. Configure an external OCR provider for scanned pages."
-                .into(),
-        );
+        warnings.push(crate::ocr_fusion::OCR_STUB_WARNING.into());
     }
     if want_visual {
         warnings.push(
@@ -598,6 +598,20 @@ fn build_data(
         engine: EngineInfo {
             name: ENGINE_NAME,
             version: ENGINE_VERSION,
+        },
+        ocr_candidate_pages: if want_ocr {
+            let empty = pages
+                .iter()
+                .filter(|page| page.text.trim().is_empty())
+                .map(|page| page.page)
+                .collect::<Vec<_>>();
+            if empty.is_empty() {
+                pages.iter().map(|page| page.page).collect()
+            } else {
+                empty
+            }
+        } else {
+            Vec::new()
         },
     };
 
@@ -779,14 +793,6 @@ fn build_data(
     }
     if want_permissions {
         data.permissions = Some(json!([]));
-    }
-    if want_ocr {
-        data.ocr_text_layer = Some(json!({
-            "profile": "pdf_ocr_text_layer",
-            "pages": [],
-            "provider": null,
-            "note": "No OCR provider configured.",
-        }));
     }
     if want_visual {
         data.visual_enrichments = Some(json!([]));
@@ -1216,7 +1222,11 @@ mod tests {
         assert!(data.form_fields.is_some());
         assert!(data.attachments.is_some());
         assert!(data.structure_trees.is_some());
-        assert!(data.ocr_text_layer.is_some());
+        // Provider-backed fields remain absent until the server fuses a
+        // normalized outcome; returning an empty placeholder would diverge
+        // from the TypeScript v3.0.14 failure semantics.
+        assert!(data.ocr_text_layer.is_none());
+        assert!(!data.ocr_candidate_pages.is_empty());
         assert!(data.visual_enrichments.is_some());
         assert_eq!(
             data.trust_report.as_ref().unwrap()["profile"],
@@ -1226,6 +1236,57 @@ mod tests {
             data.accessibility_report.as_ref().unwrap()["profile"],
             "pdf_accessibility_report"
         );
+    }
+
+    #[test]
+    fn ocr_candidates_prefer_empty_selected_pages_then_fall_back_to_all() {
+        let input = ReadPdfInput {
+            include_ocr_text_layer: true,
+            ..ReadPdfInput::default()
+        };
+        let mixed = build_data(
+            &[
+                crate::document_twin::PageText {
+                    page: 2,
+                    text: "selectable".into(),
+                },
+                crate::document_twin::PageText {
+                    page: 4,
+                    text: String::new(),
+                },
+                crate::document_twin::PageText {
+                    page: 7,
+                    text: "  \n".into(),
+                },
+            ],
+            7,
+            &input,
+            None,
+            true,
+        );
+        assert_eq!(mixed.ocr_candidate_pages, vec![4, 7]);
+
+        let selectable = build_data(
+            &[
+                crate::document_twin::PageText {
+                    page: 2,
+                    text: "first".into(),
+                },
+                crate::document_twin::PageText {
+                    page: 5,
+                    text: "second".into(),
+                },
+            ],
+            5,
+            &input,
+            None,
+            true,
+        );
+        assert_eq!(selectable.ocr_candidate_pages, vec![2, 5]);
+        assert!(serde_json::to_value(selectable)
+            .expect("serialize")
+            .get("ocr_candidate_pages")
+            .is_none());
     }
 
     #[test]

--- a/crates/pdf-reader-mcp-server/src/lib.rs
+++ b/crates/pdf-reader-mcp-server/src/lib.rs
@@ -74,18 +74,27 @@ impl PdfReaderMcp {
     #[tool(
         description = "Primary PDF reader. Pure-Rust experimental: selectable text, markdown, chunks, and best-effort twin fields. Not full 3.0.14 geometry/evidence parity."
     )]
-    pub fn read_pdf(
+    pub async fn read_pdf(
         &self,
         Parameters(args): Parameters<ReadPdfArgs>,
     ) -> Result<rmcp::model::CallToolResult, ErrorData> {
         args.validate()
             .map_err(|message| ErrorData::invalid_params(message, None))?;
+        let provider_operation = args.include_ocr_text_layer == Some(true);
         let value = serde_json::to_value(args)
             .map(omit_absent_optional_fields)
             .map_err(|error| {
                 ErrorData::invalid_params(format!("Failed to encode read_pdf args: {error}"), None)
             })?;
-        read_pdf::read_pdf(value)
+        if provider_operation {
+            tokio::task::spawn_blocking(move || read_pdf::read_pdf(value))
+                .await
+                .map_err(|error| {
+                    ErrorData::internal_error(format!("read_pdf worker failed: {error}"), None)
+                })?
+        } else {
+            read_pdf::read_pdf(value)
+        }
     }
 
     #[tool(
@@ -303,7 +312,7 @@ mod tests {
             "sample_pages": 21
         }))
         .expect("structurally valid read args");
-        assert!(server.read_pdf(Parameters(read)).is_err());
+        assert!(server.read_pdf(Parameters(read)).await.is_err());
 
         let search = serde_json::from_value(serde_json::json!({
             "sources": [{"path": "sample.pdf"}],

--- a/crates/pdf-reader-mcp-server/src/ocr_evidence.rs
+++ b/crates/pdf-reader-mcp-server/src/ocr_evidence.rs
@@ -4,6 +4,7 @@ use std::env;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
+use pdf_reader_core::{OcrPage, SourceOcrOutcome};
 use rmcp::model::{CallToolResult, Content};
 use serde_json::{json, Value};
 use tempfile::TempDir;
@@ -11,6 +12,7 @@ use tempfile::TempDir;
 use crate::command_provider::{self, CommandInvocation, CommandRunError};
 use crate::schema::PdfEvidenceArgs;
 use crate::visual_evidence;
+use crate::visual_evidence::{MaterializedSource, OcrRenderRequest, RequestWorkBudget};
 
 const DEFAULT_TIMEOUT_MS: u64 = 60_000;
 const DEFAULT_MAX_OUTPUT_CHARS: usize = 200_000;
@@ -91,6 +93,21 @@ impl RequestOcrBudget {
     fn charge_failed_provider(&mut self, provider_bytes: usize) -> Result<(), String> {
         self.charge(provider_bytes, 0)
     }
+}
+
+fn admit_read_ocr_source(
+    request_budget: &RequestOcrBudget,
+    render_budget: &mut RequestWorkBudget,
+    request_deadline: Instant,
+) -> Result<(), String> {
+    request_budget.ensure_available()?;
+    render_budget.ensure_available()?;
+    if Instant::now() >= request_deadline {
+        return render_budget.exhaust(format!(
+            "Request exceeds OCR provider time limit of {MAX_REQUEST_OCR_TIMEOUT_MS} milliseconds."
+        ));
+    }
+    Ok(())
 }
 
 #[derive(Clone)]
@@ -361,6 +378,209 @@ fn normalize_output(
     output
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ReadOcrOptions {
+    pub(crate) scale: f64,
+    pub(crate) max_pages: usize,
+    pub(crate) max_pixels_per_page: u64,
+    pub(crate) timeout_ms: u64,
+    pub(crate) max_output_chars: usize,
+}
+
+impl Default for ReadOcrOptions {
+    fn default() -> Self {
+        Self {
+            scale: 2.0,
+            max_pages: 5,
+            max_pixels_per_page: 16_000_000,
+            timeout_ms: DEFAULT_TIMEOUT_MS,
+            max_output_chars: DEFAULT_MAX_OUTPUT_CHARS,
+        }
+    }
+}
+
+/// Render and OCR read_pdf candidates without converting image bytes through
+/// MCP content/base64. All effects are synchronous by design; callers must run
+/// this boundary on a blocking worker.
+pub(crate) fn run_read_ocr(
+    sources: &[(&MaterializedSource, Vec<u32>)],
+    options: ReadOcrOptions,
+) -> Vec<SourceOcrOutcome> {
+    if sources.len() > MAX_SOURCES_PER_REQUEST {
+        let error =
+            format!("read_pdf OCR accepts at most {MAX_SOURCES_PER_REQUEST} sources per request.");
+        return sources
+            .iter()
+            .map(|(source, _)| SourceOcrOutcome {
+                source_index: source.source_index(),
+                pages: Vec::new(),
+                warnings: Vec::new(),
+                error: Some(error.clone()),
+            })
+            .collect();
+    }
+    let config = match provider_config() {
+        Ok(config) => config,
+        Err(error) => {
+            return sources
+                .iter()
+                .map(|(source, _)| SourceOcrOutcome {
+                    source_index: source.source_index(),
+                    pages: Vec::new(),
+                    warnings: Vec::new(),
+                    error: Some(error.clone()),
+                })
+                .collect()
+        }
+    };
+    let _permit = match OcrRequestPermit::acquire() {
+        Ok(permit) => permit,
+        Err(error) => {
+            return sources
+                .iter()
+                .map(|(source, _)| SourceOcrOutcome {
+                    source_index: source.source_index(),
+                    pages: Vec::new(),
+                    warnings: Vec::new(),
+                    error: Some(error.clone()),
+                })
+                .collect()
+        }
+    };
+
+    let request_deadline = Instant::now() + Duration::from_millis(MAX_REQUEST_OCR_TIMEOUT_MS);
+    let mut request_budget = RequestOcrBudget::default();
+    let mut render_budget = RequestWorkBudget::default();
+    let languages = Vec::new();
+    sources
+        .iter()
+        .map(|(source, candidate_pages)| {
+            let deadline_error = format!(
+                "Request exceeds OCR provider time limit of {MAX_REQUEST_OCR_TIMEOUT_MS} milliseconds."
+            );
+            if let Err(error) =
+                admit_read_ocr_source(&request_budget, &mut render_budget, request_deadline)
+            {
+                return SourceOcrOutcome {
+                    source_index: source.source_index(),
+                    pages: Vec::new(),
+                    warnings: Vec::new(),
+                    error: Some(error),
+                };
+            }
+            let rendered = visual_evidence::render_ocr_source(
+                source,
+                OcrRenderRequest {
+                    requested_pages: candidate_pages,
+                    scale_value: options.scale,
+                    max_pages: options.max_pages,
+                    max_pixels: options.max_pixels_per_page,
+                    request_deadline,
+                    deadline_error: &deadline_error,
+                },
+                &mut render_budget,
+            );
+            if let Some(error) = rendered.error {
+                return SourceOcrOutcome {
+                    source_index: rendered.source_index,
+                    pages: Vec::new(),
+                    warnings: rendered.warnings,
+                    error: Some(error),
+                };
+            }
+            let mut pages = Vec::with_capacity(rendered.pages.len());
+            for page in rendered.pages {
+                if let Err(error) = request_budget.ensure_available() {
+                    return SourceOcrOutcome {
+                        source_index: rendered.source_index,
+                        pages: Vec::new(),
+                        warnings: rendered.warnings,
+                        error: Some(error),
+                    };
+                }
+                let remaining_ms = u64::try_from(
+                    request_deadline
+                        .saturating_duration_since(Instant::now())
+                        .as_millis(),
+                )
+                .unwrap_or(u64::MAX);
+                if remaining_ms == 0 {
+                    return SourceOcrOutcome {
+                        source_index: rendered.source_index,
+                        pages: Vec::new(),
+                        warnings: rendered.warnings,
+                        error: Some(format!(
+                            "Request exceeds OCR provider time limit of {MAX_REQUEST_OCR_TIMEOUT_MS} milliseconds."
+                        )),
+                    };
+                }
+                let stdout = match run_provider(
+                    &config,
+                    &page.png,
+                    u64::from(page.page),
+                    &rendered.source,
+                    &languages,
+                    options.timeout_ms.min(remaining_ms),
+                    options.max_output_chars,
+                ) {
+                    Ok(stdout) => stdout,
+                    Err(error) => {
+                        let _ = request_budget.charge_failed_provider(error.charge_bytes);
+                        return SourceOcrOutcome {
+                            source_index: rendered.source_index,
+                            pages: Vec::new(),
+                            warnings: rendered.warnings,
+                            error: Some(error.message),
+                        };
+                    }
+                };
+                let mut normalized = normalize_output(
+                    &stdout,
+                    options.max_output_chars,
+                    &languages,
+                    options.scale,
+                );
+                let output_chars = normalized["text"]
+                    .as_str()
+                    .map_or(0, |text| text.encode_utf16().count());
+                if let Err(error) = request_budget.charge(stdout.len(), output_chars) {
+                    return SourceOcrOutcome {
+                        source_index: rendered.source_index,
+                        pages: Vec::new(),
+                        warnings: rendered.warnings,
+                        error: Some(error),
+                    };
+                }
+                normalized["page"] = json!(page.page);
+                normalized["provider"] = json!("command");
+                normalized["source_render_evidence_id"] = json!(page.evidence_id);
+                normalized["source_render_scale"] = json!(page.scale);
+                normalized["source_render_width"] = json!(page.width);
+                normalized["source_render_height"] = json!(page.height);
+                normalized["provenance"] =
+                    json!({"engine": "external-command", "source": "ocr-provider"});
+                match serde_json::from_value::<OcrPage>(normalized) {
+                    Ok(page) => pages.push(page),
+                    Err(error) => {
+                        return SourceOcrOutcome {
+                            source_index: rendered.source_index,
+                            pages: Vec::new(),
+                            warnings: rendered.warnings,
+                            error: Some(format!("Failed to normalize OCR provider output: {error}")),
+                        }
+                    }
+                }
+            }
+            SourceOcrOutcome {
+                source_index: rendered.source_index,
+                pages,
+                warnings: rendered.warnings,
+                error: None,
+            }
+        })
+        .collect()
+}
+
 fn text_result(payload: Value) -> CallToolResult {
     let text = serde_json::to_string_pretty(&payload).unwrap_or_else(|_| payload.to_string());
     CallToolResult {
@@ -605,6 +825,30 @@ mod tests {
             .ensure_available()
             .expect_err("exhaustion is sticky")
             .contains("characters"));
+    }
+
+    #[test]
+    fn exhausted_provider_budget_blocks_later_render_and_provider_effects() {
+        let mut request_budget = RequestOcrBudget::default();
+        request_budget
+            .charge(0, MAX_REQUEST_OCR_OUTPUT_CHARS + 1)
+            .expect_err("exhaust provider budget");
+        let mut render_budget = RequestWorkBudget::default();
+        let mut sentinel_invocations = 0usize;
+
+        if admit_read_ocr_source(
+            &request_budget,
+            &mut render_budget,
+            Instant::now() + Duration::from_secs(1),
+        )
+        .is_ok()
+        {
+            sentinel_invocations += 1;
+        }
+
+        assert_eq!(sentinel_invocations, 0);
+        assert_eq!(render_budget.rendered_pages, 0);
+        assert_eq!(render_budget.render_pixels, 0);
     }
 
     #[test]

--- a/crates/pdf-reader-mcp-server/src/read_pdf.rs
+++ b/crates/pdf-reader-mcp-server/src/read_pdf.rs
@@ -1,15 +1,19 @@
-use pdf_reader_core::read_pdf_from_value;
-use pdf_reader_core::{hash_file, ReadPdfErrorCode, READ_PDF_ROUTE};
-use rmcp::model::CallToolResult;
-use serde_json::Value;
-use std::path::PathBuf;
+use pdf_reader_core::{
+    fuse_ocr_outcomes, hash_file, read_pdf_from_value, ReadPdfErrorCode, ReadPdfResponse,
+    ReadPdfSourceResult, READ_PDF_ROUTE,
+};
+use rmcp::model::{CallToolResult, Content};
+use serde_json::{json, Value};
 
 use crate::evidence::attach_evidence;
+use crate::ocr_evidence::{run_read_ocr, ReadOcrOptions};
 use crate::schema::PdfSource;
+use crate::visual_evidence::{materialize_read_source, MaterializedSource};
 
 const DEFAULT_MAX_FILE_BYTES: u64 = 256 * 1024 * 1024;
 
 pub fn read_pdf(args: Value) -> Result<CallToolResult, rmcp::ErrorData> {
+    let ocr_requested = args.get("include_ocr_text_layer").and_then(Value::as_bool) == Some(true);
     let sources = args
         .get("sources")
         .and_then(Value::as_array)
@@ -18,8 +22,22 @@ pub fn read_pdf(args: Value) -> Result<CallToolResult, rmcp::ErrorData> {
 
     let parsed_sources: Vec<PdfSource> = sources
         .iter()
-        .filter_map(|source| serde_json::from_value(source.clone()).ok())
-        .collect();
+        .enumerate()
+        .map(|(source_index, source)| {
+            serde_json::from_value(source.clone()).map_err(|error| {
+                rmcp::ErrorData::invalid_params(
+                    format!("Invalid sources[{source_index}]: {error}"),
+                    None,
+                )
+            })
+        })
+        .collect::<Result<_, _>>()?;
+    if parsed_sources.is_empty() {
+        return Err(rmcp::ErrorData::invalid_params(
+            "sources must include at least one PDF source.",
+            None,
+        ));
+    }
 
     for source in &parsed_sources {
         if let Err(message) = source.validate() {
@@ -27,30 +45,244 @@ pub fn read_pdf(args: Value) -> Result<CallToolResult, rmcp::ErrorData> {
         }
     }
 
-    let payload = read_pdf_from_value(&args).map_err(|error| match error.code {
-        ReadPdfErrorCode::InvalidParams => rmcp::ErrorData::invalid_params(error.message, None),
-        ReadPdfErrorCode::InvalidRequest | ReadPdfErrorCode::ExtractionFailed => {
-            rmcp::ErrorData::invalid_request(error.message, None)
+    let mut materialized: Vec<Option<MaterializedSource>> =
+        (0..parsed_sources.len()).map(|_| None).collect();
+    let mut results = Vec::with_capacity(parsed_sources.len());
+    for (source_index, source) in parsed_sources.iter().enumerate() {
+        let original_label = source.label();
+        let owner = match materialize_read_source(source_index, source) {
+            Ok(owner) => owner,
+            Err(error) => {
+                results.push(ReadPdfSourceResult {
+                    source: original_label,
+                    success: false,
+                    error: Some(error),
+                    data: None,
+                });
+                continue;
+            }
+        };
+        let mut source_args = args.clone();
+        source_args["sources"] = json!([{
+            "path": owner.path().to_string_lossy(),
+            "pages": sources[source_index].get("pages").cloned().unwrap_or(Value::Null),
+        }]);
+        match read_pdf_from_value(&source_args) {
+            Ok(mut response) => {
+                let mut result = response.results.remove(0);
+                result.source = original_label;
+                results.push(result);
+                materialized[source_index] = Some(owner);
+            }
+            Err(error) if error.code == ReadPdfErrorCode::InvalidParams => {
+                return Err(rmcp::ErrorData::invalid_params(error.message, None));
+            }
+            Err(error) => {
+                results.push(ReadPdfSourceResult {
+                    source: original_label,
+                    success: false,
+                    error: Some(error.message),
+                    data: None,
+                });
+            }
         }
-    })?;
+    }
+    if results.iter().all(|result| !result.success) {
+        let errors = results
+            .iter()
+            .filter_map(|result| result.error.as_deref())
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(rmcp::ErrorData::invalid_request(
+            format!("All PDF sources failed to process: {errors}"),
+            None,
+        ));
+    }
 
-    let source_hash = parsed_sources
+    let mut payload = ReadPdfResponse {
+        profile: "pdf_read_results",
+        results,
+    };
+    let ocr_sources = payload
+        .results
         .iter()
-        .find_map(|source| source.path.as_ref())
-        .and_then(|path| hash_file(PathBuf::from(path).as_path(), DEFAULT_MAX_FILE_BYTES).ok())
+        .enumerate()
+        .filter_map(|(source_index, result)| {
+            let pages = result.data.as_ref()?.ocr_candidate_pages.clone();
+            (!pages.is_empty()).then(|| {
+                materialized[source_index]
+                    .as_ref()
+                    .map(|source| (source, pages))
+            })?
+        })
+        .collect::<Vec<_>>();
+    let mut outcomes = if ocr_sources.is_empty() {
+        Vec::new()
+    } else {
+        run_read_ocr(&ocr_sources, ReadOcrOptions::default())
+    };
+    if ocr_requested {
+        outcomes.extend(
+            payload
+                .results
+                .iter()
+                .enumerate()
+                .filter(|(_, result)| {
+                    result
+                        .data
+                        .as_ref()
+                        .is_some_and(|data| data.ocr_candidate_pages.is_empty())
+                })
+                .map(|(source_index, _)| pdf_reader_core::SourceOcrOutcome {
+                    source_index,
+                    pages: Vec::new(),
+                    warnings: Vec::new(),
+                    error: None,
+                }),
+        );
+    }
+    fuse_ocr_outcomes(&mut payload, outcomes);
+
+    let source_hash = materialized
+        .first()
+        .and_then(Option::as_ref)
+        .and_then(|source| hash_file(source.path(), DEFAULT_MAX_FILE_BYTES).ok())
         .map(|hash| hash.source_hash);
 
-    let structured = attach_evidence(
+    let has_provider_ocr = payload.results.iter().any(|result| {
+        result
+            .data
+            .as_ref()
+            .and_then(|data| data.ocr_text_layer.as_ref())
+            .is_some()
+    });
+    let mut structured = attach_evidence(
         "read_pdf",
         None,
         &parsed_sources,
         READ_PDF_ROUTE,
         source_hash,
         Vec::new(),
-        serde_json::to_value(payload).map_err(|error| {
+        serde_json::to_value(&payload).map_err(|error| {
             rmcp::ErrorData::internal_error(format!("Failed to serialize read_pdf: {error}"), None)
         })?,
     );
+    if has_provider_ocr {
+        structured["evidence"]["confidence"] = json!("provider-dependent");
+    }
 
-    Ok(CallToolResult::structured(structured))
+    let mut result = CallToolResult::structured(structured);
+    append_ocr_content(&mut result, &payload);
+    Ok(result)
+}
+
+fn append_ocr_content(result: &mut CallToolResult, payload: &ReadPdfResponse) {
+    for source in &payload.results {
+        let Some(pages) = source
+            .data
+            .as_ref()
+            .and_then(|data| data.ocr_text_layer.as_ref())
+            .and_then(|layer| layer.get("pages"))
+            .and_then(Value::as_array)
+        else {
+            continue;
+        };
+        for page in pages {
+            let Some(text) = page.get("text").and_then(Value::as_str) else {
+                continue;
+            };
+            if text.is_empty() {
+                continue;
+            }
+            let page_number = page.get("page").and_then(Value::as_u64).unwrap_or(0);
+            result
+                .content
+                .push(Content::text(format!("[Page {page_number} OCR]\n{text}")));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn appends_nonempty_ocr_pages_after_existing_content() {
+        let fixture =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test/fixtures/sample.pdf");
+        let mut payload = read_pdf_from_value(&json!({
+            "sources": [{"path": fixture}],
+            "include_ocr_text_layer": true
+        }))
+        .expect("read fixture");
+        payload.results[0]
+            .data
+            .as_mut()
+            .expect("read data")
+            .ocr_text_layer = Some(json!({
+            "profile": "ocr_text_layer",
+            "pages": [
+                {"page": 2, "text": "scanned text"},
+                {"page": 3, "text": ""}
+            ]
+        }));
+        let mut result = CallToolResult::structured(json!({"profile":"pdf_read_results"}));
+        result.content.push(Content::text("structured-json"));
+        let existing_parts = result.content.len();
+
+        append_ocr_content(&mut result, &payload);
+
+        assert_eq!(result.content.len(), existing_parts + 1);
+        let encoded = serde_json::to_value(result.content.last().expect("OCR content"))
+            .expect("content json");
+        assert_eq!(encoded["text"], "[Page 2 OCR]\nscanned text");
+        assert!(result.structured_content.is_some());
+    }
+
+    #[test]
+    fn malformed_source_is_rejected_instead_of_shifting_source_ordinals() {
+        let error = read_pdf(json!({
+            "sources": [
+                {"path": 42},
+                {"path": "later.pdf"}
+            ],
+            "include_ocr_text_layer": true
+        }))
+        .expect_err("malformed first source must fail validation");
+        assert!(error.message.contains("sources[0]"));
+    }
+
+    #[test]
+    fn empty_selected_page_set_does_not_claim_or_warn_about_provider_execution() {
+        let fixture =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test/fixtures/sample.pdf");
+        let result = read_pdf(json!({
+            "sources": [{"path": fixture, "pages": [999]}],
+            "auto": false,
+            "include_document_map": true,
+            "include_ocr_text_layer": true
+        }))
+        .expect("read with invalid selected page");
+        let structured = result.structured_content.expect("structured result");
+        let data = &structured["results"][0]["data"];
+        assert!(data.get("ocr_text_layer").is_none());
+        assert_eq!(
+            data["document_map"]["routing"]["needs_ocr_pages"],
+            json!([])
+        );
+        assert_eq!(
+            data["document_map"]["routing"]["ocr_applied_pages"],
+            json!([])
+        );
+        assert_eq!(data["document_map"]["summary"]["ocr_page_count"], 0);
+        assert_eq!(data["document_map"]["summary"]["ocr_text_chars"], 0);
+        let warnings = data["warnings"].as_array().expect("warnings");
+        assert!(warnings.iter().any(|warning| warning
+            .as_str()
+            .is_some_and(|warning| warning.contains("exceed document page count"))));
+        assert!(!warnings.iter().any(|warning| warning
+            .as_str()
+            .is_some_and(|warning| warning.contains("provider"))));
+    }
 }

--- a/crates/pdf-reader-mcp-server/src/visual_evidence.rs
+++ b/crates/pdf-reader-mcp-server/src/visual_evidence.rs
@@ -13,7 +13,8 @@ use rmcp::model::{CallToolResult, Content};
 use serde_json::{json, Value};
 
 use crate::schema::{
-    PageSpecifier, PdfEvidenceArgs, PdfEvidenceRegion, PdfEvidenceSource, RegionBoundingBox,
+    PageSpecifier, PdfEvidenceArgs, PdfEvidenceRegion, PdfEvidenceSource, PdfSource,
+    RegionBoundingBox,
 };
 
 const DEFAULT_MAX_FILE_BYTES: u64 = 256 * 1024 * 1024;
@@ -27,29 +28,38 @@ const MAX_REQUEST_REGIONS: usize = 200;
 const MAX_REQUEST_RENDER_PIXELS: u64 = 256_000_000;
 
 #[derive(Default)]
-struct RequestWorkBudget {
-    rendered_pages: usize,
+pub(crate) struct RequestWorkBudget {
+    pub(crate) rendered_pages: usize,
     regions: usize,
-    render_pixels: u64,
+    pub(crate) render_pixels: u64,
+    exhausted: Option<String>,
 }
 
 impl RequestWorkBudget {
-    fn charge_page(&mut self, pixels: u64) -> Result<(), String> {
-        let rendered_pages = self
-            .rendered_pages
-            .checked_add(1)
-            .ok_or_else(|| "Request render page work overflow.".to_string())?;
+    pub(crate) fn ensure_available(&self) -> Result<(), String> {
+        self.exhausted.clone().map_or(Ok(()), Err)
+    }
+
+    pub(crate) fn exhaust(&mut self, message: String) -> Result<(), String> {
+        self.exhausted = Some(message.clone());
+        Err(message)
+    }
+
+    pub(crate) fn charge_page(&mut self, pixels: u64) -> Result<(), String> {
+        self.ensure_available()?;
+        let Some(rendered_pages) = self.rendered_pages.checked_add(1) else {
+            return self.exhaust("Request render page work overflow.".to_string());
+        };
         if rendered_pages > MAX_REQUEST_RENDERED_PAGES {
-            return Err(format!(
+            return self.exhaust(format!(
                 "Request exceeds render work limit of {MAX_REQUEST_RENDERED_PAGES} pages."
             ));
         }
-        let render_pixels = self
-            .render_pixels
-            .checked_add(pixels)
-            .ok_or_else(|| "Request render pixel work overflow.".to_string())?;
+        let Some(render_pixels) = self.render_pixels.checked_add(pixels) else {
+            return self.exhaust("Request render pixel work overflow.".to_string());
+        };
         if render_pixels > MAX_REQUEST_RENDER_PIXELS {
-            return Err(format!(
+            return self.exhaust(format!(
                 "Request exceeds render work limit of {MAX_REQUEST_RENDER_PIXELS} pixels."
             ));
         }
@@ -59,12 +69,12 @@ impl RequestWorkBudget {
     }
 
     fn charge_region(&mut self) -> Result<(), String> {
-        let regions = self
-            .regions
-            .checked_add(1)
-            .ok_or_else(|| "Request region work overflow.".to_string())?;
+        self.ensure_available()?;
+        let Some(regions) = self.regions.checked_add(1) else {
+            return self.exhaust("Request region work overflow.".to_string());
+        };
         if regions > MAX_REQUEST_REGIONS {
-            return Err(format!(
+            return self.exhaust(format!(
                 "Request exceeds crop work limit of {MAX_REQUEST_REGIONS} regions."
             ));
         }
@@ -73,10 +83,53 @@ impl RequestWorkBudget {
     }
 }
 
-struct MaterializedSource {
+pub(crate) struct MaterializedSource {
+    source_index: usize,
     label: String,
     path: PathBuf,
     temporary: bool,
+}
+
+impl MaterializedSource {
+    pub(crate) fn source_index(&self) -> usize {
+        self.source_index
+    }
+
+    pub(crate) fn label(&self) -> &str {
+        &self.label
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct RenderedOcrPage {
+    pub(crate) page: u32,
+    pub(crate) png: Vec<u8>,
+    pub(crate) evidence_id: String,
+    pub(crate) scale: f64,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+}
+
+#[derive(Debug)]
+pub(crate) struct RenderedOcrSource {
+    pub(crate) source_index: usize,
+    pub(crate) source: String,
+    pub(crate) pages: Vec<RenderedOcrPage>,
+    pub(crate) warnings: Vec<String>,
+    pub(crate) error: Option<String>,
+}
+
+pub(crate) struct OcrRenderRequest<'a> {
+    pub(crate) requested_pages: &'a [u32],
+    pub(crate) scale_value: f64,
+    pub(crate) max_pages: usize,
+    pub(crate) max_pixels: u64,
+    pub(crate) request_deadline: std::time::Instant,
+    pub(crate) deadline_error: &'a str,
 }
 
 impl Drop for MaterializedSource {
@@ -131,6 +184,7 @@ fn parse_args(value: Value) -> Result<PdfEvidenceArgs, rmcp::ErrorData> {
 fn materialize(source: &PdfEvidenceSource) -> Result<MaterializedSource, String> {
     if let Some(path) = source.path.as_ref() {
         return Ok(MaterializedSource {
+            source_index: 0,
             label: path.clone(),
             path: PathBuf::from(path),
             temporary: false,
@@ -138,12 +192,133 @@ fn materialize(source: &PdfEvidenceSource) -> Result<MaterializedSource, String>
     }
     if let Some(url) = source.url.as_ref() {
         return fetch_url_to_temp_file(url).map(|path| MaterializedSource {
+            source_index: 0,
             label: url.clone(),
             path,
             temporary: true,
         });
     }
     Err("Provide exactly one of path or url for each PDF source.".into())
+}
+
+/// Resolve each read source exactly once. URL-backed temporary files live until
+/// the returned owner is dropped, allowing extraction and OCR rendering to
+/// share the same bytes without a second fetch.
+pub(crate) fn materialize_read_source(
+    source_index: usize,
+    source: &PdfSource,
+) -> Result<MaterializedSource, String> {
+    if let Some(path) = source.path.as_ref() {
+        return Ok(MaterializedSource {
+            source_index,
+            label: path.clone(),
+            path: PathBuf::from(path),
+            temporary: false,
+        });
+    }
+    if let Some(url) = source.url.as_ref() {
+        return fetch_url_to_temp_file(url).map(|path| MaterializedSource {
+            source_index,
+            label: url.clone(),
+            path,
+            temporary: true,
+        });
+    }
+    Err("Provide exactly one of path or url for each PDF source.".into())
+}
+
+pub(crate) fn render_ocr_source(
+    source: &MaterializedSource,
+    request: OcrRenderRequest<'_>,
+    work_budget: &mut RequestWorkBudget,
+) -> RenderedOcrSource {
+    let output = (|| -> Result<(Vec<RenderedOcrPage>, Vec<String>), String> {
+        work_budget.ensure_available()?;
+        if std::time::Instant::now() >= request.request_deadline {
+            let error = work_budget
+                .exhaust(request.deadline_error.to_string())
+                .expect_err("deadline exhausts render budget");
+            return Err(error);
+        }
+        let document =
+            RenderDocument::new(read_pdf(source.path())?).map_err(|error| error.message)?;
+        let num_pages = document.page_count();
+        if num_pages == 0 {
+            return Err("PDF contains no pages.".into());
+        }
+        let valid = request
+            .requested_pages
+            .iter()
+            .copied()
+            .filter(|page| (*page as usize) <= num_pages)
+            .collect::<Vec<_>>();
+        let invalid = request
+            .requested_pages
+            .iter()
+            .copied()
+            .filter(|page| (*page as usize) > num_pages)
+            .collect::<Vec<_>>();
+        let pages_to_render = &valid[..valid.len().min(request.max_pages)];
+        let truncated = &valid[pages_to_render.len()..];
+        if pages_to_render.is_empty() {
+            return Err(format!(
+                "No valid OCR candidate pages for source {}.",
+                source.label()
+            ));
+        }
+        let warnings = render_warnings(&invalid, truncated, num_pages, request.max_pages);
+        let scale = request.scale_value as f32;
+        let mut pages = Vec::with_capacity(pages_to_render.len());
+        for page in pages_to_render {
+            work_budget.ensure_available()?;
+            if std::time::Instant::now() >= request.request_deadline {
+                let error = work_budget
+                    .exhaust(request.deadline_error.to_string())
+                    .expect_err("deadline exhausts render budget");
+                return Err(error);
+            }
+            let pixels = document
+                .planned_render_pixel_count(*page as usize, scale)
+                .map_err(|error| error.message)?;
+            work_budget.charge_page(pixels)?;
+            let rendered = document
+                .render_page(
+                    *page as usize,
+                    scale,
+                    request.max_pixels,
+                    DEFAULT_MAX_RENDER_OUTPUT_BYTES,
+                )
+                .map_err(|error| error.message)?;
+            pages.push(RenderedOcrPage {
+                page: rendered.page as u32,
+                png: rendered.png,
+                evidence_id: format!(
+                    "page-{}-render-scale-{}",
+                    rendered.page, request.scale_value
+                ),
+                scale: request.scale_value,
+                width: rendered.width,
+                height: rendered.height,
+            });
+        }
+        Ok((pages, warnings))
+    })();
+    match output {
+        Ok((pages, warnings)) => RenderedOcrSource {
+            source_index: source.source_index(),
+            source: source.label().to_string(),
+            pages,
+            warnings,
+            error: None,
+        },
+        Err(error) => RenderedOcrSource {
+            source_index: source.source_index(),
+            source: source.label().to_string(),
+            pages: Vec::new(),
+            warnings: Vec::new(),
+            error: Some(error),
+        },
+    }
 }
 
 fn read_pdf(path: &Path) -> Result<Vec<u8>, String> {
@@ -264,6 +439,7 @@ pub fn render_pages(value: Value) -> Result<CallToolResult, rmcp::ErrorData> {
         let source_label = source.label();
         let image_base_index = images.len();
         let output = (|| -> Result<(Value, Vec<ImagePart>, usize), String> {
+            work_budget.ensure_available()?;
             let mut source_images = Vec::new();
             let mut source_bytes = 0usize;
             let materialized = materialize(source)?;
@@ -457,6 +633,7 @@ pub fn extract_regions(value: Value) -> Result<CallToolResult, rmcp::ErrorData> 
         let source_label = source.label();
         let image_base_index = images.len();
         let output = (|| -> Result<(Value, Vec<ImagePart>, usize), String> {
+            work_budget.ensure_available()?;
             let mut source_images = Vec::new();
             let mut source_bytes = 0usize;
             let materialized = materialize(source)?;
@@ -796,6 +973,10 @@ mod tests {
         }
         assert!(budget.charge_page(1).unwrap_err().contains("pages"));
         assert_eq!(budget.rendered_pages, MAX_REQUEST_RENDERED_PAGES);
+        assert!(budget
+            .ensure_available()
+            .expect_err("page exhaustion is sticky")
+            .contains("pages"));
 
         let mut pixel_budget = RequestWorkBudget::default();
         pixel_budget
@@ -803,6 +984,10 @@ mod tests {
             .expect("pixels at bound");
         assert!(pixel_budget.charge_page(1).unwrap_err().contains("pixels"));
         assert_eq!(pixel_budget.render_pixels, MAX_REQUEST_RENDER_PIXELS);
+        assert!(pixel_budget
+            .ensure_available()
+            .expect_err("pixel exhaustion is sticky")
+            .contains("pixels"));
 
         let mut region_budget = RequestWorkBudget::default();
         for _ in 0..MAX_REQUEST_REGIONS {
@@ -813,6 +998,10 @@ mod tests {
             .unwrap_err()
             .contains("regions"));
         assert_eq!(region_budget.regions, MAX_REQUEST_REGIONS);
+        assert!(region_budget
+            .ensure_available()
+            .expect_err("region exhaustion is sticky")
+            .contains("regions"));
     }
 
     #[test]

--- a/docs/performance/why-rust.md
+++ b/docs/performance/why-rust.md
@@ -38,7 +38,7 @@ their current status is recorded in the
 | Structure | `tables`, `document_map`, `document_ast`, `layout_diagnostics` |
 | Safety / trust | `safety_findings`, `trust_report`, `accessibility_report` |
 | Document signals | `outline`, `annotations`, `form_fields`, `attachments`, `structure_trees`, `page_labels`, `page_geometry`, `permissions` |
-| Provider opt-in | `ocr_text_layer`, `visual_enrichments` (empty + warning without providers — same model as optional TS providers) |
+| Provider opt-in | `ocr_text_layer` has a bounded command-provider fusion subset; without a provider the field is omitted with an explicit warning, matching TS failure semantics. `visual_enrichments` remains a placeholder. |
 | Evidence | `pdf_evidence` `inspect` (routing); visual ops fail closed with guidance when no render/OCR backend is configured |
 
 The following commands exercise only the currently claimed subset. They are
@@ -115,13 +115,17 @@ Artifact: `benchmark-artifacts/pdf_pure_rust_benchmark.json`.
 ## Capability honesty
 
 Pure-Rust text extraction currently uses the selectable text layer. Geometry,
-OCR, visual evidence, and full Document Twin parity remain open work. Empty
+visual evidence, and full Document Twin parity remain open work. Empty
 placeholder arrays prove only response shape; they do not prove capability.
 
 Visual `pdf_evidence` operations now have bounded Hayro render/crop plus opt-in
-command-provider OCR and region-analysis subsets. They remain partial: OCR TSV,
-region-analysis HTTP/presets, broader renderer fixtures, and full Document Twin
-fusion are open. Unavailable paths fail closed; this is not TS 3.0.14 parity.
+command-provider OCR and region-analysis subsets. `read_pdf` can now select OCR
+pages, invoke that bounded command provider, return the normalized parallel OCR
+layer, link applied pages into `document_map`, and emit OCR MCP text parts. The
+immutable detached TS 3.0.14 differential covers this bounded fusion case.
+It remains partial: OCR-derived tables/AST, OCR TSV, region-analysis
+HTTP/presets, broader renderer fixtures, and full Document Twin fusion are
+open. Unavailable paths fail closed; this is not TS 3.0.14 parity.
 
 ## Install
 

--- a/docs/specs/2026-06-15-ocr-provider.md
+++ b/docs/specs/2026-06-15-ocr-provider.md
@@ -108,6 +108,11 @@ Confidence values above 1 are treated as percentages and normalized to 0-1.
 
 ## `read_pdf` Fusion
 
+> Pure-Rust migration status (2026-07-18): command-provider text-layer and
+> document-map linkage are implemented and differentially fenced. OCR-derived
+> table/document-AST fusion and `tesseract-tsv` remain open; the published
+> TypeScript 3.0.14 behavior described below remains the parity authority.
+
 `read_pdf` accepts:
 
 ```json

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -46,7 +46,7 @@
       "include_page_geometry": "STUB",
       "include_permissions": "STUB",
       "include_images": "STUB",
-      "include_ocr_text_layer": "STUB",
+      "include_ocr_text_layer": "PARTIAL",
       "include_visual_enrichments": "STUB",
       "auto_policy": "PARTIAL",
       "bounding_boxes": "MISSING"
@@ -72,15 +72,15 @@
   },
   "claimedForDifferential": [
     "exact 10-case immutable TS v3.0.14 behavior subset: full text, page selection/order/duplicates, metadata, literal search, case sensitivity, whole word, Unicode, UTF-16 offsets, missing and malformed inputs, and mixed-source partial success",
-    "exact 14-case immutable TS v3.0.14 render/crop/command-provider semantic subset over stdio: defaults, page selection and warnings, region ordering, padding and fractional bounds, rotated pages, mixed-source and late-provider partial success, all-source failure, MCP image indexing, OCR normalization, rich region-analysis normalization, plain-text truncation, and truthful provenance; exact pdf.js pixels and antialiasing are not claimed",
+    "exact 15-case immutable TS v3.0.14 render/crop/command-provider semantic subset over stdio: defaults, page selection and warnings, region ordering, padding and fractional bounds, rotated pages, mixed-source and late-provider partial success, all-source failure, MCP image indexing, standalone OCR normalization, read_pdf OCR text-layer/map fusion, rich region-analysis normalization, plain-text truncation, and truthful provenance; exact pdf.js pixels and antialiasing are not claimed",
     "DNS-pinned URL fetch: one resolution per redirect hop, reject mixed public/non-public answers, disable ambient proxies, and revalidate every redirect; still PARTIAL because resolver timeout and TLS-SNI fixtures remain open",
     "auto off when include_* keys are present"
   ],
   "explicitlyNotClaimed": [
     "complete TS 3.0.14 semantic parity outside the immutable 10-case subset",
     "text/search geometry, geometry-perfect pdf.js boxes, and general bounding-box parity",
-    "render/crop/OCR/analyze semantic parity outside the immutable 14-case subset, including exact pdf.js pixels and antialiasing",
-    "OCR success paths outside the opt-in command JSON/plain-text subset, including tesseract-tsv; analyze_regions HTTP and preset providers",
+    "render/crop/OCR/analyze/read-fusion semantic parity outside the immutable 15-case subset, including exact pdf.js pixels and antialiasing",
+    "OCR success paths outside the opt-in command JSON/plain-text subset, including tesseract-tsv; OCR-derived table/document_ast fusion; analyze_regions HTTP and preset providers",
     "COS outline/annotations/forms",
     "cross-platform npm native binary",
     "npm library exports for pure-Rust",

--- a/scripts/differential/check-v3014-visual-differential.ts
+++ b/scripts/differential/check-v3014-visual-differential.ts
@@ -24,7 +24,7 @@ const outputFlag = process.argv.indexOf('--output');
 const outputPath = outputFlag >= 0 ? process.argv[outputFlag + 1] : undefined;
 
 const corpus = JSON.parse(readFileSync(corpusPath, 'utf8')) as {
-  cases: Array<{ id: string; input: Record<string, unknown> }>;
+  cases: Array<{ id: string; tool?: 'read_pdf'; input: Record<string, unknown> }>;
 };
 const oracle = JSON.parse(readFileSync(oraclePath, 'utf8')) as {
   baseline: {
@@ -70,8 +70,8 @@ function verifyAuthority(): Record<string, string> {
     }
   }
   const ids = corpus.cases.map((entry) => entry.id);
-  if (ids.length !== 14 || new Set(ids).size !== ids.length) {
-    throw new Error(`visual/OCR/analysis corpus must contain 14 unique cases (got ${ids.length})`);
+  if (ids.length !== 15 || new Set(ids).size !== ids.length) {
+    throw new Error(`visual/OCR/analysis corpus must contain 15 unique cases (got ${ids.length})`);
   }
   if (sha256(readFileSync(providerPath)) !== oracle.providerSha256) {
     throw new Error('reference OCR provider digest mismatch');
@@ -154,7 +154,7 @@ function imageFacts(content: Content): Record<string, Json> {
   } as Record<string, Json>;
 }
 
-function canonicalize(result: ToolResult): Json {
+function canonicalize(result: ToolResult, tool?: 'read_pdf'): Json {
   if (result.isError) {
     return {
       outcome: 'error',
@@ -162,6 +162,49 @@ function canonicalize(result: ToolResult): Json {
     };
   }
   const payload = JSON.parse(result.content[0]?.text ?? '{}') as Record<string, unknown>;
+  if (tool === 'read_pdf') {
+    const readResults = ((payload.results ?? []) as Array<Record<string, unknown>>).map((source) => {
+      if (!source.success) {
+        return {
+          source: basename(String(source.source ?? '')),
+          success: false,
+          category: errorCategory(String(source.error ?? '')),
+        };
+      }
+      const data = (source.data ?? {}) as Record<string, unknown>;
+      const layer = data.ocr_text_layer as Record<string, unknown> | undefined;
+      const map = data.document_map as Record<string, unknown> | undefined;
+      return {
+        source: basename(String(source.source ?? '')),
+        success: true,
+        ocr_text_layer: layer
+          ? {
+              profile: layer.profile,
+              pages: layer.pages,
+              summary: layer.summary,
+              warnings: layer.warnings ?? [],
+            }
+          : null,
+        document_map: map
+          ? {
+              has_ocr_layer:
+                Array.isArray(map.layers) && map.layers.includes('ocr_text_layer'),
+              needs_ocr_pages: (map.routing as Record<string, unknown>)?.needs_ocr_pages,
+              ocr_applied_pages: (map.routing as Record<string, unknown>)?.ocr_applied_pages,
+              ocr_page_count: (map.summary as Record<string, unknown>)?.ocr_page_count,
+              ocr_text_chars: (map.summary as Record<string, unknown>)?.ocr_text_chars,
+            }
+          : null,
+      };
+    });
+    return {
+      outcome: 'success',
+      content_ocr: result.content
+        .filter((content) => content.type === 'text' && content.text?.startsWith('[Page '))
+        .map((content) => content.text ?? null) as Json,
+      results: readResults as Json,
+    };
+  }
   const images = result.content.filter((content) => content.type === 'image').map(imageFacts);
   const results = ((payload.results ?? []) as Array<Record<string, unknown>>).map((source) => {
     if (!source.success) {
@@ -379,11 +422,11 @@ async function main() {
     const failures: Array<{ id: string; expected: Json; actual: Json }> = [];
     for (const [index, entry] of corpus.cases.entries()) {
       const response = await request(index + 10, 'tools/call', {
-        name: 'pdf_evidence',
+        name: entry.tool ?? 'pdf_evidence',
         arguments: materialize(entry.input),
       });
       if (response.error) throw new Error(`Rust MCP error for ${entry.id}: ${JSON.stringify(response.error)}`);
-      const actual = stable(canonicalize(response.result as ToolResult));
+      const actual = stable(canonicalize(response.result as ToolResult, entry.tool));
       const expected = stable(oracle.expectations[entry.id]!);
       observations[entry.id] = actual;
       if (JSON.stringify(actual) !== JSON.stringify(expected)) {

--- a/scripts/differential/fixtures/v3014-visual-corpus.json
+++ b/scripts/differential/fixtures/v3014-visual-corpus.json
@@ -140,6 +140,16 @@
       }
     },
     {
+      "id": "read-ocr-command-fusion",
+      "tool": "read_pdf",
+      "input": {
+        "sources": [{ "fixture": "v3014-visual-v1.pdf", "pages": [1] }],
+        "auto": false,
+        "include_document_map": true,
+        "include_ocr_text_layer": true
+      }
+    },
+    {
       "id": "analyze-command-rich-normalization",
       "input": {
         "operation": "analyze_regions",

--- a/scripts/differential/fixtures/v3014-visual-oracle.json
+++ b/scripts/differential/fixtures/v3014-visual-oracle.json
@@ -14,6 +14,8 @@
       "src/handlers/extractRegions.ts": "a125e4fa3b9c3aee1087f7e60a5092ce2354d918d2b1d01bc70f222d42219c33",
       "src/handlers/ocrPages.ts": "3ecca45d73471c422b225bba1a2bfee704d316826bf9f509ccf8d860f2ea6ac4",
       "src/handlers/analyzeRegions.ts": "b84d5e9741ff8a6ea0ac37ee3b764ec94f08229662b51d0552f6ebddf3723dc8",
+      "src/handlers/readPdf.ts": "1e7488cba29dc66ef8b6a86322d871ac3a3e5bf01981e9ab98a47ec4b0b1d5c4",
+      "src/pdf/readCoordinator.ts": "827cb1018a8621287de154132c0a00a00188497b84622a168a343d0df3ce5eca",
       "src/pdf/ocr.ts": "9c2f89afb8426fea801501f7a2264a90e536609c7f5d64e7257945d4038041ee",
       "src/pdf/regionAnalysis.ts": "26ffb87a2af378665fdb59b9b9c8f6b9060b1015083da8c898479157bd1d80ef",
       "src/pdf/renderer.ts": "29cf9917feaa470d3e3dafea5b432439fe0450eaee90b350458fb1e41bfe75a8",
@@ -713,6 +715,69 @@
               }
             }
           ]
+        }
+      ]
+    },
+    "read-ocr-command-fusion": {
+      "outcome": "success",
+      "content_ocr": [
+        "[Page 1 OCR]\nReference OCR page 1 at 240x160"
+      ],
+      "results": [
+        {
+          "source": "v3014-visual-v1.pdf",
+          "success": true,
+          "ocr_text_layer": {
+            "profile": "ocr_text_layer",
+            "pages": [
+              {
+                "page": 1,
+                "text": "Reference OCR page 1 at 240x160",
+                "confidence": 0.87,
+                "words": [
+                  {
+                    "text": "Reference",
+                    "confidence": 0.91,
+                    "bounding_box": {
+                      "left": 10,
+                      "bottom": 5,
+                      "right": 50,
+                      "top": 15
+                    }
+                  }
+                ],
+                "provider": "command",
+                "source_render_evidence_id": "page-1-render-scale-2",
+                "source_render_scale": 2,
+                "source_render_width": 240,
+                "source_render_height": 160,
+                "provenance": {
+                  "engine": "external-command",
+                  "source": "ocr-provider"
+                }
+              }
+            ],
+            "summary": {
+              "page_count": 1,
+              "text_chars": 31,
+              "word_count": 1,
+              "words_with_bounding_boxes": 1,
+              "source_render_count": 1,
+              "average_confidence": 0.87
+            },
+            "warnings": []
+          },
+          "document_map": {
+            "has_ocr_layer": true,
+            "needs_ocr_pages": [
+              1
+            ],
+            "ocr_applied_pages": [
+              1
+            ],
+            "ocr_page_count": 1,
+            "ocr_text_chars": 31
+          }
         }
       ]
     },

--- a/scripts/differential/v3014-visual-baseline-runner.ts
+++ b/scripts/differential/v3014-visual-baseline-runner.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { PNG } from 'pngjs';
 import { pdfEvidence } from './src/handlers/pdfEvidence.ts';
+import { readPdf } from './src/handlers/readPdf.ts';
 
 type Content = { type: string; text?: string; data?: string; mimeType?: string };
 type ToolResult = { content: Content[]; isError?: boolean };
@@ -29,7 +30,7 @@ process.env['MCP_PDF_REGION_ANALYSIS_ARGS_JSON'] = JSON.stringify([
   '{languages}',
 ]);
 const corpus = JSON.parse(readFileSync(corpusPath, 'utf8')) as {
-  cases: Array<{ id: string; input: Record<string, unknown> }>;
+  cases: Array<{ id: string; tool?: 'read_pdf'; input: Record<string, unknown> }>;
 };
 
 function materialize(value: unknown): unknown {
@@ -83,12 +84,55 @@ function imageFacts(content: Content): Record<string, unknown> {
   };
 }
 
-function canonicalize(result: ToolResult): Record<string, unknown> {
+function canonicalize(result: ToolResult, tool?: 'read_pdf'): Record<string, unknown> {
   if (result.isError) {
     const message = result.content[0]?.text ?? '';
     return { outcome: 'error', category: errorCategory(message) };
   }
   const payload = JSON.parse(result.content[0]?.text ?? '{}') as Record<string, unknown>;
+  if (tool === 'read_pdf') {
+    const readResults = ((payload.results ?? []) as Array<Record<string, unknown>>).map((source) => {
+      if (!source.success) {
+        return {
+          source: basename(String(source.source ?? '')),
+          success: false,
+          category: errorCategory(String(source.error ?? '')),
+        };
+      }
+      const data = (source.data ?? {}) as Record<string, unknown>;
+      const layer = data.ocr_text_layer as Record<string, unknown> | undefined;
+      const map = data.document_map as Record<string, unknown> | undefined;
+      return {
+        source: basename(String(source.source ?? '')),
+        success: true,
+        ocr_text_layer: layer
+          ? {
+              profile: layer.profile,
+              pages: layer.pages,
+              summary: layer.summary,
+              warnings: layer.warnings ?? [],
+            }
+          : null,
+        document_map: map
+          ? {
+              has_ocr_layer:
+                Array.isArray(map.layers) && map.layers.includes('ocr_text_layer'),
+              needs_ocr_pages: (map.routing as Record<string, unknown>)?.needs_ocr_pages,
+              ocr_applied_pages: (map.routing as Record<string, unknown>)?.ocr_applied_pages,
+              ocr_page_count: (map.summary as Record<string, unknown>)?.ocr_page_count,
+              ocr_text_chars: (map.summary as Record<string, unknown>)?.ocr_text_chars,
+            }
+          : null,
+      };
+    });
+    return {
+      outcome: 'success',
+      content_ocr: result.content
+        .filter((content) => content.type === 'text' && content.text?.startsWith('[Page '))
+        .map((content) => content.text),
+      results: readResults,
+    };
+  }
   const imageBlocks = result.content.filter((content) => content.type === 'image');
   const images = imageBlocks.map(imageFacts);
   const results = ((payload.results ?? []) as Array<Record<string, unknown>>).map((source) => {
@@ -215,7 +259,10 @@ function canonicalize(result: ToolResult): Record<string, unknown> {
 const observations: Record<string, unknown> = {};
 for (const entry of corpus.cases) {
   const input = materialize(entry.input) as never;
-  const raw = await pdfEvidence.handler({ input, ctx: {} });
-  observations[entry.id] = canonicalize(normalizeResult(raw));
+  const raw =
+    entry.tool === 'read_pdf'
+      ? await readPdf.handler({ input, ctx: {} })
+      : await pdfEvidence.handler({ input, ctx: {} });
+  observations[entry.id] = canonicalize(normalizeResult(raw), entry.tool);
 }
 console.log(JSON.stringify(observations));

--- a/scripts/run-pdf-reader-differential.sh
+++ b/scripts/run-pdf-reader-differential.sh
@@ -77,7 +77,7 @@ echo "--- deterministic v3.0.14 visual fixture + baseline replay ---" | tee -a "
 bun "$REPO_ROOT/scripts/differential/generate-v3014-visual-fixtures.ts" 2>&1 | tee -a "$LOG"
 bun "$REPO_ROOT/scripts/differential/capture-v3014-visual-oracle.ts" 2>&1 | tee -a "$LOG"
 
-echo "--- immutable v3.0.14 render/crop/OCR/analyze differential (14 semantic cases) ---" | tee -a "$LOG"
+echo "--- immutable v3.0.14 render/crop/OCR/analyze/read-fusion differential (15 semantic cases) ---" | tee -a "$LOG"
 bun "$REPO_ROOT/scripts/differential/check-v3014-visual-differential.ts" \
   --output "$V3014_VISUAL_JSON" >>"$LOG"
 
@@ -191,7 +191,7 @@ jq -n \
     immutableVisualDifferential: "scripts/differential/check-v3014-visual-differential.ts",
     liveTextOracle: "scripts/differential/ts-vs-rust-text-oracle.ts",
     structuralConsistencyOracle: "scripts/differential/pdf-reader-mcp-oracle.ts",
-    nonClaims: ["full TS 3.0.14 behavioral parity", "visual/provider parity outside the immutable 14-case render/crop/OCR/analyze corpus", "Tesseract TSV parity", "analyze_regions HTTP/preset provider parity", "Document Twin semantic parity"],
+    nonClaims: ["full TS 3.0.14 behavioral parity", "visual/provider parity outside the immutable 15-case render/crop/OCR/analyze/read-fusion corpus", "Tesseract TSV parity", "OCR-derived table/document_ast fusion", "analyze_regions HTTP/preset provider parity", "Document Twin semantic parity"],
     retirementGate: "scripts/check-no-ts-stdio-backend.sh (runs only when dropInFor3014=true)"
   }' >"$ARTIFACT"
 

--- a/test/integration/http-transport.test.ts
+++ b/test/integration/http-transport.test.ts
@@ -326,6 +326,56 @@ describe('MCP Server HTTP Transport Integration (Rust rmcp)', () => {
     });
   });
 
+  it('should fuse command-provider OCR into read_pdf over HTTP', async () => {
+    const client = createMcpHttpClient();
+    await client.initializeSession();
+    const fixture = path.resolve(__dirname, '../fixtures/differential/v3014-visual-v1.pdf');
+    const response = await client.sendRequest(
+      'tools/call',
+      {
+        name: 'read_pdf',
+        arguments: {
+          sources: [{ path: fixture, pages: [1] }],
+          auto: false,
+          include_document_map: true,
+          include_ocr_text_layer: true,
+        },
+      },
+      51
+    );
+    expect(response.error).toBeUndefined();
+    const result = response.result as {
+      isError?: boolean;
+      content?: Array<{ type?: string; text?: string }>;
+      structuredContent?: {
+        evidence?: { confidence?: string };
+        results?: Array<{
+          success?: boolean;
+          data?: {
+            ocr_text_layer?: { profile?: string; pages?: Array<Record<string, unknown>> };
+            document_map?: { layers?: string[]; routing?: Record<string, unknown> };
+          };
+        }>;
+      };
+    };
+    expect(result.isError).not.toBe(true);
+    const data = result.structuredContent?.results?.[0]?.data;
+    expect(data?.ocr_text_layer).toMatchObject({
+      profile: 'ocr_text_layer',
+      pages: [
+        {
+          page: 1,
+          text: 'Reference OCR page 1 at 240x160',
+          provider: 'command',
+        },
+      ],
+    });
+    expect(data?.document_map?.layers).toContain('ocr_text_layer');
+    expect(data?.document_map?.routing).toMatchObject({ ocr_applied_pages: [1] });
+    expect(result.structuredContent?.evidence?.confidence).toBe('provider-dependent');
+    expect(result.content?.at(-1)?.text).toBe('[Page 1 OCR]\nReference OCR page 1 at 240x160');
+  });
+
   it('should return normalized command-provider region analysis over HTTP', async () => {
     const client = createMcpHttpClient();
     await client.initializeSession();

--- a/test/integration/mcp-ocr-provider.test.ts
+++ b/test/integration/mcp-ocr-provider.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import type { ChildProcess } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import {
@@ -20,8 +20,12 @@ describe('pure-Rust command OCR provider integration', () => {
   let failingProc: ChildProcess;
   let timeoutProc: ChildProcess;
   let descendantProc: ChildProcess;
+  let ordinalProc: ChildProcess;
   const descendantWorkspace = mkdtempSync(path.join(tmpdir(), 'pdf-reader-ocr-descendant-'));
   const descendantMarker = path.join(descendantWorkspace, 'input-path.txt');
+  const ordinalWorkspace = mkdtempSync(path.join(tmpdir(), 'pdf-reader-ocr-ordinal-'));
+  const ordinalProvider = path.join(ordinalWorkspace, 'fail-first-provider.mjs');
+  const ordinalMarker = path.join(ordinalWorkspace, 'invocations.txt');
 
   beforeAll(async () => {
     ensureProductionArtifacts('pure-rust');
@@ -65,6 +69,23 @@ describe('pure-Rust command OCR provider integration', () => {
       ]),
     });
     await initializeSession(descendantProc, 'rust-ocr-provider-descendant-contract');
+
+    writeFileSync(
+      ordinalProvider,
+      `import fs from 'node:fs';
+const [, page = '0', marker] = process.argv.slice(2);
+const previous = fs.existsSync(marker) ? Number(fs.readFileSync(marker, 'utf8')) : 0;
+fs.writeFileSync(marker, String(previous + 1));
+if (previous === 0) process.exit(7);
+process.stdout.write(JSON.stringify({ text: 'Ordinal OCR page ' + page, confidence: 0.9, words: [] }));
+`
+    );
+    ordinalProc = spawnProductionMcp({
+      PDF_READER_ENGINE_MODE: 'pure-rust',
+      MCP_PDF_OCR_COMMAND: process.execPath,
+      MCP_PDF_OCR_ARGS_JSON: JSON.stringify([ordinalProvider, '{input}', '{page}', ordinalMarker]),
+    });
+    await initializeSession(ordinalProc, 'rust-ocr-provider-ordinal-contract');
   }, 420_000);
 
   afterAll(() => {
@@ -72,7 +93,9 @@ describe('pure-Rust command OCR provider integration', () => {
     failingProc?.kill('SIGTERM');
     timeoutProc?.kill('SIGTERM');
     descendantProc?.kill('SIGTERM');
+    ordinalProc?.kill('SIGTERM');
     rmSync(descendantWorkspace, { recursive: true, force: true });
+    rmSync(ordinalWorkspace, { recursive: true, force: true });
   });
 
   test('renders a bounded page and returns normalized OCR provenance', async () => {
@@ -126,6 +149,162 @@ describe('pure-Rust command OCR provider integration', () => {
         },
       ],
     });
+  }, 120_000);
+
+  test('fuses command OCR into read_pdf without mutating selectable text surfaces', async () => {
+    const response = await callTool(
+      proc,
+      45,
+      'read_pdf',
+      {
+        sources: [{ path: fixture, pages: [1] }],
+        auto: false,
+        include_full_text: true,
+        include_document_map: true,
+        include_ocr_text_layer: true,
+      },
+      90_000
+    );
+    const payload = parseToolPayload(response);
+    expect(payload.isError).toBe(false);
+    const structured = response.result?.structuredContent as
+      | {
+          evidence?: { confidence?: string };
+          results?: Array<{
+            success?: boolean;
+            data?: {
+              full_text?: string;
+              page_texts?: Array<{ page?: number; text?: string }>;
+              ocr_text_layer?: {
+                profile?: string;
+                pages?: Array<Record<string, unknown>>;
+                summary?: Record<string, unknown>;
+              };
+              document_map?: {
+                layers?: string[];
+                routing?: { needs_ocr_pages?: number[]; ocr_applied_pages?: number[] };
+              };
+            };
+          }>;
+        }
+      | undefined;
+    const data = structured?.results?.[0]?.data;
+    expect(structured?.results?.[0]?.success).toBe(true);
+    expect(data?.full_text).toBeUndefined();
+    expect(data?.page_texts?.[0]?.page).toBe(1);
+    expect(JSON.stringify(data?.page_texts)).not.toContain('Reference OCR page');
+    expect(data?.ocr_text_layer).toMatchObject({
+      profile: 'ocr_text_layer',
+      pages: [
+        {
+          page: 1,
+          text: 'Reference OCR page 1 at 240x160',
+          confidence: 0.87,
+          provider: 'command',
+          source_render_evidence_id: 'page-1-render-scale-2',
+          provenance: { engine: 'external-command', source: 'ocr-provider' },
+        },
+      ],
+      summary: {
+        page_count: 1,
+        text_chars: 31,
+        word_count: 1,
+        words_with_bounding_boxes: 1,
+        source_render_count: 1,
+        average_confidence: 0.87,
+      },
+    });
+    expect(data?.document_map?.layers).toContain('ocr_text_layer');
+    expect(data?.document_map?.routing).toMatchObject({
+      needs_ocr_pages: [1],
+      ocr_applied_pages: [1],
+    });
+    expect(structured?.evidence?.confidence).toBe('provider-dependent');
+    expect(response.result?.content?.at(-1)?.text).toBe(
+      '[Page 1 OCR]\nReference OCR page 1 at 240x160'
+    );
+  }, 120_000);
+
+  test('keeps read_pdf source successful and omits the layer when OCR fails', async () => {
+    const response = await callTool(
+      failingProc,
+      46,
+      'read_pdf',
+      {
+        sources: [{ path: fixture, pages: [1] }],
+        auto: false,
+        include_full_text: true,
+        include_ocr_text_layer: true,
+      },
+      30_000
+    );
+    const payload = parseToolPayload(response);
+    expect(payload.isError).toBe(false);
+    const structured = response.result?.structuredContent as {
+      results?: Array<{
+        success?: boolean;
+        data?: { ocr_text_layer?: unknown; warnings?: string[] };
+      }>;
+    };
+    const result = structured.results?.[0];
+    expect(result?.success).toBe(true);
+    expect(result?.data?.ocr_text_layer).toBeUndefined();
+    expect(result?.data?.warnings).toContain(
+      'OCR text layer unavailable: OCR provider command failed for page 1.'
+    );
+    expect(response.result?.content?.some((part) => part.text?.startsWith('[Page 1 OCR]'))).toBe(
+      false
+    );
+  }, 30_000);
+
+  test('keeps duplicate source labels aligned when early OCR fails and later OCR succeeds', async () => {
+    const response = await callTool(
+      ordinalProc,
+      47,
+      'read_pdf',
+      {
+        sources: [
+          { path: fixture, pages: [1] },
+          { path: fixture, pages: [1] },
+        ],
+        auto: false,
+        include_document_map: true,
+        include_ocr_text_layer: true,
+      },
+      90_000
+    );
+    const payload = parseToolPayload(response);
+    expect(payload.isError).toBe(false);
+    const structured = response.result?.structuredContent as {
+      results?: Array<{
+        source?: string;
+        success?: boolean;
+        data?: {
+          ocr_text_layer?: { pages?: Array<{ text?: string }> };
+          document_map?: { routing?: Record<string, unknown> };
+          warnings?: string[];
+        };
+      }>;
+    };
+    const results = structured.results ?? [];
+    expect(results).toHaveLength(2);
+    expect(results[0]?.source).toBe(results[1]?.source);
+    expect(results[0]?.success).toBe(true);
+    expect(results[0]?.data?.ocr_text_layer).toBeUndefined();
+    expect(results[0]?.data?.warnings).toContain(
+      'OCR text layer unavailable: OCR provider command failed for page 1.'
+    );
+    expect(results[0]?.data?.document_map?.routing).toMatchObject({
+      needs_ocr_pages: [1],
+      ocr_applied_pages: [],
+    });
+    expect(results[1]?.success).toBe(true);
+    expect(results[1]?.data?.ocr_text_layer?.pages?.[0]?.text).toBe('Ordinal OCR page 1');
+    expect(results[1]?.data?.document_map?.routing).toMatchObject({
+      needs_ocr_pages: [1],
+      ocr_applied_pages: [1],
+    });
+    expect(readFileSync(ordinalMarker, 'utf8')).toBe('2');
   }, 120_000);
 
   test('fails closed when the provider exits unsuccessfully', async () => {

--- a/test/production/capabilityParity.contract.test.ts
+++ b/test/production/capabilityParity.contract.test.ts
@@ -43,7 +43,6 @@ const READ_PDF_REQUIRED_FIELDS: Record<string, string[]> = {
   attachments: ['attachments'],
   structure: ['structure_trees'],
   images: ['images'],
-  ocr: ['ocr_text_layer'],
   visual: ['visual_enrichments'],
 };
 
@@ -111,7 +110,12 @@ describe.skipIf(!pureRustEnabled)('experimental pure-Rust capability contract', 
   beforeAll(async () => {
     process.env.PDF_READER_ENGINE_MODE = 'pure-rust';
     ensureProductionArtifacts();
-    proc = spawnProductionMcp({ PDF_READER_ENGINE_MODE: 'pure-rust' });
+    proc = spawnProductionMcp({
+      PDF_READER_ENGINE_MODE: 'pure-rust',
+      MCP_PDF_OCR_COMMAND: '',
+      MCP_PDF_OCR_ARGS_JSON: '',
+      MCP_PDF_OCR_PRESET: '',
+    });
     await initializeSession(proc, 'capability-parity-contract');
   }, 420_000);
 
@@ -181,6 +185,33 @@ describe.skipIf(!pureRustEnabled)('experimental pure-Rust capability contract', 
     }
     expect(missing).toEqual([]);
     expect(deepHasKey(parsed, 'full_text')).toBe(false);
+  }, 120_000);
+
+  test('provider-backed OCR is omitted with an explicit warning when no provider is configured', async () => {
+    const response = await callTool(
+      proc,
+      nextId(),
+      'read_pdf',
+      {
+        sources: [{ path: samplePdf, pages: [1] }],
+        auto: false,
+        include_ocr_text_layer: true,
+      },
+      90_000
+    );
+    const payload = parseToolPayload(response);
+    expect(payload.isError).toBe(false);
+    const parsed = JSON.parse(payload.text) as {
+      results?: Array<{
+        success?: boolean;
+        data?: { ocr_text_layer?: unknown; warnings?: string[] };
+      }>;
+    };
+    expect(parsed.results?.[0]?.success).toBe(true);
+    expect(parsed.results?.[0]?.data?.ocr_text_layer).toBeUndefined();
+    expect(parsed.results?.[0]?.data?.warnings).toContain(
+      'OCR text layer unavailable: OCR provider is not configured. Set MCP_PDF_OCR_COMMAND or MCP_PDF_OCR_PRESET=tesseract to enable ocr_pages.'
+    );
   }, 120_000);
 
   test('search_pdf public options remain available', async () => {


### PR DESCRIPTION
## Outcome

Adds bounded command-provider OCR fusion to the pure-Rust read_pdf path without claiming TS 3.0.14 drop-in parity or unfreezing publication.

## Contract

- preserves source ordinals and selectable text
- materializes each source once and reuses it for extraction and rendering
- appends OCR content and typed ocr_text_layer on provider success
- keeps source success and omits the layer on provider failure
- maintains honest document_map routing, including zero-candidate requests
- enforces request-wide source, render, pixel, provider-output, timeout, and concurrency budgets before effects
- keeps OCR-derived tables/document_ast and TSV parity explicitly open

## Evidence

- immutable TS v3.0.14 oracle: 92651c79c6ce8d10dfa3c76332176c26f222bd78
- candidate: c89aa19fc63e9e769d60559b42396e2c9ee006ac
- visual/provider/read-fusion differential: 15/15 passed, 0 skipped
- Rust differential: 25 cases green
- core unit tests: 58 passed
- server unit tests: 30 passed
- fmt, clippy -D warnings, and diff-check green
- independent adversarial review: PASS, confidence 0.99

## Non-claims

- dropInFor3014 remains false
- publishFreeze remains true
- no claim of OCR-derived table/document_ast fusion, Tesseract TSV parity, broad Document Twin parity, cross-platform npm packaging, or industry-grade A/B benchmark

Release must remain blocked at the explicit publish-freeze gate.