### PR TITLE
feat(rust): project boxed OCR tables

### DIFF
--- a/.github/workflows/rust-parity-differential.yml
+++ b/.github/workflows/rust-parity-differential.yml
@@ -147,7 +147,7 @@ jobs:
           jq -e --arg sha "$CANDIDATE_SHA" '
             .profile == "pdf_reader_v3014_visual_result" and
             .candidateSha == $sha and .pass == true and
-            .caseCount == 15 and .passed == 15 and .skipped == 0
+            .caseCount == 16 and .passed == 16 and .skipped == 0
           ' "$VISUAL_ARTIFACT" >/dev/null || {
             echo "::error::v3.0.14 visual result is incomplete, failing, or not SHA-bound"
             exit 1

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Pure-Rust is a **work in progress**, not the published product.
 | Full Document Twin (geometry, outline, COS structure) | **Not yet** |
 | Evidence `render_page` / `extract_regions` | Partial: bounded Hayro PNG render/crop in the source experiment |
 | Evidence OCR / analyze | Partial: bounded opt-in command adapters; OCR TSV and analyze HTTP/presets are not yet available |
-| `read_pdf` OCR fusion | Partial: command-provider OCR layer, map linkage, and MCP text parts; OCR-derived tables/AST and TSV remain open |
+| `read_pdf` OCR fusion | Partial: command-provider OCR layer plus boxed-word table projection into elements/chunks/Markdown/HTML/AST/map; TSV, mixed-table continuation, and broad Twin parity remain open |
 | Cross-platform npm binary | **Not yet** |
 | Drop-in for 3.0.14 | **No** |
 

--- a/crates/pdf-reader-core/src/document_twin.rs
+++ b/crates/pdf-reader-core/src/document_twin.rs
@@ -128,6 +128,83 @@ pub fn build_elements(pages: &[PageText], semantic_hints: bool) -> Value {
     json!(elements)
 }
 
+/// Build selectable-text elements and append table elements after the ordinary
+/// elements for each page, matching the v3.0.14 structured projection order.
+pub fn build_elements_with_tables(
+    pages: &[PageText],
+    tables: &Value,
+    semantic_hints: bool,
+) -> Value {
+    let base = build_elements(pages, semantic_hints);
+    let mut base_by_page = std::collections::BTreeMap::<u32, Vec<Value>>::new();
+    for element in base.as_array().into_iter().flatten() {
+        let page = element.get("page").and_then(Value::as_u64).unwrap_or(0) as u32;
+        base_by_page.entry(page).or_default().push(element.clone());
+    }
+
+    let mut tables_by_page = std::collections::BTreeMap::<u32, Vec<Value>>::new();
+    for table in tables.as_array().into_iter().flatten() {
+        let page = table.get("page").and_then(Value::as_u64).unwrap_or(0) as u32;
+        tables_by_page.entry(page).or_default().push(table.clone());
+    }
+    for page_tables in tables_by_page.values_mut() {
+        page_tables
+            .sort_by_key(|table| table.get("tableIndex").and_then(Value::as_u64).unwrap_or(0));
+    }
+
+    let mut elements = Vec::new();
+    for page in pages {
+        elements.extend(base_by_page.remove(&page.page).unwrap_or_default());
+        for table in tables_by_page.remove(&page.page).unwrap_or_default() {
+            let table_index = table.get("tableIndex").and_then(Value::as_u64).unwrap_or(0);
+            let ocr = table.pointer("/provenance/source").and_then(Value::as_str)
+                == Some("ocr_text_layer");
+            let mut provenance = if ocr {
+                json!({"engine":"external-command","source":"ocr-table-detector"})
+            } else {
+                json!({"engine":"pdf-reader-core","source":"table-detector"})
+            };
+            if ocr {
+                if let Some(evidence_id) = table
+                    .pointer("/provenance/ocr_source_render_evidence_id")
+                    .cloned()
+                {
+                    provenance["ocr_source_render_evidence_id"] = evidence_id;
+                }
+            }
+            let confidence = table.get("confidence").cloned().unwrap_or(Value::Null);
+            let bounding_box = table.get("bounding_box").cloned();
+            let mut element = json!({
+                "id": format!("p{}-table-{}", page.page, table_index + 1),
+                "type": "table",
+                "page": page.page,
+                "table": table,
+                "confidence": confidence,
+                "provenance": provenance,
+            });
+            if let Some(box_) = bounding_box {
+                element["bounding_box"] = box_;
+            }
+            elements.push(element);
+        }
+    }
+    for (_, remaining) in base_by_page {
+        elements.extend(remaining);
+    }
+    for (page, remaining) in tables_by_page {
+        for table in remaining {
+            let table_index = table.get("tableIndex").and_then(Value::as_u64).unwrap_or(0);
+            elements.push(json!({
+                "id": format!("p{page}-table-{}", table_index + 1),
+                "type":"table",
+                "page":page,
+                "table":table,
+            }));
+        }
+    }
+    json!(elements)
+}
+
 pub fn build_tables(pages: &[PageText]) -> Value {
     let mut tables = Vec::new();
     for page in pages {
@@ -587,6 +664,39 @@ pub fn build_document_ast(pages: &[PageText], elements: &Value, tables: &Value) 
             }
             page_children.push(node);
         }
+        for table in
+            tables.as_array().into_iter().flatten().filter(|table| {
+                table.get("page").and_then(Value::as_u64) == Some(u64::from(page_no))
+            })
+        {
+            let table_index = table.get("tableIndex").and_then(Value::as_u64).unwrap_or(0);
+            let mut table_payload = json!({
+                "rows": table.get("rows"),
+                "rowCount": table.get("rowCount"),
+                "colCount": table.get("colCount"),
+                "confidence": table.get("confidence"),
+            });
+            for key in ["quality", "continuation", "provenance"] {
+                if let Some(value) = table.get(key).cloned() {
+                    table_payload[key] = value;
+                }
+            }
+            let mut node = json!({
+                "id": format!("p{}-table-{}", page_no, table_index + 1),
+                "type": "table",
+                "page_start": page_no,
+                "page_end": page_no,
+                "element_ids": [format!("p{}-table-{}", page_no, table_index + 1)],
+                "text": table.get("rows").and_then(Value::as_array).into_iter().flatten().map(|row| {
+                    row.as_array().into_iter().flatten().filter_map(Value::as_str).collect::<Vec<_>>().join(" | ")
+                }).collect::<Vec<_>>().join("\n"),
+                "table": table_payload,
+            });
+            if let Some(box_) = table.get("bounding_box").cloned() {
+                node["bounding_boxes"] = json!([box_]);
+            }
+            page_children.push(node);
+        }
         children.push(json!({
             "id": format!("page-{}", page_no),
             "type": "page",
@@ -594,23 +704,6 @@ pub fn build_document_ast(pages: &[PageText], elements: &Value, tables: &Value) 
             "page_end": page_no,
             "element_ids": [],
             "children": page_children,
-        }));
-    }
-
-    for table in tables.as_array().into_iter().flatten() {
-        let page = table.get("page").cloned().unwrap_or(json!(1));
-        children.push(json!({
-            "id": format!("ast-table-{}", table.get("tableIndex").and_then(Value::as_u64).unwrap_or(0)),
-            "type": "table",
-            "page_start": page,
-            "page_end": page,
-            "element_ids": [],
-            "table": {
-                "rows": table.get("rows"),
-                "rowCount": table.get("rowCount"),
-                "colCount": table.get("colCount"),
-                "confidence": table.get("confidence"),
-            }
         }));
     }
 
@@ -626,6 +719,9 @@ pub fn build_document_ast(pages: &[PageText], elements: &Value, tables: &Value) 
             "children": children,
         },
         "element_count": elements.as_array().map(|a| a.len()).unwrap_or(0),
+        "summary": {
+            "table_count": tables.as_array().map(|a| a.len()).unwrap_or(0),
+        },
         "warnings": if pages.iter().all(|p| p.text.lines().filter(|l| looks_like_heading(l)).count() == 0) {
             vec!["No heading hierarchy detected; document_ast uses page-level leaf nodes."]
         } else {
@@ -657,6 +753,10 @@ pub fn build_document_map(
     ];
     if tables.as_array().is_some_and(|a| !a.is_empty()) {
         layers.push("tables");
+        layers.push("table_structure");
+    }
+    if chunks.as_array().is_some_and(|a| !a.is_empty()) {
+        layers.push("citation_chunks");
     }
     if safety.as_array().is_some_and(|a| !a.is_empty()) {
         layers.push("safety_findings");
@@ -696,6 +796,7 @@ pub fn build_document_map(
             "safety_finding_count": safety.as_array().map(|a| a.len()).unwrap_or(0),
             "layout_page_count": layout.as_array().map(|a| a.len()).unwrap_or(0),
         },
+        "elements": elements,
         "routing": {
             "trust_report": trust.is_some(),
             "accessibility_report": a11y.is_some(),

--- a/crates/pdf-reader-core/src/lib.rs
+++ b/crates/pdf-reader-core/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod document_twin;
 pub mod legacy;
 pub mod ocr_fusion;
+pub mod ocr_tables;
 pub mod page_cache;
 pub mod read_pdf;
 pub mod render;
@@ -14,10 +15,7 @@ pub mod url_fetch;
 pub use ssrf::{assert_host_not_private, is_private_ip};
 
 pub use legacy::legacy_engine_allowed;
-pub use ocr_fusion::{
-    fuse_ocr_outcomes, OcrPage, OcrWord, SourceOcrOutcome, OCR_STRUCTURED_FUSION_GAP_WARNING,
-    OCR_STUB_WARNING,
-};
+pub use ocr_fusion::{fuse_ocr_outcomes, OcrPage, OcrWord, SourceOcrOutcome, OCR_STUB_WARNING};
 pub use read_pdf::{
     read_pdf, read_pdf_from_value, ReadPdfError, ReadPdfErrorCode, ReadPdfInput, ReadPdfResponse,
     ReadPdfSource, ReadPdfSourceResult, READ_PDF_ROUTE,

--- a/crates/pdf-reader-core/src/ocr_fusion.rs
+++ b/crates/pdf-reader-core/src/ocr_fusion.rs
@@ -7,10 +7,9 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::read_pdf::ReadPdfResponse;
+use crate::read_pdf::{rebuild_structured_outputs, ReadPdfResponse};
 
 pub const OCR_STUB_WARNING: &str = "include_ocr_text_layer: provider execution is owned by pdf-reader-mcp-server; pdf-reader-core omits ocr_text_layer until a normalized provider outcome is fused.";
-pub const OCR_STRUCTURED_FUSION_GAP_WARNING: &str = "OCR text is available as a parallel text layer, but OCR word boxes are not yet fused into tables or document_ast on the pure-Rust path.";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct OcrWord {
@@ -158,6 +157,10 @@ pub fn fuse_ocr_outcomes(response: &mut ReadPdfResponse, outcomes: Vec<SourceOcr
         data.ocr_text_layer = None;
 
         if let Some(error) = outcome.error {
+            if let Some(context) = data.structured_fusion_context.clone() {
+                let selectable_tables = context.selectable_tables.clone();
+                rebuild_structured_outputs(data, &context, &selectable_tables);
+            }
             if let Some(map) = data.document_map.as_mut() {
                 fuse_document_map(map, &data.ocr_candidate_pages, &[]);
             }
@@ -168,6 +171,10 @@ pub fn fuse_ocr_outcomes(response: &mut ReadPdfResponse, outcomes: Vec<SourceOcr
             continue;
         }
         if outcome.pages.is_empty() {
+            if let Some(context) = data.structured_fusion_context.clone() {
+                let selectable_tables = context.selectable_tables.clone();
+                rebuild_structured_outputs(data, &context, &selectable_tables);
+            }
             if let Some(map) = data.document_map.as_mut() {
                 fuse_document_map(map, &data.ocr_candidate_pages, &[]);
             }
@@ -217,14 +224,13 @@ pub fn fuse_ocr_outcomes(response: &mut ReadPdfResponse, outcomes: Vec<SourceOcr
             append_unique_warning(&mut data.warnings, warning);
         }
 
+        if let Some(context) = data.structured_fusion_context.clone() {
+            let merged_tables =
+                crate::ocr_tables::merge_ocr_tables(&outcome.pages, &context.selectable_tables);
+            rebuild_structured_outputs(data, &context, &merged_tables);
+        }
         if let Some(map) = data.document_map.as_mut() {
             fuse_document_map(map, &data.ocr_candidate_pages, &outcome.pages);
-        }
-        if data.tables.is_some() || data.document_ast.is_some() {
-            append_unique_warning(
-                &mut data.warnings,
-                OCR_STRUCTURED_FUSION_GAP_WARNING.to_string(),
-            );
         }
     }
 }
@@ -232,7 +238,8 @@ pub fn fuse_ocr_outcomes(response: &mut ReadPdfResponse, outcomes: Vec<SourceOcr
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::read_pdf::{EngineInfo, ReadPdfData, ReadPdfSourceResult};
+    use crate::document_twin::PageText;
+    use crate::read_pdf::{EngineInfo, ReadPdfData, ReadPdfSourceResult, StructuredFusionContext};
 
     fn response() -> ReadPdfResponse {
         ReadPdfResponse {
@@ -278,6 +285,7 @@ mod tests {
                         version: "test",
                     },
                     ocr_candidate_pages: vec![2],
+                    structured_fusion_context: None,
                 }),
             }],
         }
@@ -409,26 +417,53 @@ mod tests {
     }
 
     #[test]
-    fn structured_outputs_remain_unchanged_and_gap_is_explicit() {
+    fn boxed_ocr_table_rebuilds_every_table_derived_surface() {
         let mut response = response();
         let data = response.results[0].data.as_mut().unwrap();
-        data.tables = Some(json!([{"id":"selectable-table"}]));
-        data.document_ast = Some(json!({"root":{"id":"selectable-root"}}));
-        let tables_before = data.tables.clone();
-        let ast_before = data.document_ast.clone();
+        data.structured_fusion_context = Some(StructuredFusionContext {
+            pages: vec![PageText {
+                page: 2,
+                text: String::new(),
+            }],
+            selectable_tables: json!([]),
+            semantic_hints: true,
+            emit_markdown: true,
+            emit_html: true,
+            emit_chunks: true,
+            emit_elements: true,
+            emit_tables: true,
+            emit_document_ast: true,
+            emit_document_map: true,
+            safety: json!([]),
+            layout: json!([]),
+            trust: None,
+            accessibility: None,
+        });
         fuse_ocr_outcomes(
             &mut response,
             vec![SourceOcrOutcome {
                 source_index: 0,
                 pages: vec![OcrPage {
                     page: 2,
-                    text: "OCR".into(),
+                    text: "Metric Value\nRevenue 24%".into(),
                     confidence: None,
-                    words: Some(vec![OcrWord {
-                        text: "cell".into(),
-                        confidence: None,
-                        bounding_box: Some(json!({"left":1,"bottom":1,"right":2,"top":2})),
-                    }]),
+                    words: Some(
+                        vec![
+                            ("Metric", 40, 700, 88, 710),
+                            ("Value", 160, 700, 202, 710),
+                            ("Revenue", 40, 680, 100, 690),
+                            ("24%", 160, 680, 184, 690),
+                        ]
+                        .into_iter()
+                        .map(|(text, left, bottom, right, top)| OcrWord {
+                            text: text.into(),
+                            confidence: None,
+                            bounding_box: Some(
+                                json!({"left":left,"bottom":bottom,"right":right,"top":top}),
+                            ),
+                        })
+                        .collect(),
+                    ),
                     language: None,
                     provider: "command".into(),
                     source_render_evidence_id: "render-2".into(),
@@ -443,12 +478,52 @@ mod tests {
             }],
         );
         let data = response.results[0].data.as_ref().unwrap();
-        assert_eq!(data.tables, tables_before);
-        assert_eq!(data.document_ast, ast_before);
+        assert_eq!(
+            data.tables.as_ref().unwrap()[0]["rows"][1],
+            json!(["Revenue", "24%"])
+        );
+        assert_eq!(
+            data.elements.as_ref().unwrap()[0]["provenance"]["source"],
+            "ocr-table-detector"
+        );
+        assert_eq!(data.chunks.as_ref().unwrap()[0]["strategy"], "table");
         assert!(data
-            .warnings
-            .as_ref()
+            .markdown
+            .as_deref()
             .unwrap()
-            .contains(&OCR_STRUCTURED_FUSION_GAP_WARNING.to_string()));
+            .contains("| Metric | Value |"));
+        assert!(data.html.as_deref().unwrap().contains("<table"));
+        assert_eq!(
+            data.document_ast.as_ref().unwrap()["summary"]["table_count"],
+            1
+        );
+        assert_eq!(
+            data.document_map.as_ref().unwrap()["indexes"]["table_count"],
+            1
+        );
+        assert_eq!(
+            data.document_map.as_ref().unwrap()["routing"]["ocr_applied_pages"],
+            json!([2])
+        );
+
+        fuse_ocr_outcomes(
+            &mut response,
+            vec![SourceOcrOutcome {
+                source_index: 0,
+                pages: Vec::new(),
+                warnings: Vec::new(),
+                error: Some("later provider failure".into()),
+            }],
+        );
+        let reset = response.results[0].data.as_ref().unwrap();
+        assert_eq!(reset.tables.as_ref().unwrap(), &json!([]));
+        assert_eq!(
+            reset.document_ast.as_ref().unwrap()["summary"]["table_count"],
+            0
+        );
+        assert_eq!(
+            reset.document_map.as_ref().unwrap()["routing"]["ocr_applied_pages"],
+            json!([])
+        );
     }
 }

--- a/crates/pdf-reader-core/src/ocr_tables.rs
+++ b/crates/pdf-reader-core/src/ocr_tables.rs
@@ -1,0 +1,902 @@
+//! Deterministic OCR-word table extraction and selectable/OCR evidence merge.
+//!
+//! This is the provider-neutral projection of the immutable TypeScript
+//! v3.0.14 table contract. OCR prose alone is intentionally insufficient:
+//! only normalized non-empty words with valid PDF-coordinate boxes can form
+//! tables.
+
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use serde_json::{json, Value};
+
+use crate::ocr_fusion::OcrPage;
+
+const Y_TOLERANCE: f64 = 5.0;
+const COLUMN_GAP_THRESHOLD: f64 = 15.0;
+const MIN_ROWS: usize = 2;
+const MIN_COLS: usize = 2;
+const MIN_ROW_ITEMS: usize = 2;
+const PAGE_EDGE_CONTINUATION_BOTTOM_Y: f64 = 120.0;
+const PAGE_EDGE_CONTINUATION_TOP_Y: f64 = 500.0;
+const COLUMN_GEOMETRY_TOLERANCE: f64 = 24.0;
+const CONTINUATION_MIN_GEOMETRY_SIMILARITY: f64 = 0.8;
+const MAX_OCR_TABLE_PAGES: usize = 20;
+const MAX_OCR_WORDS_PER_PAGE: usize = 50_000;
+const MAX_OCR_TABLES: usize = 512;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct Box2d {
+    left: f64,
+    bottom: f64,
+    right: f64,
+    top: f64,
+}
+
+impl Box2d {
+    fn from_value(value: &Value) -> Option<Self> {
+        let object = value.as_object()?;
+        let box_ = Self {
+            left: object.get("left")?.as_f64()?,
+            bottom: object.get("bottom")?.as_f64()?,
+            right: object.get("right")?.as_f64()?,
+            top: object.get("top")?.as_f64()?,
+        };
+        ([box_.left, box_.bottom, box_.right, box_.top]
+            .into_iter()
+            .all(f64::is_finite)
+            && box_.right > box_.left
+            && box_.top > box_.bottom)
+            .then_some(box_)
+    }
+
+    fn area(self) -> f64 {
+        (self.right - self.left).max(0.0) * (self.top - self.bottom).max(0.0)
+    }
+
+    fn to_value(self) -> Value {
+        json!({
+            "left": self.left,
+            "bottom": self.bottom,
+            "right": self.right,
+            "top": self.top,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+struct TextItem {
+    text: String,
+    x: f64,
+    y: f64,
+    box_: Box2d,
+}
+
+#[derive(Clone, Debug)]
+struct TextRow {
+    y: f64,
+    items: Vec<TextItem>,
+}
+
+#[derive(Clone, Debug)]
+struct Region {
+    rows: Vec<TextRow>,
+    columns: Vec<f64>,
+}
+
+fn cmp_f64(left: f64, right: f64) -> Ordering {
+    left.partial_cmp(&right).unwrap_or(Ordering::Equal)
+}
+
+fn round_ratio(value: f64) -> f64 {
+    (value * 100.0).round() / 100.0
+}
+
+fn merge_boxes(boxes: impl IntoIterator<Item = Box2d>) -> Option<Box2d> {
+    boxes.into_iter().reduce(|left, right| Box2d {
+        left: left.left.min(right.left),
+        bottom: left.bottom.min(right.bottom),
+        right: left.right.max(right.right),
+        top: left.top.max(right.top),
+    })
+}
+
+fn text_items(page: &OcrPage) -> Vec<TextItem> {
+    page.words
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .take(MAX_OCR_WORDS_PER_PAGE)
+        .filter_map(|word| {
+            let text = word.text.trim();
+            let box_ = Box2d::from_value(word.bounding_box.as_ref()?)?;
+            (!text.is_empty()).then(|| TextItem {
+                text: text.to_string(),
+                x: box_.left,
+                y: box_.bottom,
+                box_,
+            })
+        })
+        .collect()
+}
+
+fn cluster_rows(mut items: Vec<TextItem>) -> Vec<TextRow> {
+    items.sort_by(|left, right| cmp_f64(right.y, left.y));
+    let Some(first) = items.first().cloned() else {
+        return Vec::new();
+    };
+    let mut rows = Vec::new();
+    let mut current = TextRow {
+        y: first.y,
+        items: vec![first],
+    };
+    for item in items.into_iter().skip(1) {
+        if (current.y - item.y).abs() <= Y_TOLERANCE {
+            current.items.push(item);
+        } else {
+            current
+                .items
+                .sort_by(|left, right| cmp_f64(left.x, right.x));
+            rows.push(current);
+            current = TextRow {
+                y: item.y,
+                items: vec![item],
+            };
+        }
+    }
+    current
+        .items
+        .sort_by(|left, right| cmp_f64(left.x, right.x));
+    rows.push(current);
+    rows
+}
+
+fn detect_columns(rows: &[TextRow]) -> Vec<f64> {
+    let mut positions = rows
+        .iter()
+        .flat_map(|row| row.items.iter().map(|item| item.x))
+        .collect::<Vec<_>>();
+    positions.sort_by(|left, right| cmp_f64(*left, *right));
+    let Some(first) = positions.first().copied() else {
+        return Vec::new();
+    };
+    let mut columns = vec![first];
+    for pair in positions.windows(2) {
+        if pair[1] - pair[0] >= COLUMN_GAP_THRESHOLD {
+            columns.push(pair[1]);
+        }
+    }
+    columns
+}
+
+fn column_for(x: f64, columns: &[f64]) -> usize {
+    columns
+        .iter()
+        .rposition(|boundary| x >= *boundary - COLUMN_GAP_THRESHOLD / 2.0)
+        .unwrap_or(0)
+}
+
+fn identify_regions(rows: Vec<TextRow>) -> Vec<Region> {
+    let candidates = rows
+        .into_iter()
+        .filter(|row| row.items.len() >= MIN_ROW_ITEMS)
+        .collect::<Vec<_>>();
+    if candidates.len() < MIN_ROWS {
+        return Vec::new();
+    }
+    let columns = detect_columns(&candidates);
+    if columns.len() < MIN_COLS {
+        return Vec::new();
+    }
+    let mut regions = Vec::new();
+    let mut current = Vec::new();
+    for row in candidates {
+        let aligned = row
+            .items
+            .iter()
+            .filter(|item| {
+                columns
+                    .iter()
+                    .any(|boundary| (item.x - boundary).abs() < COLUMN_GAP_THRESHOLD)
+            })
+            .count();
+        if aligned >= MIN_COLS - 1 {
+            current.push(row);
+        } else {
+            if current.len() >= MIN_ROWS {
+                regions.push(Region {
+                    rows: std::mem::take(&mut current),
+                    columns: columns.clone(),
+                });
+            } else {
+                current.clear();
+            }
+        }
+    }
+    if current.len() >= MIN_ROWS {
+        regions.push(Region {
+            rows: current,
+            columns,
+        });
+    }
+    regions
+}
+
+fn row_spacing_consistency(rows: &[TextRow]) -> f64 {
+    if rows.len() < 3 {
+        return if rows.len() >= 2 { 1.0 } else { 0.0 };
+    }
+    let spacings = rows
+        .windows(2)
+        .map(|pair| (pair[0].y - pair[1].y).abs())
+        .collect::<Vec<_>>();
+    let average = spacings.iter().sum::<f64>() / spacings.len() as f64;
+    if average <= 0.0 {
+        return 0.0;
+    }
+    let variance = spacings
+        .iter()
+        .map(|spacing| (spacing - average).powi(2))
+        .sum::<f64>()
+        / spacings.len() as f64;
+    round_ratio((1.0 - variance.sqrt() / average).max(0.0))
+}
+
+fn row_alignment(rows: &[TextRow], columns: &[f64]) -> f64 {
+    if rows.is_empty() || columns.is_empty() {
+        return 0.0;
+    }
+    let total = rows
+        .iter()
+        .map(|row| {
+            let occupied = row
+                .items
+                .iter()
+                .map(|item| column_for(item.x, columns))
+                .collect::<BTreeSet<_>>()
+                .len();
+            (occupied as f64 / columns.len() as f64).min(1.0)
+        })
+        .sum::<f64>();
+    round_ratio(total / rows.len() as f64)
+}
+
+fn confidence(rows: &[TextRow], columns: &[f64]) -> f64 {
+    if rows.len() < MIN_ROWS || columns.len() < MIN_COLS {
+        return 0.0;
+    }
+    let mut score = 0.0;
+    let mut checks = 0usize;
+    for row in rows {
+        score += row
+            .items
+            .iter()
+            .map(|item| column_for(item.x, columns))
+            .collect::<BTreeSet<_>>()
+            .len() as f64
+            / columns.len() as f64;
+        checks += 1;
+    }
+    let spacings = rows
+        .windows(2)
+        .map(|pair| (pair[0].y - pair[1].y).abs())
+        .collect::<Vec<_>>();
+    if !spacings.is_empty() {
+        let average = spacings.iter().sum::<f64>() / spacings.len() as f64;
+        let variance = spacings
+            .iter()
+            .map(|spacing| (spacing - average).powi(2))
+            .sum::<f64>()
+            / spacings.len() as f64;
+        score += if average > 0.0 {
+            (1.0 - variance.sqrt() / average).max(0.0)
+        } else {
+            0.0
+        };
+        checks += 1;
+    }
+    (score / checks as f64).min(1.0)
+}
+
+fn infer_span(box_: Option<Box2d>, column: usize, columns: &[f64]) -> usize {
+    let Some(box_) = box_ else { return 1 };
+    let mut span = 1;
+    for boundary in columns.iter().skip(column + 1) {
+        if box_.right >= *boundary - COLUMN_GAP_THRESHOLD / 2.0 {
+            span += 1;
+        } else {
+            break;
+        }
+    }
+    span.clamp(1, columns.len() - column)
+}
+
+fn quality(rows: &[TextRow], cells: &[Value], columns: &[f64], confidence: f64) -> Value {
+    let non_empty = cells
+        .iter()
+        .filter(|cell| {
+            cell.get("text")
+                .and_then(Value::as_str)
+                .is_some_and(|text| !text.trim().is_empty())
+        })
+        .count();
+    let boxed = cells
+        .iter()
+        .filter(|cell| cell.get("bounding_box").is_some())
+        .count();
+    let inferred = cells
+        .iter()
+        .filter(|cell| cell.get("inferred") == Some(&Value::Bool(true)))
+        .count();
+    let missing = cells.len().saturating_sub(non_empty);
+    let merged = cells
+        .iter()
+        .filter(|cell| cell.get("colSpan").and_then(Value::as_u64).unwrap_or(1) > 1)
+        .count();
+    let ratio = |count: usize| {
+        if cells.is_empty() {
+            0.0
+        } else {
+            round_ratio(count as f64 / cells.len() as f64)
+        }
+    };
+    let alignment = row_alignment(rows, columns);
+    let spacing = row_spacing_consistency(rows);
+    let mut signals = vec![if missing == 0 {
+        "complete_grid"
+    } else {
+        "missing_cells"
+    }];
+    let mut warnings = Vec::new();
+    if missing > 0 {
+        warnings
+            .push("Detected empty inferred cells; table may contain sparse or merged structure.");
+    }
+    if merged > 0 {
+        signals.push("merged_cell_candidates");
+        warnings
+            .push("Detected cells whose text boxes cross column boundaries; spans are inferred.");
+    }
+    if boxed < cells.len() {
+        signals.push("incomplete_cell_geometry");
+        warnings.push("Some table cells lack bounding boxes; verify the table with region crops when cell-level evidence matters.");
+    }
+    if spacing < 0.75 {
+        signals.push("irregular_row_spacing");
+        warnings.push("Row spacing is irregular; verify the table with visual evidence when precision matters.");
+    }
+    if confidence < 0.65 {
+        signals.push("low_confidence");
+        warnings.push("Table detector confidence is low; use region crops or page rendering for verification.");
+    }
+    let mut value = json!({
+        "completeness": round_ratio(ratio(non_empty) * alignment),
+        "nonEmptyCellRatio": ratio(non_empty),
+        "cellBoundingBoxCoverage": ratio(boxed),
+        "inferredCellRatio": ratio(inferred),
+        "rowAlignment": alignment,
+        "rowSpacingConsistency": spacing,
+        "cellBoundingBoxCount": boxed,
+        "inferredCellCount": inferred,
+        "missingCellCount": missing,
+        "mergedCellCandidateCount": merged,
+        "signals": signals,
+    });
+    if !warnings.is_empty() {
+        value["warnings"] = json!(warnings);
+    }
+    value
+}
+
+fn table_for_region(page: &OcrPage, table_index: usize, region: Region) -> Option<Value> {
+    let score = confidence(&region.rows, &region.columns);
+    if score < 0.3 {
+        return None;
+    }
+    let mut rows = Vec::new();
+    let mut cells = Vec::new();
+    for (row_index, row) in region.rows.iter().enumerate() {
+        let mut by_column = vec![Vec::<&TextItem>::new(); region.columns.len()];
+        for item in &row.items {
+            by_column[column_for(item.x, &region.columns)].push(item);
+        }
+        let mut values = Vec::with_capacity(region.columns.len());
+        for (column, items) in by_column.into_iter().enumerate() {
+            let text = items
+                .iter()
+                .map(|item| item.text.as_str())
+                .collect::<Vec<_>>()
+                .join(" ");
+            let box_ = merge_boxes(items.iter().map(|item| item.box_));
+            let span = infer_span(box_, column, &region.columns);
+            let mut cell = json!({
+                "text": text,
+                "rowIndex": row_index,
+                "colIndex": column,
+                "rowSpan": 1,
+                "colSpan": span,
+                "isHeader": row_index == 0,
+                "inferred": items.is_empty(),
+            });
+            if let Some(box_) = box_ {
+                cell["bounding_box"] = box_.to_value();
+            }
+            values.push(text);
+            cells.push(cell);
+        }
+        rows.push(values);
+    }
+    let box_ = merge_boxes(
+        cells
+            .iter()
+            .filter_map(|cell| Box2d::from_value(cell.get("bounding_box")?)),
+    );
+    let rounded = round_ratio(score);
+    let mut table = json!({
+        "page": page.page,
+        "tableIndex": table_index,
+        "rows": rows,
+        "cells": cells,
+        "rowCount": region.rows.len(),
+        "colCount": region.columns.len(),
+        "confidence": rounded,
+        "provenance": {
+            "source": "ocr_text_layer",
+            "engine": "external-command",
+            "ocr_source_render_evidence_id": page.source_render_evidence_id,
+        },
+    });
+    if let Some(box_) = box_ {
+        table["bounding_box"] = box_.to_value();
+    }
+    table["quality"] = quality(&region.rows, &cells, &region.columns, rounded);
+    Some(table)
+}
+
+fn table_page(table: &Value) -> u64 {
+    table.get("page").and_then(Value::as_u64).unwrap_or(0)
+}
+
+fn table_index(table: &Value) -> u64 {
+    table.get("tableIndex").and_then(Value::as_u64).unwrap_or(0)
+}
+
+fn table_id(table: &Value) -> String {
+    format!("p{}-table-{}", table_page(table), table_index(table) + 1)
+}
+
+fn table_key_from_id(id: &str) -> Option<(u64, u64)> {
+    let value = id.strip_prefix('p')?;
+    let (page, table) = value.split_once("-table-")?;
+    let table = table.parse::<u64>().ok()?.checked_sub(1)?;
+    Some((page.parse().ok()?, table))
+}
+
+fn table_box(table: &Value) -> Option<Box2d> {
+    Box2d::from_value(table.get("bounding_box")?)
+}
+
+fn overlap_ratio(left: &Value, right: &Value) -> f64 {
+    let (Some(left), Some(right)) = (table_box(left), table_box(right)) else {
+        return 0.0;
+    };
+    let intersection = (left.right.min(right.right) - left.left.max(right.left)).max(0.0)
+        * (left.top.min(right.top) - left.bottom.max(right.bottom)).max(0.0);
+    let denominator = left.area().min(right.area());
+    if denominator > 0.0 {
+        intersection / denominator
+    } else {
+        0.0
+    }
+}
+
+fn header(table: &Value) -> BTreeSet<String> {
+    table
+        .get("rows")
+        .and_then(Value::as_array)
+        .and_then(|rows| rows.first())
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .map(str::to_lowercase)
+        .collect()
+}
+
+fn header_similarity(left: &Value, right: &Value) -> f64 {
+    let left = header(left);
+    let right = header(right);
+    if left.is_empty() || right.is_empty() {
+        return 0.0;
+    }
+    left.intersection(&right).count() as f64 / left.len().max(right.len()) as f64
+}
+
+fn column_anchors(table: &Value) -> Option<Vec<f64>> {
+    let count = table.get("colCount")?.as_u64()? as usize;
+    let cells = table.get("cells")?.as_array()?;
+    (0..count)
+        .map(|column| {
+            cells
+                .iter()
+                .filter(|cell| {
+                    cell.get("colIndex").and_then(Value::as_u64) == Some(column as u64)
+                        && cell.get("inferred") != Some(&Value::Bool(true))
+                })
+                .filter_map(|cell| Box2d::from_value(cell.get("bounding_box")?))
+                .map(|box_| box_.left)
+                .min_by(|left, right| cmp_f64(*left, *right))
+        })
+        .collect()
+}
+
+fn continuation_evidence(left: &Value, right: &Value) -> Option<(f64, Vec<&'static str>)> {
+    if left.get("colCount") != right.get("colCount") {
+        return None;
+    }
+    let similarity = header_similarity(left, right);
+    if similarity >= 0.6 {
+        return Some((
+            round_ratio(0.55 + similarity * 0.4),
+            vec!["same_column_count", "repeated_header_candidate"],
+        ));
+    }
+    let left_anchors = column_anchors(left)?;
+    let right_anchors = column_anchors(right)?;
+    if left_anchors.len() != right_anchors.len() || left_anchors.is_empty() {
+        return None;
+    }
+    let geometry = round_ratio(
+        left_anchors
+            .iter()
+            .zip(right_anchors)
+            .map(|(left, right)| (1.0 - (left - right).abs() / COLUMN_GEOMETRY_TOLERANCE).max(0.0))
+            .sum::<f64>()
+            / left_anchors.len() as f64,
+    );
+    let (Some(left_box), Some(right_box)) = (table_box(left), table_box(right)) else {
+        return None;
+    };
+    if geometry < CONTINUATION_MIN_GEOMETRY_SIMILARITY
+        || left_box.bottom > PAGE_EDGE_CONTINUATION_BOTTOM_Y
+        || right_box.top < PAGE_EDGE_CONTINUATION_TOP_Y
+    {
+        return None;
+    }
+    Some((
+        round_ratio((0.58 + geometry * 0.25 + 0.12).min(0.95)),
+        vec![
+            "same_column_count",
+            "column_geometry_match",
+            "page_edge_continuation_candidate",
+            "non_repeated_header_candidate",
+        ],
+    ))
+}
+
+fn add_quality_signal(table: &mut Value, signal: &str) {
+    let Some(signals) = table
+        .get_mut("quality")
+        .and_then(|quality| quality.get_mut("signals"))
+        .and_then(Value::as_array_mut)
+    else {
+        return;
+    };
+    let signal = json!(signal);
+    if !signals.contains(&signal) {
+        signals.push(signal);
+    }
+}
+
+fn link_continuations(tables: &mut [Value]) {
+    tables.sort_by_key(|table| (table_page(table), table_index(table)));
+    for index in 0..tables.len().saturating_sub(1) {
+        let (left, right) = tables.split_at_mut(index + 1);
+        let current = &mut left[index];
+        let next = &mut right[0];
+        if table_page(next) != table_page(current) + 1 {
+            continue;
+        }
+        let Some((confidence, signals)) = continuation_evidence(current, next) else {
+            continue;
+        };
+        let current_id = table_id(current);
+        let next_id = table_id(next);
+        let group = format!("table-continuation-{current_id}-{next_id}");
+        let previous_id = current
+            .pointer("/continuation/previousTableId")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let following_id = next
+            .pointer("/continuation/nextTableId")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let mut current_continuation = json!({
+            "groupId": group,
+            "role": if previous_id.is_some() { "continues" } else { "starts" },
+            "nextTableId": next_id,
+            "confidence": confidence,
+            "signals": signals,
+        });
+        if let Some(previous_id) = previous_id {
+            current_continuation["previousTableId"] = json!(previous_id);
+        }
+        current["continuation"] = current_continuation;
+        let mut next_continuation = json!({
+            "groupId": group,
+            "role": if following_id.is_some() { "continues" } else { "ends" },
+            "previousTableId": current_id,
+            "confidence": confidence,
+            "signals": signals,
+        });
+        if let Some(following_id) = following_id {
+            next_continuation["nextTableId"] = json!(following_id);
+        }
+        next["continuation"] = next_continuation;
+        add_quality_signal(current, "multi_page_continuation_candidate");
+        add_quality_signal(next, "multi_page_continuation_candidate");
+    }
+}
+
+/// Extract TS v3.0.14-compatible tables from normalized OCR word boxes.
+pub fn extract_ocr_tables(ocr_pages: &[OcrPage]) -> Value {
+    let mut tables = ocr_pages
+        .iter()
+        .take(MAX_OCR_TABLE_PAGES)
+        .flat_map(|page| {
+            identify_regions(cluster_rows(text_items(page)))
+                .into_iter()
+                .enumerate()
+                .filter_map(|(index, region)| table_for_region(page, index, region))
+                .collect::<Vec<_>>()
+        })
+        .take(MAX_OCR_TABLES)
+        .collect::<Vec<_>>();
+    link_continuations(&mut tables);
+    Value::Array(tables)
+}
+
+fn rebase_continuation(
+    table: &mut Value,
+    old_id: &str,
+    new_id: &str,
+    id_map: &HashMap<(u64, u64), String>,
+) {
+    let Some(continuation) = table.get_mut("continuation").and_then(Value::as_object_mut) else {
+        return;
+    };
+    let remap = |value: Option<&Value>| {
+        value.and_then(Value::as_str).map(|id| {
+            table_key_from_id(id)
+                .and_then(|key| id_map.get(&key).cloned())
+                .unwrap_or_else(|| id.to_string())
+        })
+    };
+    let previous = remap(continuation.get("previousTableId"));
+    let next = remap(continuation.get("nextTableId"));
+    if let Some(previous) = previous.as_ref() {
+        continuation.insert("previousTableId".into(), json!(previous));
+    }
+    if let Some(next) = next.as_ref() {
+        continuation.insert("nextTableId".into(), json!(next));
+    }
+    let group = if let Some(previous) = previous {
+        format!("table-continuation-{previous}-{new_id}")
+    } else if let Some(next) = next {
+        format!("table-continuation-{new_id}-{next}")
+    } else {
+        continuation
+            .get("groupId")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .replace(old_id, new_id)
+    };
+    continuation.insert("groupId".into(), json!(group));
+}
+
+/// Merge selectable table JSON with tables derived from normalized OCR words.
+///
+/// Non-array selectable input is treated as an empty table collection. Existing
+/// selectable values are preserved byte-for-JSON-value; only OCR tables are
+/// deduplicated, reindexed, and continuation-rebased.
+pub fn merge_ocr_tables(ocr_pages: &[OcrPage], selectable_tables: &Value) -> Value {
+    let selectable = selectable_tables.as_array().cloned().unwrap_or_default();
+    let extracted = extract_ocr_tables(ocr_pages);
+    let mut ocr = extracted.as_array().cloned().unwrap_or_default();
+    ocr.retain(|candidate| {
+        !selectable.iter().any(|table| {
+            table_page(table) == table_page(candidate) && overlap_ratio(table, candidate) >= 0.6
+        })
+    });
+
+    let mut max_index = BTreeMap::<u64, u64>::new();
+    for table in &selectable {
+        max_index
+            .entry(table_page(table))
+            .and_modify(|index| *index = (*index).max(table_index(table)))
+            .or_insert_with(|| table_index(table));
+    }
+    let mut ordinal = BTreeMap::<u64, u64>::new();
+    let mut id_map = HashMap::new();
+    let mut indexed = Vec::with_capacity(ocr.len());
+    for mut table in ocr {
+        let page = table_page(&table);
+        let old_index = table_index(&table);
+        let old_id = table_id(&table);
+        let position = ordinal.entry(page).or_default();
+        if let Some(base) = max_index.get(&page) {
+            table["tableIndex"] = json!(*base + 1 + *position);
+        }
+        *position += 1;
+        id_map.insert((page, old_index), table_id(&table));
+        indexed.push((old_id, table));
+    }
+    for (old_id, table) in &mut indexed {
+        let new_id = table_id(table);
+        rebase_continuation(table, old_id, &new_id, &id_map);
+    }
+
+    let mut merged = selectable;
+    merged.extend(indexed.into_iter().map(|(_, table)| table));
+    merged.sort_by_key(|table| (table_page(table), table_index(table)));
+    Value::Array(merged)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ocr_fusion::OcrWord;
+
+    fn word(text: &str, left: f64, bottom: f64, right: f64, top: f64) -> OcrWord {
+        OcrWord {
+            text: text.into(),
+            confidence: Some(0.9),
+            bounding_box: Some(json!({
+                "left": left,
+                "bottom": bottom,
+                "right": right,
+                "top": top,
+            })),
+        }
+    }
+
+    fn page(page: u32, words: Vec<OcrWord>) -> OcrPage {
+        OcrPage {
+            page,
+            text: words
+                .iter()
+                .map(|word| word.text.as_str())
+                .collect::<Vec<_>>()
+                .join(" "),
+            confidence: Some(0.92),
+            words: Some(words),
+            language: Some("eng".into()),
+            provider: "command".into(),
+            source_render_evidence_id: format!("page-{page}-render-scale-2"),
+            source_render_scale: Some(2.0),
+            source_render_width: Some(1224),
+            source_render_height: Some(1584),
+            provenance: json!({"engine":"external-command","source":"ocr-provider"}),
+            warnings: None,
+        }
+    }
+
+    fn ocr_table_page(words_left: f64, page_number: u32) -> OcrPage {
+        page(
+            page_number,
+            vec![
+                word("Metric", words_left, 700.0, words_left + 48.0, 710.0),
+                word(
+                    "Value",
+                    words_left + 120.0,
+                    700.0,
+                    words_left + 162.0,
+                    710.0,
+                ),
+                word("Revenue", words_left, 680.0, words_left + 60.0, 690.0),
+                word("24%", words_left + 120.0, 680.0, words_left + 144.0, 690.0),
+            ],
+        )
+    }
+
+    #[test]
+    fn extracts_boxed_two_by_two_with_cells_provenance_and_quality() {
+        let result = extract_ocr_tables(&[ocr_table_page(40.0, 1)]);
+        let table = &result[0];
+        assert_eq!(
+            table["rows"],
+            json!([["Metric", "Value"], ["Revenue", "24%"]])
+        );
+        assert_eq!(table["rowCount"], 2);
+        assert_eq!(table["colCount"], 2);
+        assert_eq!(table["cells"].as_array().map(Vec::len), Some(4));
+        assert_eq!(
+            table["bounding_box"],
+            json!({"left":40.0,"bottom":680.0,"right":202.0,"top":710.0})
+        );
+        assert_eq!(table["provenance"]["source"], "ocr_text_layer");
+        assert_eq!(table["quality"]["cellBoundingBoxCoverage"], 1.0);
+        assert_eq!(table["quality"]["signals"], json!(["complete_grid"]));
+    }
+
+    #[test]
+    fn unboxed_words_and_invalid_boxes_do_not_form_tables() {
+        let mut invalid = word("bad", 1.0, 1.0, 2.0, 2.0);
+        invalid.bounding_box = Some(json!({"left":1,"bottom":1,"right":1,"top":2}));
+        let unboxed = OcrWord {
+            text: "plain".into(),
+            confidence: None,
+            bounding_box: None,
+        };
+        assert_eq!(
+            extract_ocr_tables(&[page(1, vec![invalid, unboxed])]),
+            json!([])
+        );
+    }
+
+    #[test]
+    fn removes_overlap_but_keeps_and_reindexes_distinct_ocr_table() {
+        let selectable = json!([
+            {
+                "page":1,
+                "tableIndex":0,
+                "rows":[["existing"]],
+                "bounding_box":{"left":39,"bottom":679,"right":203,"top":711}
+            },
+            {
+                "page":1,
+                "tableIndex":4,
+                "rows":[["later"]],
+                "bounding_box":{"left":500,"bottom":100,"right":550,"top":120}
+            }
+        ]);
+        let result = merge_ocr_tables(
+            &[ocr_table_page(40.0, 1), ocr_table_page(300.0, 1)],
+            &selectable,
+        );
+        let tables = result.as_array().expect("tables");
+        assert_eq!(tables.len(), 3);
+        assert_eq!(
+            tables.iter().map(table_index).collect::<Vec<_>>(),
+            vec![0, 4, 5]
+        );
+        assert_eq!(tables[2]["provenance"]["source"], "ocr_text_layer");
+    }
+
+    #[test]
+    fn sorts_by_page_then_index_and_rebases_continuation_ids() {
+        let selectable = json!([{
+            "page":1,
+            "tableIndex":0,
+            "rows":[["selectable"]],
+            "bounding_box":{"left":500,"bottom":100,"right":550,"top":120}
+        }]);
+        let result = merge_ocr_tables(
+            &[ocr_table_page(300.0, 2), ocr_table_page(300.0, 1)],
+            &selectable,
+        );
+        let tables = result.as_array().expect("tables");
+        assert_eq!(
+            tables
+                .iter()
+                .map(|table| (table_page(table), table_index(table)))
+                .collect::<Vec<_>>(),
+            vec![(1, 0), (1, 1), (2, 0)]
+        );
+        assert_eq!(tables[1]["continuation"]["nextTableId"], "p2-table-1");
+        assert_eq!(tables[2]["continuation"]["previousTableId"], "p1-table-2");
+        assert_eq!(
+            tables[1]["continuation"]["groupId"],
+            "table-continuation-p1-table-2-p2-table-1"
+        );
+    }
+
+    #[test]
+    fn non_array_selectable_input_is_an_empty_collection() {
+        let result = merge_ocr_tables(&[ocr_table_page(40.0, 2)], &Value::Null);
+        assert_eq!(result[0]["page"], 2);
+        assert_eq!(result[0]["tableIndex"], 0);
+    }
+}

--- a/crates/pdf-reader-core/src/read_pdf.rs
+++ b/crates/pdf-reader-core/src/read_pdf.rs
@@ -65,6 +65,26 @@ pub struct EngineInfo {
     pub version: &'static str,
 }
 
+/// Non-serialized source material needed to deterministically rebuild
+/// table-derived surfaces after an optional OCR provider returns.
+#[derive(Debug, Clone)]
+pub struct StructuredFusionContext {
+    pub pages: Vec<crate::document_twin::PageText>,
+    pub selectable_tables: Value,
+    pub semantic_hints: bool,
+    pub emit_markdown: bool,
+    pub emit_html: bool,
+    pub emit_chunks: bool,
+    pub emit_elements: bool,
+    pub emit_tables: bool,
+    pub emit_document_ast: bool,
+    pub emit_document_map: bool,
+    pub safety: Value,
+    pub layout: Value,
+    pub trust: Option<Value>,
+    pub accessibility: Option<Value>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct ReadPdfData {
@@ -133,6 +153,9 @@ pub struct ReadPdfData {
     /// Selected OCR candidates used by the server-side provider boundary.
     #[serde(skip)]
     pub ocr_candidate_pages: Vec<u32>,
+    /// Provider-neutral inputs for the post-OCR structured reconstruction pass.
+    #[serde(skip)]
+    pub structured_fusion_context: Option<StructuredFusionContext>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -367,6 +390,178 @@ fn select_pages(
     (selected, invalid)
 }
 
+fn build_structured_chunks(pages: &[crate::document_twin::PageText], elements: &Value) -> Value {
+    let mut chunks = pages
+        .iter()
+        .filter(|page| !page.text.trim().is_empty())
+        .map(|page| {
+            json!({
+                "id": format!("chunk-p{}", page.page),
+                "page": page.page,
+                "text": page.text,
+                "element_ids": elements.as_array().into_iter().flatten()
+                    .filter(|element| element.get("page").and_then(Value::as_u64) == Some(u64::from(page.page)))
+                    .filter(|element| element.get("type").and_then(Value::as_str) != Some("table"))
+                    .filter_map(|element| element.get("id").cloned())
+                    .collect::<Vec<_>>(),
+            })
+        })
+        .collect::<Vec<_>>();
+    for element in elements
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter(|element| element.get("type").and_then(Value::as_str) == Some("table"))
+    {
+        let id = element.get("id").and_then(Value::as_str).unwrap_or("table");
+        let text = element
+            .pointer("/table/rows")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .map(|row| {
+                row.as_array()
+                    .into_iter()
+                    .flatten()
+                    .filter_map(Value::as_str)
+                    .collect::<Vec<_>>()
+                    .join(" | ")
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let mut chunk = json!({
+            "id": format!("chunk-{id}"),
+            "page": element.get("page"),
+            "text": text,
+            "element_ids": [id],
+            "strategy": "table",
+        });
+        if let Some(box_) = element.get("bounding_box").cloned() {
+            chunk["bounding_box"] = box_;
+        }
+        chunks.push(chunk);
+    }
+    json!(chunks)
+}
+
+fn render_structured_markdown(pages: &[crate::document_twin::PageText], tables: &Value) -> String {
+    let mut parts = pages
+        .iter()
+        .filter(|page| !page.text.trim().is_empty())
+        .map(|page| format!("## Page {}\n\n{}", page.page, page.text.trim()))
+        .collect::<Vec<_>>();
+    for table in tables.as_array().into_iter().flatten() {
+        let mut lines = Vec::new();
+        for (row_index, row) in table
+            .get("rows")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .enumerate()
+        {
+            let cells = row
+                .as_array()
+                .into_iter()
+                .flatten()
+                .map(|cell| cell.as_str().unwrap_or("").to_string())
+                .collect::<Vec<_>>();
+            lines.push(format!("| {} |", cells.join(" | ")));
+            if row_index == 0 {
+                lines.push(format!(
+                    "| {} |",
+                    cells.iter().map(|_| "---").collect::<Vec<_>>().join(" | ")
+                ));
+            }
+        }
+        if !lines.is_empty() {
+            parts.push(format!(
+                "### Table (page {})\n\n{}",
+                table.get("page").and_then(Value::as_u64).unwrap_or(0),
+                lines.join("\n")
+            ));
+        }
+    }
+    parts.join("\n\n")
+}
+
+fn render_structured_html(pages: &[crate::document_twin::PageText], tables: &Value) -> String {
+    let mut parts = pages
+        .iter()
+        .map(|page| {
+            format!(
+                "<section data-page=\"{}\"><pre>{}</pre></section>",
+                page.page,
+                html_escape(&page.text)
+            )
+        })
+        .collect::<Vec<_>>();
+    for table in tables.as_array().into_iter().flatten() {
+        let rows = table
+            .get("rows")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .map(|row| {
+                let cells = row
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .map(|cell| format!("<td>{}</td>", html_escape(cell.as_str().unwrap_or(""))))
+                    .collect::<String>();
+                format!("<tr>{cells}</tr>")
+            })
+            .collect::<String>();
+        parts.push(format!(
+            "<table data-page=\"{}\">{rows}</table>",
+            table.get("page").and_then(Value::as_u64).unwrap_or(0)
+        ));
+    }
+    parts.join("\n")
+}
+
+pub(crate) fn rebuild_structured_outputs(
+    data: &mut ReadPdfData,
+    context: &StructuredFusionContext,
+    tables: &Value,
+) {
+    use crate::document_twin::{
+        build_document_ast, build_document_map, build_elements_with_tables,
+    };
+
+    let elements = build_elements_with_tables(&context.pages, tables, context.semantic_hints);
+    let chunks = build_structured_chunks(&context.pages, &elements);
+    if context.emit_markdown {
+        data.markdown = Some(render_structured_markdown(&context.pages, tables));
+    }
+    if context.emit_html {
+        data.html = Some(render_structured_html(&context.pages, tables));
+    }
+    if context.emit_chunks {
+        data.chunks = Some(chunks.clone());
+    }
+    if context.emit_elements {
+        data.elements = Some(elements.clone());
+    }
+    if context.emit_tables {
+        data.tables = Some(tables.clone());
+    }
+    if context.emit_document_ast {
+        data.document_ast = Some(build_document_ast(&context.pages, &elements, tables));
+    }
+    if context.emit_document_map {
+        data.document_map = Some(build_document_map(
+            &context.pages,
+            &elements,
+            &chunks,
+            tables,
+            &context.safety,
+            &context.layout,
+            context.trust.as_ref(),
+            context.accessibility.as_ref(),
+        ));
+    }
+}
+
 fn build_data(
     pages: &[crate::document_twin::PageText],
     total_pages: u32,
@@ -478,7 +673,7 @@ fn build_data(
     } else {
         None
     };
-    let tables = if want_tables || want_ast || want_map {
+    let tables = if want_tables || want_ast || want_map || want_visual || want_trust {
         Some(build_tables(pages))
     } else {
         None
@@ -613,6 +808,24 @@ fn build_data(
         } else {
             Vec::new()
         },
+        structured_fusion_context: (want_ocr
+            && (want_tables || want_ast || want_map || want_visual || want_trust))
+            .then(|| StructuredFusionContext {
+                pages: pages.to_vec(),
+                selectable_tables: tables.clone().unwrap_or_else(|| json!([])),
+                semantic_hints: want_semantic || want_elements,
+                emit_markdown: want_md,
+                emit_html: want_html,
+                emit_chunks: want_chunks,
+                emit_elements: want_elements || want_semantic,
+                emit_tables: want_tables,
+                emit_document_ast: want_ast,
+                emit_document_map: want_map,
+                safety: safety.clone().unwrap_or_else(|| json!([])),
+                layout: layout.clone().unwrap_or_else(|| json!([])),
+                trust: trust.clone(),
+                accessibility: a11y.clone(),
+            }),
     };
 
     if want_meta {
@@ -797,6 +1010,10 @@ fn build_data(
     if want_visual {
         data.visual_enrichments = Some(json!([]));
         data.visual_enrichment_candidates = Some(json!([]));
+    }
+
+    if let Some(context) = data.structured_fusion_context.clone() {
+        rebuild_structured_outputs(&mut data, &context, &context.selectable_tables);
     }
 
     if !warnings.is_empty() {

--- a/docs/performance/why-rust.md
+++ b/docs/performance/why-rust.md
@@ -121,11 +121,13 @@ placeholder arrays prove only response shape; they do not prove capability.
 Visual `pdf_evidence` operations now have bounded Hayro render/crop plus opt-in
 command-provider OCR and region-analysis subsets. `read_pdf` can now select OCR
 pages, invoke that bounded command provider, return the normalized parallel OCR
-layer, link applied pages into `document_map`, and emit OCR MCP text parts. The
-immutable detached TS 3.0.14 differential covers this bounded fusion case.
-It remains partial: OCR-derived tables/AST, OCR TSV, region-analysis
-HTTP/presets, broader renderer fixtures, and full Document Twin fusion are
-open. Unavailable paths fail closed; this is not TS 3.0.14 parity.
+layer, link applied pages into `document_map`, emit OCR MCP text parts, and
+project one bounded boxed-word table subset through tables, elements, chunks,
+Markdown, HTML, AST, and map. The immutable detached TS 3.0.14 differential
+covers these bounded fusion cases. It remains partial: mixed selectable/OCR
+table continuation, full AST hierarchy, OCR TSV, region-analysis HTTP/presets,
+broader renderer fixtures, and full Document Twin fusion are open. Unavailable
+paths fail closed; this is not TS 3.0.14 parity.
 
 ## Install
 

--- a/docs/specs/2026-06-15-ocr-provider.md
+++ b/docs/specs/2026-06-15-ocr-provider.md
@@ -135,6 +135,10 @@ document without zero-text pages. The response includes:
   `document_map.pages[*]`.
 - `document_map.routing.ocr_applied_pages` for completed OCR pages.
 - Separate `[Page N OCR]` MCP text content parts for agent context.
+- When boxed OCR words form a table, table-derived elements, citation chunks,
+  Markdown, HTML, `document_ast`, and `document_map` are rebuilt from one
+  shared structured context; raw OCR prose is never promoted into those text
+  surfaces.
 
 Provider failures are reported as warnings on the source result instead of
 silently mixing incomplete OCR into selectable-text outputs.
@@ -166,6 +170,9 @@ silently mixing incomplete OCR into selectable-text outputs.
 - When `include_tables` is also enabled, OCR word boxes may produce
   OCR-derived table structure with provenance linking back to the source page
   render evidence.
+- The provider-neutral table detector is hard-bounded to 20 OCR pages, 50,000
+  words per page, and 512 tables; the public server's five-page default is
+  tighter.
 
 ## Follow-On Work
 

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -72,15 +72,15 @@
   },
   "claimedForDifferential": [
     "exact 10-case immutable TS v3.0.14 behavior subset: full text, page selection/order/duplicates, metadata, literal search, case sensitivity, whole word, Unicode, UTF-16 offsets, missing and malformed inputs, and mixed-source partial success",
-    "exact 15-case immutable TS v3.0.14 render/crop/command-provider semantic subset over stdio: defaults, page selection and warnings, region ordering, padding and fractional bounds, rotated pages, mixed-source and late-provider partial success, all-source failure, MCP image indexing, standalone OCR normalization, read_pdf OCR text-layer/map fusion, rich region-analysis normalization, plain-text truncation, and truthful provenance; exact pdf.js pixels and antialiasing are not claimed",
+    "exact 16-case immutable TS v3.0.14 render/crop/command-provider semantic subset over stdio: defaults, page selection and warnings, region ordering, padding and fractional bounds, rotated pages, mixed-source and late-provider partial success, all-source failure, MCP image indexing, standalone OCR normalization, read_pdf OCR text-layer/map fusion, boxed OCR table projection into elements/chunks/markdown/html/document_ast/document_map, rich region-analysis normalization, plain-text truncation, and truthful provenance; exact pdf.js pixels and antialiasing are not claimed",
     "DNS-pinned URL fetch: one resolution per redirect hop, reject mixed public/non-public answers, disable ambient proxies, and revalidate every redirect; still PARTIAL because resolver timeout and TLS-SNI fixtures remain open",
     "auto off when include_* keys are present"
   ],
   "explicitlyNotClaimed": [
     "complete TS 3.0.14 semantic parity outside the immutable 10-case subset",
     "text/search geometry, geometry-perfect pdf.js boxes, and general bounding-box parity",
-    "render/crop/OCR/analyze/read-fusion semantic parity outside the immutable 15-case subset, including exact pdf.js pixels and antialiasing",
-    "OCR success paths outside the opt-in command JSON/plain-text subset, including tesseract-tsv; OCR-derived table/document_ast fusion; analyze_regions HTTP and preset providers",
+    "render/crop/OCR/analyze/read-fusion/table-projection semantic parity outside the immutable 16-case subset, including exact pdf.js pixels and antialiasing",
+    "OCR success paths outside the opt-in command JSON/plain-text subset, including tesseract-tsv; mixed selectable/OCR table continuation and full AST hierarchy parity; analyze_regions HTTP and preset providers",
     "COS outline/annotations/forms",
     "cross-platform npm native binary",
     "npm library exports for pure-Rust",

--- a/scripts/differential/check-v3014-visual-differential.ts
+++ b/scripts/differential/check-v3014-visual-differential.ts
@@ -70,8 +70,8 @@ function verifyAuthority(): Record<string, string> {
     }
   }
   const ids = corpus.cases.map((entry) => entry.id);
-  if (ids.length !== 15 || new Set(ids).size !== ids.length) {
-    throw new Error(`visual/OCR/analysis corpus must contain 15 unique cases (got ${ids.length})`);
+  if (ids.length !== 16 || new Set(ids).size !== ids.length) {
+    throw new Error(`visual/OCR/analysis corpus must contain 16 unique cases (got ${ids.length})`);
   }
   if (sha256(readFileSync(providerPath)) !== oracle.providerSha256) {
     throw new Error('reference OCR provider digest mismatch');
@@ -154,6 +154,71 @@ function imageFacts(content: Content): Record<string, Json> {
   } as Record<string, Json>;
 }
 
+function tableProjectionFacts(
+  data: Record<string, unknown>,
+  map: Record<string, unknown> | undefined
+): Json {
+  const tables = (data.table_info ?? data.tables) as Array<Record<string, unknown>> | undefined;
+  const elements = (data.elements ?? []) as Array<Record<string, unknown>>;
+  const chunks = (data.chunks ?? []) as Array<Record<string, unknown>>;
+  const ast = data.document_ast as Record<string, unknown> | undefined;
+  if (!tables && !elements.some((element) => element.type === 'table') && !ast) return null;
+  return {
+    tables: (tables ?? []).map((table) => ({
+      page: table.page ?? null,
+      tableIndex: table.tableIndex ?? null,
+      rowCount: table.rowCount ?? null,
+      colCount: table.colCount ?? null,
+      cellCount:
+        table.cellCount ?? (Array.isArray(table.cells) ? table.cells.length : null),
+      provenance: (table.provenance ?? null) as Json,
+      quality: (table.quality ?? null) as Json,
+    })) as Json,
+    elements: elements
+      .filter((element) => element.type === 'table')
+      .map((element) => ({
+        id: element.id ?? null,
+        page: element.page ?? null,
+        provenance: (element.provenance ?? null) as Json,
+        rows: ((element.table as Record<string, unknown> | undefined)?.rows ?? null) as Json,
+      })) as Json,
+    chunks: chunks
+      .filter((chunk) => chunk.strategy === 'table')
+      .map((chunk) => ({
+        text: chunk.text ?? null,
+        element_ids: (chunk.element_ids ?? null) as Json,
+        strategy: chunk.strategy ?? null,
+      })) as Json,
+    markdown_has_table:
+      typeof data.markdown === 'string' && data.markdown.includes('| Metric | Value |'),
+    html_has_table: typeof data.html === 'string' && data.html.includes('<table'),
+    ast_table_count:
+      ((ast?.summary as Record<string, unknown> | undefined)?.table_count as Json) ?? null,
+    ast_has_ocr_table_provenance: JSON.stringify(ast ?? {}).includes(
+      '"source":"ocr_text_layer"'
+    ),
+    map: map
+      ? ({
+          has_table_structure:
+            Array.isArray(map.layers) && map.layers.includes('table_structure'),
+          has_citation_chunks:
+            Array.isArray(map.layers) && map.layers.includes('citation_chunks'),
+          page_table_count:
+            ((((map.pages as Array<Record<string, unknown>> | undefined) ?? [])[0]
+              ?.table_count as Json) ?? null),
+          table_element_sources: ((
+            (map.elements as Array<Record<string, unknown>> | undefined) ?? []
+          )
+            .filter((element) => element.type === 'table')
+            .map(
+              (element) =>
+                (element.provenance as Record<string, unknown> | undefined)?.source ?? null
+            ) as Json),
+        } as Json)
+      : null,
+  };
+}
+
 function canonicalize(result: ToolResult, tool?: 'read_pdf'): Json {
   if (result.isError) {
     return {
@@ -195,6 +260,7 @@ function canonicalize(result: ToolResult, tool?: 'read_pdf'): Json {
               ocr_text_chars: (map.summary as Record<string, unknown>)?.ocr_text_chars,
             }
           : null,
+        table_projection: tableProjectionFacts(data, map),
       };
     });
     return {

--- a/scripts/differential/fixtures/v3014-visual-corpus.json
+++ b/scripts/differential/fixtures/v3014-visual-corpus.json
@@ -150,6 +150,22 @@
       }
     },
     {
+      "id": "read-ocr-boxed-table-projection",
+      "tool": "read_pdf",
+      "input": {
+        "sources": [{ "fixture": "v3014-visual-v1.pdf", "pages": [3] }],
+        "auto": false,
+        "include_tables": true,
+        "include_elements": true,
+        "include_chunks": true,
+        "include_markdown": true,
+        "include_html": true,
+        "include_document_map": true,
+        "include_document_ast": true,
+        "include_ocr_text_layer": true
+      }
+    },
+    {
       "id": "analyze-command-rich-normalization",
       "input": {
         "operation": "analyze_regions",

--- a/scripts/differential/fixtures/v3014-visual-oracle.json
+++ b/scripts/differential/fixtures/v3014-visual-oracle.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "profile": "pdf_reader_v3014_visual_oracle",
-  "providerSha256": "86ab98b7ad9729da32b18326c728eaa3c87d33b2786c813b7e82e619db32c4b6",
+  "providerSha256": "256e0430fe3039637f67a12f4845dbaf66c94730f4a792dbc1d22131862dadf7",
   "regionProviderSha256": "7f766456549bb2e40547bf12340d62b86af507d479e84bfc911c2ebbaa47b5ba",
   "baseline": {
     "tag": "v3.0.14",
@@ -16,6 +16,9 @@
       "src/handlers/analyzeRegions.ts": "b84d5e9741ff8a6ea0ac37ee3b764ec94f08229662b51d0552f6ebddf3723dc8",
       "src/handlers/readPdf.ts": "1e7488cba29dc66ef8b6a86322d871ac3a3e5bf01981e9ab98a47ec4b0b1d5c4",
       "src/pdf/readCoordinator.ts": "827cb1018a8621287de154132c0a00a00188497b84622a168a343d0df3ce5eca",
+      "src/pdf/tableExtractor.ts": "ae21a6327349337efe6245ad391f3b94692c59bafb565f82c2bc8ed85cccecd4",
+      "src/pdf/documentModel.ts": "acb67cf9cb3c6373bd5a797fb8032cf8158943486853a2f59ac6486992264ef5",
+      "src/pdf/documentAst.ts": "f49272418eef6e412f0fc6a52daf82a6ad15d8a479a7fa6e387659624c6bbbd3",
       "src/pdf/ocr.ts": "9c2f89afb8426fea801501f7a2264a90e536609c7f5d64e7257945d4038041ee",
       "src/pdf/regionAnalysis.ts": "26ffb87a2af378665fdb59b9b9c8f6b9060b1015083da8c898479157bd1d80ef",
       "src/pdf/renderer.ts": "29cf9917feaa470d3e3dafea5b432439fe0450eaee90b350458fb1e41bfe75a8",
@@ -777,6 +780,173 @@
             ],
             "ocr_page_count": 1,
             "ocr_text_chars": 31
+          },
+          "table_projection": null
+        }
+      ]
+    },
+    "read-ocr-boxed-table-projection": {
+      "outcome": "success",
+      "content_ocr": [
+        "[Page 3 OCR]\nMetric Value\nRevenue 24%"
+      ],
+      "results": [
+        {
+          "source": "v3014-visual-v1.pdf",
+          "success": true,
+          "ocr_text_layer": {
+            "profile": "ocr_text_layer",
+            "pages": [
+              {
+                "page": 3,
+                "text": "Metric Value\nRevenue 24%",
+                "confidence": 0.87,
+                "words": [
+                  {
+                    "text": "Metric",
+                    "confidence": 0.93,
+                    "bounding_box": {
+                      "left": 40,
+                      "bottom": 700,
+                      "right": 88,
+                      "top": 710
+                    }
+                  },
+                  {
+                    "text": "Value",
+                    "confidence": 0.93,
+                    "bounding_box": {
+                      "left": 160,
+                      "bottom": 700,
+                      "right": 202,
+                      "top": 710
+                    }
+                  },
+                  {
+                    "text": "Revenue",
+                    "confidence": 0.93,
+                    "bounding_box": {
+                      "left": 40,
+                      "bottom": 680,
+                      "right": 100,
+                      "top": 690
+                    }
+                  },
+                  {
+                    "text": "24%",
+                    "confidence": 0.93,
+                    "bounding_box": {
+                      "left": 160,
+                      "bottom": 680,
+                      "right": 184,
+                      "top": 690
+                    }
+                  }
+                ],
+                "provider": "command",
+                "source_render_evidence_id": "page-3-render-scale-2",
+                "source_render_scale": 2,
+                "source_render_width": 160,
+                "source_render_height": 240,
+                "provenance": {
+                  "engine": "external-command",
+                  "source": "ocr-provider"
+                }
+              }
+            ],
+            "summary": {
+              "page_count": 1,
+              "text_chars": 24,
+              "word_count": 4,
+              "words_with_bounding_boxes": 4,
+              "source_render_count": 1,
+              "average_confidence": 0.87
+            },
+            "warnings": []
+          },
+          "document_map": {
+            "has_ocr_layer": true,
+            "needs_ocr_pages": [
+              3
+            ],
+            "ocr_applied_pages": [
+              3
+            ],
+            "ocr_page_count": 1,
+            "ocr_text_chars": 24
+          },
+          "table_projection": {
+            "tables": [
+              {
+                "page": 3,
+                "tableIndex": 0,
+                "rowCount": 2,
+                "colCount": 2,
+                "cellCount": 4,
+                "provenance": {
+                  "source": "ocr_text_layer",
+                  "engine": "external-command",
+                  "ocr_source_render_evidence_id": "page-3-render-scale-2"
+                },
+                "quality": {
+                  "completeness": 1,
+                  "nonEmptyCellRatio": 1,
+                  "cellBoundingBoxCoverage": 1,
+                  "inferredCellRatio": 0,
+                  "rowAlignment": 1,
+                  "rowSpacingConsistency": 1,
+                  "cellBoundingBoxCount": 4,
+                  "inferredCellCount": 0,
+                  "missingCellCount": 0,
+                  "mergedCellCandidateCount": 0,
+                  "signals": [
+                    "complete_grid"
+                  ]
+                }
+              }
+            ],
+            "elements": [
+              {
+                "id": "p3-table-1",
+                "page": 3,
+                "provenance": {
+                  "engine": "external-command",
+                  "source": "ocr-table-detector",
+                  "ocr_source_render_evidence_id": "page-3-render-scale-2"
+                },
+                "rows": [
+                  [
+                    "Metric",
+                    "Value"
+                  ],
+                  [
+                    "Revenue",
+                    "24%"
+                  ]
+                ]
+              }
+            ],
+            "chunks": [
+              {
+                "text": "Metric | Value\nRevenue | 24%",
+                "element_ids": [
+                  "p3-table-1"
+                ],
+                "strategy": "table"
+              }
+            ],
+            "markdown_has_table": true,
+            "html_has_table": true,
+            "ast_table_count": 1,
+            "ast_has_ocr_table_provenance": true,
+            "map": {
+              "has_table_structure": true,
+              "has_citation_chunks": true,
+              "page_table_count": 1,
+              "table_element_sources": [
+                "ocr-table-detector"
+              ]
+            }
           }
         }
       ]

--- a/scripts/differential/reference-ocr-provider.ts
+++ b/scripts/differential/reference-ocr-provider.ts
@@ -24,17 +24,34 @@ if (mode === 'escaped-descendant') {
 }
 const png = PNG.sync.read(readFileSync(input));
 
+const words =
+  page === '3'
+    ? [
+        ['Metric', 80, 1400, 176, 1420],
+        ['Value', 320, 1400, 404, 1420],
+        ['Revenue', 80, 1360, 200, 1380],
+        ['24%', 320, 1360, 368, 1380],
+      ].map(([text, left, bottom, right, top]) => ({
+        text,
+        confidence: 93,
+        bounding_box: { left, bottom, right, top },
+      }))
+    : [
+        {
+          text: 'Reference',
+          confidence: 91,
+          bounding_box: { left: 20, bottom: 10, right: 100, top: 30 },
+        },
+      ];
+
 process.stdout.write(
   JSON.stringify({
-    text: `Reference OCR page ${page} at ${String(png.width)}x${String(png.height)}`,
+    text:
+      page === '3'
+        ? 'Metric Value\nRevenue 24%'
+        : `Reference OCR page ${page} at ${String(png.width)}x${String(png.height)}`,
     confidence: 87,
-    words: [
-      {
-        text: 'Reference',
-        confidence: 91,
-        bounding_box: { left: 20, bottom: 10, right: 100, top: 30 },
-      },
-    ],
+    words,
     ...(languages ? { language: languages.split(',')[0] } : {}),
   })
 );

--- a/scripts/differential/v3014-visual-baseline-runner.ts
+++ b/scripts/differential/v3014-visual-baseline-runner.ts
@@ -84,6 +84,65 @@ function imageFacts(content: Content): Record<string, unknown> {
   };
 }
 
+function tableProjectionFacts(
+  data: Record<string, unknown>,
+  map: Record<string, unknown> | undefined
+): Record<string, unknown> | null {
+  const tables = (data.table_info ?? data.tables) as Array<Record<string, unknown>> | undefined;
+  const elements = (data.elements ?? []) as Array<Record<string, unknown>>;
+  const chunks = (data.chunks ?? []) as Array<Record<string, unknown>>;
+  const ast = data.document_ast as Record<string, unknown> | undefined;
+  if (!tables && !elements.some((element) => element.type === 'table') && !ast) return null;
+  return {
+    tables: (tables ?? []).map((table) => ({
+      page: table.page,
+      tableIndex: table.tableIndex,
+      rowCount: table.rowCount,
+      colCount: table.colCount,
+      cellCount:
+        table.cellCount ??
+        (Array.isArray(table.cells) ? table.cells.length : undefined),
+      provenance: table.provenance,
+      quality: table.quality,
+    })),
+    elements: elements
+      .filter((element) => element.type === 'table')
+      .map((element) => ({
+        id: element.id,
+        page: element.page,
+        provenance: element.provenance,
+        rows: (element.table as Record<string, unknown>)?.rows,
+      })),
+    chunks: chunks
+      .filter((chunk) => chunk.strategy === 'table')
+      .map((chunk) => ({
+        text: chunk.text,
+        element_ids: chunk.element_ids,
+        strategy: chunk.strategy,
+      })),
+    markdown_has_table:
+      typeof data.markdown === 'string' && data.markdown.includes('| Metric | Value |'),
+    html_has_table: typeof data.html === 'string' && data.html.includes('<table'),
+    ast_table_count: (ast?.summary as Record<string, unknown> | undefined)?.table_count,
+    ast_has_ocr_table_provenance: JSON.stringify(ast ?? {}).includes(
+      '"source":"ocr_text_layer"'
+    ),
+    map: map
+      ? {
+          has_table_structure:
+            Array.isArray(map.layers) && map.layers.includes('table_structure'),
+          has_citation_chunks:
+            Array.isArray(map.layers) && map.layers.includes('citation_chunks'),
+          page_table_count: ((map.pages as Array<Record<string, unknown>> | undefined) ?? [])[0]
+            ?.table_count,
+          table_element_sources: ((map.elements as Array<Record<string, unknown>> | undefined) ?? [])
+            .filter((element) => element.type === 'table')
+            .map((element) => (element.provenance as Record<string, unknown> | undefined)?.source),
+        }
+      : null,
+  };
+}
+
 function canonicalize(result: ToolResult, tool?: 'read_pdf'): Record<string, unknown> {
   if (result.isError) {
     const message = result.content[0]?.text ?? '';
@@ -123,6 +182,7 @@ function canonicalize(result: ToolResult, tool?: 'read_pdf'): Record<string, unk
               ocr_text_chars: (map.summary as Record<string, unknown>)?.ocr_text_chars,
             }
           : null,
+        table_projection: tableProjectionFacts(data, map),
       };
     });
     return {

--- a/scripts/run-pdf-reader-differential.sh
+++ b/scripts/run-pdf-reader-differential.sh
@@ -77,7 +77,7 @@ echo "--- deterministic v3.0.14 visual fixture + baseline replay ---" | tee -a "
 bun "$REPO_ROOT/scripts/differential/generate-v3014-visual-fixtures.ts" 2>&1 | tee -a "$LOG"
 bun "$REPO_ROOT/scripts/differential/capture-v3014-visual-oracle.ts" 2>&1 | tee -a "$LOG"
 
-echo "--- immutable v3.0.14 render/crop/OCR/analyze/read-fusion differential (15 semantic cases) ---" | tee -a "$LOG"
+echo "--- immutable v3.0.14 render/crop/OCR/analyze/read-fusion differential (16 semantic cases) ---" | tee -a "$LOG"
 bun "$REPO_ROOT/scripts/differential/check-v3014-visual-differential.ts" \
   --output "$V3014_VISUAL_JSON" >>"$LOG"
 
@@ -191,7 +191,7 @@ jq -n \
     immutableVisualDifferential: "scripts/differential/check-v3014-visual-differential.ts",
     liveTextOracle: "scripts/differential/ts-vs-rust-text-oracle.ts",
     structuralConsistencyOracle: "scripts/differential/pdf-reader-mcp-oracle.ts",
-    nonClaims: ["full TS 3.0.14 behavioral parity", "visual/provider parity outside the immutable 15-case render/crop/OCR/analyze/read-fusion corpus", "Tesseract TSV parity", "OCR-derived table/document_ast fusion", "analyze_regions HTTP/preset provider parity", "Document Twin semantic parity"],
+    nonClaims: ["full TS 3.0.14 behavioral parity", "visual/provider parity outside the immutable 16-case render/crop/OCR/analyze/read-fusion/table-projection corpus", "Tesseract TSV parity", "mixed selectable/OCR table continuation and full AST hierarchy parity", "analyze_regions HTTP/preset provider parity", "Document Twin semantic parity"],
     retirementGate: "scripts/check-no-ts-stdio-backend.sh (runs only when dropInFor3014=true)"
   }' >"$ARTIFACT"
 


### PR DESCRIPTION
## Outcome

Adds a bounded immutable-TS-backed boxed OCR table projection to the pure-Rust read_pdf path. Publication remains frozen and overall TS 3.0.14 drop-in parity remains false.

## Contract

- extracts tables only from nonblank OCR words with valid PDF-coordinate boxes
- preserves raw OCR as a parallel layer; never promotes OCR prose into selectable text
- merges selectable and OCR table evidence with same-page overlap dedupe, reindexing, ordering, and continuation-ID rebasing
- rebuilds tables, table elements, standalone table chunks, Markdown, HTML, document_ast, and document_map through one hidden typed reconstruction context
- rolls structured outputs back to the selectable baseline after a later provider failure or no-op
- caps table work at 20 OCR pages, 50,000 words per page, and 512 tables

## Evidence

- immutable TS authority: 92651c79c6ce8d10dfa3c76332176c26f222bd78
- exact candidate: 24736b9b73a065339f1e20564de2b0faf7705283
- detached visual/provider/read/table differential: 16/16 passed, 0 skipped
- full bounded differential artifact is SHA-bound to the exact candidate
- Rust core: 63 passed; server: 30 passed; workspace tests green
- TypeScript typecheck and published 3.0.14 production contract green
- clippy -D warnings, fmt, matrix, and diff-check green
- independent adversarial review: PASS, confidence 0.96

## Non-claims

- dropInFor3014 remains false
- publishFreeze remains true
- no claim of Tesseract TSV parity, mixed selectable/OCR continuation parity, full AST hierarchy/caption parity, broad Document Twin parity, cross-platform npm packaging, or final A/B benchmark

Release must remain blocked at the explicit publish-freeze gate.