### PR TITLE
feat(rust): add exact COS page signals slice

### DIFF
--- a/.github/workflows/rust-parity-differential.yml
+++ b/.github/workflows/rust-parity-differential.yml
@@ -134,7 +134,7 @@ jobs:
           jq -e --arg sha "$CANDIDATE_SHA" '
             .profile == "pdf_reader_v3014_behavior_result" and
             .candidateSha == $sha and .pass == true and
-            .caseCount == 10 and .passed == 10 and .skipped == 0
+            .caseCount == 11 and .passed == 11 and .skipped == 0
           ' "$BEHAVIOR_ARTIFACT" >/dev/null || {
             echo "::error::v3.0.14 behavior result is incomplete, failing, or not SHA-bound"
             exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,6 +1302,7 @@ version = "3.1.1"
 dependencies = [
  "hayro",
  "image",
+ "lopdf",
  "pdf-extract",
  "serde",
  "serde_json",

--- a/crates/pdf-reader-core/Cargo.toml
+++ b/crates/pdf-reader-core/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/lib.rs"
 [dependencies]
 hayro = "0.7.1"
 image = { version = "0.25", default-features = false, features = ["png"] }
+lopdf = { version = "0.36", default-features = false }
 pdf-extract = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/pdf-reader-core/src/cos_document.rs
+++ b/crates/pdf-reader-core/src/cos_document.rs
@@ -1,0 +1,78 @@
+use std::fs;
+use std::path::Path;
+
+use lopdf::{Document, ObjectId};
+use sha2::{Digest, Sha256};
+
+use crate::text_index::{TextIndexError, TextIndexErrorCode};
+
+pub(crate) struct ParsedPdf {
+    pub document: Document,
+    pub pages: Vec<(u32, ObjectId)>,
+    #[allow(dead_code)]
+    pub source_hash: String,
+}
+
+impl ParsedPdf {
+    pub fn load(path: &Path, max_file_bytes: u64) -> Result<Self, TextIndexError> {
+        let metadata = fs::metadata(path).map_err(|error| invalid_request(path, error))?;
+        if !metadata.is_file() {
+            return Err(request_error(format!(
+                "Path '{}' is not a regular file.",
+                path.display()
+            )));
+        }
+        if metadata.len() > max_file_bytes {
+            return Err(request_error(format!(
+                "File exceeds maximum size of {max_file_bytes} bytes."
+            )));
+        }
+        let bytes = fs::read(path).map_err(|error| {
+            request_error(format!(
+                "Failed to read PDF bytes at '{}': {error}",
+                path.display()
+            ))
+        })?;
+        if bytes.len() as u64 > max_file_bytes {
+            return Err(request_error(format!(
+                "File exceeds maximum size of {max_file_bytes} bytes."
+            )));
+        }
+        let source_hash = format!("{:x}", Sha256::digest(&bytes));
+        let mut document = Document::load_mem(&bytes).map_err(extraction_error)?;
+        if document.is_encrypted() {
+            document.decrypt("").map_err(|error| {
+                extraction_error(format!(
+                    "encrypted PDF requires a supported password: {error}"
+                ))
+            })?;
+        }
+        let pages = document.get_pages().into_iter().collect();
+        Ok(Self {
+            document,
+            pages,
+            source_hash,
+        })
+    }
+}
+
+fn invalid_request(path: &Path, error: std::io::Error) -> TextIndexError {
+    request_error(format!(
+        "Unable to access file at '{}': {error}",
+        path.display()
+    ))
+}
+
+fn request_error(message: String) -> TextIndexError {
+    TextIndexError {
+        code: TextIndexErrorCode::InvalidRequest,
+        message,
+    }
+}
+
+fn extraction_error(error: impl std::fmt::Display) -> TextIndexError {
+    TextIndexError {
+        code: TextIndexErrorCode::ExtractionFailed,
+        message: format!("Failed to extract PDF: {error}"),
+    }
+}

--- a/crates/pdf-reader-core/src/cos_document.rs
+++ b/crates/pdf-reader-core/src/cos_document.rs
@@ -1,4 +1,5 @@
-use std::fs;
+use std::fs::File;
+use std::io::Read;
 use std::path::Path;
 
 use lopdf::{Document, ObjectId};
@@ -15,7 +16,10 @@ pub(crate) struct ParsedPdf {
 
 impl ParsedPdf {
     pub fn load(path: &Path, max_file_bytes: u64) -> Result<Self, TextIndexError> {
-        let metadata = fs::metadata(path).map_err(|error| invalid_request(path, error))?;
+        let file = File::open(path).map_err(|error| invalid_request(path, error))?;
+        let metadata = file
+            .metadata()
+            .map_err(|error| invalid_request(path, error))?;
         if !metadata.is_file() {
             return Err(request_error(format!(
                 "Path '{}' is not a regular file.",
@@ -27,12 +31,16 @@ impl ParsedPdf {
                 "File exceeds maximum size of {max_file_bytes} bytes."
             )));
         }
-        let bytes = fs::read(path).map_err(|error| {
-            request_error(format!(
-                "Failed to read PDF bytes at '{}': {error}",
-                path.display()
-            ))
-        })?;
+        let mut bytes =
+            Vec::with_capacity(usize::try_from(metadata.len().min(max_file_bytes)).unwrap_or(0));
+        file.take(max_file_bytes.saturating_add(1))
+            .read_to_end(&mut bytes)
+            .map_err(|error| {
+                request_error(format!(
+                    "Failed to read PDF bytes at '{}': {error}",
+                    path.display()
+                ))
+            })?;
         if bytes.len() as u64 > max_file_bytes {
             return Err(request_error(format!(
                 "File exceeds maximum size of {max_file_bytes} bytes."

--- a/crates/pdf-reader-core/src/lib.rs
+++ b/crates/pdf-reader-core/src/lib.rs
@@ -1,10 +1,12 @@
 //! Rust hashing, SSRF-safe fetch, and text-index primitives for pdf-reader-mcp.
 
+mod cos_document;
 pub mod document_twin;
 pub mod legacy;
 pub mod ocr_fusion;
 pub mod ocr_tables;
 pub mod page_cache;
+mod page_signals;
 pub mod read_pdf;
 pub mod render;
 pub mod search_pdf;

--- a/crates/pdf-reader-core/src/page_signals.rs
+++ b/crates/pdf-reader-core/src/page_signals.rs
@@ -10,6 +10,27 @@ const MAX_ANNOTATIONS_PER_SOURCE: usize = 10_000;
 const MAX_STRING_BYTES: usize = 64 * 1024;
 const MAX_SIGNAL_TEXT_BYTES: usize = 2 * 1024 * 1024;
 
+struct SignalTextBudget {
+    remaining: usize,
+    truncated: bool,
+}
+
+impl SignalTextBudget {
+    fn consume(&mut self, bytes: usize) -> bool {
+        if bytes > self.remaining {
+            self.truncated = true;
+            false
+        } else {
+            self.remaining -= bytes;
+            true
+        }
+    }
+
+    fn reject_oversized(&mut self) {
+        self.truncated = true;
+    }
+}
+
 #[derive(Default)]
 pub(crate) struct PageSignals {
     pub geometry: Vec<Value>,
@@ -27,7 +48,10 @@ pub(crate) fn extract_page_signals(
     let mut signals = PageSignals::default();
     let selected: HashSet<u32> = selected_pages.iter().copied().collect();
     let mut annotation_work = 0usize;
-    let mut text_budget = MAX_SIGNAL_TEXT_BYTES;
+    let mut text_budget = SignalTextBudget {
+        remaining: MAX_SIGNAL_TEXT_BYTES,
+        truncated: false,
+    };
     for (page, page_id) in pages {
         if !selected.contains(page) {
             continue;
@@ -64,16 +88,20 @@ pub(crate) fn extract_page_signals(
             "include_annotations: source reached the {MAX_ANNOTATIONS_PER_SOURCE} annotation work limit."
         ));
     }
+    if want_annotations && text_budget.truncated {
+        signals.warnings.push(format!(
+            "include_annotations: annotation strings exceeded the {MAX_STRING_BYTES}-byte field or {MAX_SIGNAL_TEXT_BYTES}-byte source text limit."
+        ));
+    }
     signals
 }
 
 fn page_geometry(document: &Document, page: u32, page_id: ObjectId) -> Option<Value> {
     let media = inherited_array(document, page_id, b"MediaBox")
-        .and_then(|value| box_values(document, value))
-        .map(normalize_box)
+        .and_then(|value| page_box_values(document, value))
         .unwrap_or([0.0, 0.0, 612.0, 792.0]);
     let crop = inherited_array(document, page_id, b"CropBox")
-        .and_then(|value| box_values(document, value))
+        .and_then(|value| page_box_values(document, value))
         .and_then(|crop| intersect_boxes(media, crop))
         .unwrap_or(media);
     let raw_rotation = inherited_number(document, page_id, b"Rotate").unwrap_or(0.0);
@@ -119,7 +147,7 @@ fn page_annotations(
     page: u32,
     page_id: ObjectId,
     limit: usize,
-    text_budget: &mut usize,
+    text_budget: &mut SignalTextBudget,
 ) -> (Vec<Value>, bool, usize) {
     let Some(annots) = inherited_array(document, page_id, b"Annots") else {
         return (Vec::new(), false, 0);
@@ -141,7 +169,7 @@ fn normalize_annotation(
     document: &Document,
     page: u32,
     value: &Object,
-    text_budget: &mut usize,
+    text_budget: &mut SignalTextBudget,
 ) -> Option<Value> {
     let id = match value {
         Object::Reference((object, generation)) => Some(if *generation == 0 {
@@ -278,6 +306,15 @@ fn box_values(document: &Document, value: &Object) -> Option<[f64; 4]> {
         .then_some(parsed)
 }
 
+fn page_box_values(document: &Document, value: &Object) -> Option<[f64; 4]> {
+    let values = resolve(document, value).ok()?.as_array().ok()?;
+    if values.len() != 4 {
+        return None;
+    }
+    let value = normalize_box(box_values(document, value)?);
+    (value[0] < value[2] && value[1] < value[3]).then_some(value)
+}
+
 fn number(value: &Object) -> Option<f64> {
     match value {
         Object::Integer(value) => Some(*value as f64),
@@ -307,35 +344,47 @@ fn normalize_box(value: [f64; 4]) -> [f64; 4] {
     ]
 }
 
-fn bounded_name(value: &Object, budget: &mut usize) -> Option<String> {
+fn bounded_name(value: &Object, budget: &mut SignalTextBudget) -> Option<String> {
     let bytes = value.as_name().ok()?;
-    if bytes.len() > MAX_STRING_BYTES || bytes.len() > *budget {
+    if bytes.len() > MAX_STRING_BYTES {
+        budget.reject_oversized();
         return None;
     }
     let decoded = String::from_utf8_lossy(bytes).into_owned();
-    if decoded.len() > *budget {
+    if !budget.consume(decoded.len()) {
         return None;
     }
-    *budget -= decoded.len();
     Some(decoded)
 }
 
-fn decoded_string(document: &Document, value: &Object, budget: &mut usize) -> Option<String> {
+fn decoded_string(
+    document: &Document,
+    value: &Object,
+    budget: &mut SignalTextBudget,
+) -> Option<String> {
     let value = resolve(document, value).ok()?;
     if let Object::String(bytes, _) = value {
-        if bytes.len() > MAX_STRING_BYTES || bytes.len() > *budget {
+        if bytes.len() > MAX_STRING_BYTES {
+            budget.reject_oversized();
             return None;
         }
     }
     let decoded = decode_text_string(value).ok()?;
-    if decoded.len() > MAX_STRING_BYTES || decoded.len() > *budget {
+    if decoded.len() > MAX_STRING_BYTES {
+        budget.reject_oversized();
         return None;
     }
-    *budget -= decoded.len();
+    if !budget.consume(decoded.len()) {
+        return None;
+    }
     Some(decoded)
 }
 
-fn destination(document: &Document, value: &Object, budget: &mut usize) -> Option<Value> {
+fn destination(
+    document: &Document,
+    value: &Object,
+    budget: &mut SignalTextBudget,
+) -> Option<Value> {
     let value = resolve(document, value).ok()?;
     match value {
         Object::String(_, _) => decoded_string(document, value, budget).map(Value::String),
@@ -448,9 +497,15 @@ mod tests {
                 "MediaBox" => vec![0.into(), 0.into(), 200.into(), 300.into()],
                 "Rotate" => -90,
             },
+            dictionary! { "MediaBox" => vec![0.into(), 0.into(), 0.into(), 0.into()] },
+            dictionary! { "MediaBox" => vec![0.into(), 0.into(), 200.into(), 300.into(), 999.into()] },
+            dictionary! {
+                "MediaBox" => vec![0.into(), 0.into(), 200.into(), 300.into()],
+                "CropBox" => vec![10.into(), 10.into(), 10.into(), 20.into()],
+            },
         ]);
         let pages = document.get_pages().into_iter().collect::<Vec<_>>();
-        let signals = extract_page_signals(&document, &pages, &[1, 2, 3, 4], true, false);
+        let signals = extract_page_signals(&document, &pages, &[1, 2, 3, 4, 5, 6, 7], true, false);
         assert_eq!(
             signals.geometry,
             vec![
@@ -458,6 +513,9 @@ mod tests {
                 json!({"page":2,"width":612.0,"height":792.0,"rotation":0.0,"user_unit":1.0,"view_box":{"left":0.0,"bottom":0.0,"right":612.0,"top":792.0}}),
                 json!({"page":3,"width":200.0,"height":300.0,"rotation":0.0,"user_unit":1.0,"view_box":{"left":0.0,"bottom":0.0,"right":200.0,"top":300.0}}),
                 json!({"page":4,"width":300.0,"height":200.0,"rotation":270.0,"user_unit":1.0,"view_box":{"left":0.0,"bottom":0.0,"right":200.0,"top":300.0}}),
+                json!({"page":5,"width":612.0,"height":792.0,"rotation":0.0,"user_unit":1.0,"view_box":{"left":0.0,"bottom":0.0,"right":612.0,"top":792.0}}),
+                json!({"page":6,"width":612.0,"height":792.0,"rotation":0.0,"user_unit":1.0,"view_box":{"left":0.0,"bottom":0.0,"right":612.0,"top":792.0}}),
+                json!({"page":7,"width":200.0,"height":300.0,"rotation":0.0,"user_unit":1.0,"view_box":{"left":0.0,"bottom":0.0,"right":200.0,"top":300.0}}),
             ]
         );
     }
@@ -477,6 +535,27 @@ mod tests {
         assert!(signals.annotations.is_empty());
         assert_eq!(signals.warnings, vec![format!(
             "include_annotations: source reached the {MAX_ANNOTATIONS_PER_SOURCE} annotation work limit."
+        )]);
+    }
+
+    #[test]
+    fn oversized_annotation_strings_are_omitted_with_a_warning() {
+        let annotation = Object::Dictionary(dictionary! {
+            "Subtype" => "Text",
+            "Contents" => Object::string_literal("x".repeat(MAX_STRING_BYTES + 1)),
+        });
+        let document = document_with_pages(vec![dictionary! {
+            "MediaBox" => vec![0.into(), 0.into(), 100.into(), 100.into()],
+            "Annots" => vec![annotation],
+        }]);
+        let pages = document.get_pages().into_iter().collect::<Vec<_>>();
+        let signals = extract_page_signals(&document, &pages, &[1], false, true);
+        assert_eq!(signals.annotations[0]["annotations"][0]["subtype"], "Text");
+        assert!(signals.annotations[0]["annotations"][0]
+            .get("contents")
+            .is_none());
+        assert_eq!(signals.warnings, vec![format!(
+            "include_annotations: annotation strings exceeded the {MAX_STRING_BYTES}-byte field or {MAX_SIGNAL_TEXT_BYTES}-byte source text limit."
         )]);
     }
 }

--- a/crates/pdf-reader-core/src/page_signals.rs
+++ b/crates/pdf-reader-core/src/page_signals.rs
@@ -13,11 +13,33 @@ const MAX_SIGNAL_TEXT_BYTES: usize = 2 * 1024 * 1024;
 struct SignalTextBudget {
     remaining: usize,
     truncated: bool,
+    #[cfg(test)]
+    decode_attempts: usize,
 }
 
 impl SignalTextBudget {
+    fn new() -> Self {
+        Self {
+            remaining: MAX_SIGNAL_TEXT_BYTES,
+            truncated: false,
+            #[cfg(test)]
+            decode_attempts: 0,
+        }
+    }
+
+    fn admit_raw(&mut self, bytes: usize) -> bool {
+        if self.remaining == 0 || bytes > self.remaining {
+            self.remaining = 0;
+            self.truncated = true;
+            false
+        } else {
+            true
+        }
+    }
+
     fn consume(&mut self, bytes: usize) -> bool {
         if bytes > self.remaining {
+            self.remaining = 0;
             self.truncated = true;
             false
         } else {
@@ -48,10 +70,7 @@ pub(crate) fn extract_page_signals(
     let mut signals = PageSignals::default();
     let selected: HashSet<u32> = selected_pages.iter().copied().collect();
     let mut annotation_work = 0usize;
-    let mut text_budget = SignalTextBudget {
-        remaining: MAX_SIGNAL_TEXT_BYTES,
-        truncated: false,
-    };
+    let mut text_budget = SignalTextBudget::new();
     for (page, page_id) in pages {
         if !selected.contains(page) {
             continue;
@@ -350,6 +369,9 @@ fn bounded_name(value: &Object, budget: &mut SignalTextBudget) -> Option<String>
         budget.reject_oversized();
         return None;
     }
+    if !budget.admit_raw(bytes.len()) {
+        return None;
+    }
     let decoded = String::from_utf8_lossy(bytes).into_owned();
     if !budget.consume(decoded.len()) {
         return None;
@@ -368,6 +390,13 @@ fn decoded_string(
             budget.reject_oversized();
             return None;
         }
+        if !budget.admit_raw(bytes.len()) {
+            return None;
+        }
+    }
+    #[cfg(test)]
+    {
+        budget.decode_attempts += 1;
     }
     let decoded = decode_text_string(value).ok()?;
     if decoded.len() > MAX_STRING_BYTES {
@@ -557,5 +586,21 @@ mod tests {
         assert_eq!(signals.warnings, vec![format!(
             "include_annotations: annotation strings exceeded the {MAX_STRING_BYTES}-byte field or {MAX_SIGNAL_TEXT_BYTES}-byte source text limit."
         )]);
+    }
+
+    #[test]
+    fn aggregate_text_exhaustion_stops_later_decode_attempts() {
+        let document = Document::with_version("1.7");
+        let chunk = Object::string_literal("x".repeat(MAX_STRING_BYTES));
+        let sentinel = Object::string_literal("must-not-decode");
+        let mut budget = SignalTextBudget::new();
+        for _ in 0..(MAX_SIGNAL_TEXT_BYTES / MAX_STRING_BYTES) {
+            assert!(decoded_string(&document, &chunk, &mut budget).is_some());
+        }
+        assert_eq!(budget.remaining, 0);
+        assert_eq!(budget.decode_attempts, 32);
+        assert!(decoded_string(&document, &sentinel, &mut budget).is_none());
+        assert_eq!(budget.decode_attempts, 32);
+        assert!(budget.truncated);
     }
 }

--- a/crates/pdf-reader-core/src/page_signals.rs
+++ b/crates/pdf-reader-core/src/page_signals.rs
@@ -8,6 +8,7 @@ const MAX_PARENT_DEPTH: usize = 64;
 const MAX_ANNOTATIONS_PER_PAGE: usize = 1_000;
 const MAX_ANNOTATIONS_PER_SOURCE: usize = 10_000;
 const MAX_STRING_BYTES: usize = 64 * 1024;
+const MAX_SIGNAL_TEXT_BYTES: usize = 2 * 1024 * 1024;
 
 #[derive(Default)]
 pub(crate) struct PageSignals {
@@ -25,7 +26,8 @@ pub(crate) fn extract_page_signals(
 ) -> PageSignals {
     let mut signals = PageSignals::default();
     let selected: HashSet<u32> = selected_pages.iter().copied().collect();
-    let mut annotation_count = 0usize;
+    let mut annotation_work = 0usize;
+    let mut text_budget = MAX_SIGNAL_TEXT_BYTES;
     for (page, page_id) in pages {
         if !selected.contains(page) {
             continue;
@@ -35,14 +37,15 @@ pub(crate) fn extract_page_signals(
                 signals.geometry.push(value);
             }
         }
-        if want_annotations && annotation_count < MAX_ANNOTATIONS_PER_SOURCE {
-            let (annotations, truncated) = page_annotations(
+        if want_annotations && annotation_work < MAX_ANNOTATIONS_PER_SOURCE {
+            let (annotations, truncated, inspected) = page_annotations(
                 document,
                 *page,
                 *page_id,
-                (MAX_ANNOTATIONS_PER_SOURCE - annotation_count).min(MAX_ANNOTATIONS_PER_PAGE),
+                (MAX_ANNOTATIONS_PER_SOURCE - annotation_work).min(MAX_ANNOTATIONS_PER_PAGE),
+                &mut text_budget,
             );
-            annotation_count += annotations.len();
+            annotation_work += inspected;
             if !annotations.is_empty() {
                 signals.annotations.push(json!({
                     "page": page,
@@ -56,30 +59,37 @@ pub(crate) fn extract_page_signals(
             }
         }
     }
-    if want_annotations && annotation_count >= MAX_ANNOTATIONS_PER_SOURCE {
+    if want_annotations && annotation_work >= MAX_ANNOTATIONS_PER_SOURCE {
         signals.warnings.push(format!(
-            "include_annotations: source exceeded the {MAX_ANNOTATIONS_PER_SOURCE} annotation limit."
+            "include_annotations: source reached the {MAX_ANNOTATIONS_PER_SOURCE} annotation work limit."
         ));
     }
     signals
 }
 
 fn page_geometry(document: &Document, page: u32, page_id: ObjectId) -> Option<Value> {
-    let media = inherited_array(document, page_id, b"MediaBox")?;
-    let media = box_values(document, media)?;
+    let media = inherited_array(document, page_id, b"MediaBox")
+        .and_then(|value| box_values(document, value))
+        .map(normalize_box)
+        .unwrap_or([0.0, 0.0, 612.0, 792.0]);
     let crop = inherited_array(document, page_id, b"CropBox")
         .and_then(|value| box_values(document, value))
         .and_then(|crop| intersect_boxes(media, crop))
         .unwrap_or(media);
-    let rotation = inherited_number(document, page_id, b"Rotate")
-        .unwrap_or(0.0)
-        .rem_euclid(360.0);
+    let raw_rotation = inherited_number(document, page_id, b"Rotate").unwrap_or(0.0);
+    let rotation = if raw_rotation.is_finite() && raw_rotation.rem_euclid(90.0) == 0.0 {
+        raw_rotation.rem_euclid(360.0)
+    } else {
+        0.0
+    };
     // PDF.js exposes page.userUnit from the page dictionary itself; unlike
     // MediaBox/CropBox/Rotate, a Pages-node UserUnit is not inherited there.
-    let user_unit = page_number(document, page_id, b"UserUnit").unwrap_or(1.0);
-    if !user_unit.is_finite() || user_unit <= 0.0 {
-        return None;
-    }
+    let raw_user_unit = page_number(document, page_id, b"UserUnit").unwrap_or(1.0);
+    let user_unit = if raw_user_unit.is_finite() && raw_user_unit > 0.0 {
+        raw_user_unit
+    } else {
+        1.0
+    };
     let base_width = (crop[2] - crop[0]).abs() * user_unit;
     let base_height = (crop[3] - crop[1]).abs() * user_unit;
     let quarter_turn =
@@ -109,23 +119,30 @@ fn page_annotations(
     page: u32,
     page_id: ObjectId,
     limit: usize,
-) -> (Vec<Value>, bool) {
+    text_budget: &mut usize,
+) -> (Vec<Value>, bool, usize) {
     let Some(annots) = inherited_array(document, page_id, b"Annots") else {
-        return (Vec::new(), false);
+        return (Vec::new(), false, 0);
     };
     let Ok(values) = resolve(document, annots).and_then(Object::as_array) else {
-        return (Vec::new(), false);
+        return (Vec::new(), false, 0);
     };
     let truncated = values.len() > limit;
+    let inspected = values.len().min(limit);
     let annotations = values
         .iter()
         .take(limit)
-        .filter_map(|value| normalize_annotation(document, page, value))
+        .filter_map(|value| normalize_annotation(document, page, value, text_budget))
         .collect();
-    (annotations, truncated)
+    (annotations, truncated, inspected)
 }
 
-fn normalize_annotation(document: &Document, page: u32, value: &Object) -> Option<Value> {
+fn normalize_annotation(
+    document: &Document,
+    page: u32,
+    value: &Object,
+    text_budget: &mut usize,
+) -> Option<Value> {
     let id = match value {
         Object::Reference((object, generation)) => Some(if *generation == 0 {
             format!("{object}R")
@@ -135,15 +152,15 @@ fn normalize_annotation(document: &Document, page: u32, value: &Object) -> Optio
         _ => None,
     };
     let dict = resolve(document, value).ok()?.as_dict().ok()?;
-    let subtype = name_value(dict.get(b"Subtype").ok()?);
+    let subtype = bounded_name(dict.get(b"Subtype").ok()?, text_budget);
     let contents = dict
         .get(b"Contents")
         .ok()
-        .and_then(|value| decoded_string(document, value));
+        .and_then(|value| decoded_string(document, value, text_budget));
     let title = dict
         .get(b"T")
         .ok()
-        .and_then(|value| decoded_string(document, value));
+        .and_then(|value| decoded_string(document, value, text_budget));
     let rect = dict
         .get(b"Rect")
         .ok()
@@ -151,15 +168,17 @@ fn normalize_annotation(document: &Document, page: u32, value: &Object) -> Optio
     let dest = dict
         .get(b"Dest")
         .ok()
-        .and_then(|value| destination(document, value));
+        .and_then(|value| destination(document, value, text_budget));
     let url = dict
         .get(b"A")
         .ok()
         .and_then(|value| resolve(document, value).ok())
         .and_then(|value| value.as_dict().ok())
-        .filter(|action| action.get(b"S").ok().and_then(name_value).as_deref() == Some("URI"))
+        .filter(|action| {
+            action.get(b"S").ok().and_then(|value| value.as_name().ok()) == Some(b"URI")
+        })
         .and_then(|action| action.get(b"URI").ok())
-        .and_then(|value| decoded_string(document, value));
+        .and_then(|value| decoded_string(document, value, text_budget));
 
     if id.is_none()
         && subtype.is_none()
@@ -268,18 +287,8 @@ fn number(value: &Object) -> Option<f64> {
 }
 
 fn intersect_boxes(a: [f64; 4], b: [f64; 4]) -> Option<[f64; 4]> {
-    let a = [
-        a[0].min(a[2]),
-        a[1].min(a[3]),
-        a[0].max(a[2]),
-        a[1].max(a[3]),
-    ];
-    let b = [
-        b[0].min(b[2]),
-        b[1].min(b[3]),
-        b[0].max(b[2]),
-        b[1].max(b[3]),
-    ];
+    let a = normalize_box(a);
+    let b = normalize_box(b);
     let value = [
         a[0].max(b[0]),
         a[1].max(b[1]),
@@ -289,31 +298,57 @@ fn intersect_boxes(a: [f64; 4], b: [f64; 4]) -> Option<[f64; 4]> {
     (value[0] < value[2] && value[1] < value[3]).then_some(value)
 }
 
-fn name_value(value: &Object) -> Option<String> {
-    value
-        .as_name()
-        .ok()
-        .map(|value| String::from_utf8_lossy(value).into_owned())
+fn normalize_box(value: [f64; 4]) -> [f64; 4] {
+    [
+        value[0].min(value[2]),
+        value[1].min(value[3]),
+        value[0].max(value[2]),
+        value[1].max(value[3]),
+    ]
 }
 
-fn decoded_string(document: &Document, value: &Object) -> Option<String> {
+fn bounded_name(value: &Object, budget: &mut usize) -> Option<String> {
+    let bytes = value.as_name().ok()?;
+    if bytes.len() > MAX_STRING_BYTES || bytes.len() > *budget {
+        return None;
+    }
+    let decoded = String::from_utf8_lossy(bytes).into_owned();
+    if decoded.len() > *budget {
+        return None;
+    }
+    *budget -= decoded.len();
+    Some(decoded)
+}
+
+fn decoded_string(document: &Document, value: &Object, budget: &mut usize) -> Option<String> {
     let value = resolve(document, value).ok()?;
+    if let Object::String(bytes, _) = value {
+        if bytes.len() > MAX_STRING_BYTES || bytes.len() > *budget {
+            return None;
+        }
+    }
     let decoded = decode_text_string(value).ok()?;
-    (decoded.len() <= MAX_STRING_BYTES).then_some(decoded)
+    if decoded.len() > MAX_STRING_BYTES || decoded.len() > *budget {
+        return None;
+    }
+    *budget -= decoded.len();
+    Some(decoded)
 }
 
-fn destination(document: &Document, value: &Object) -> Option<Value> {
+fn destination(document: &Document, value: &Object, budget: &mut usize) -> Option<Value> {
     let value = resolve(document, value).ok()?;
     match value {
-        Object::String(_, _) => decoded_string(document, value).map(Value::String),
-        Object::Name(value) => Some(Value::String(String::from_utf8_lossy(value).into_owned())),
+        Object::String(_, _) => decoded_string(document, value, budget).map(Value::String),
+        Object::Name(_) => bounded_name(value, budget).map(Value::String),
         Object::Array(values) if values.len() <= 8 => Some(Value::Array(
             values
                 .iter()
                 .filter_map(|value| match resolve(document, value).ok()? {
                     Object::Integer(value) => Some(json!(value)),
                     Object::Real(value) => Some(json!(value)),
-                    Object::Name(value) => Some(json!(String::from_utf8_lossy(value))),
+                    Object::Name(_) => {
+                        bounded_name(resolve(document, value).ok()?, budget).map(Value::String)
+                    }
                     Object::Null => Some(Value::Null),
                     Object::Reference((object, generation)) => Some(json!([object, generation])),
                     _ => None,
@@ -327,11 +362,39 @@ fn destination(document: &Document, value: &Object) -> Option<Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lopdf::{dictionary, Dictionary};
 
     fn fixture_document() -> Document {
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../../test/fixtures/differential/v3014-behavior-v1.pdf");
         Document::load(path).expect("load immutable signal fixture")
+    }
+
+    fn document_with_pages(page_dicts: Vec<Dictionary>) -> Document {
+        let mut document = Document::with_version("1.7");
+        let pages_id = document.new_object_id();
+        let page_ids = page_dicts
+            .into_iter()
+            .map(|mut page| {
+                page.set("Type", "Page");
+                page.set("Parent", pages_id);
+                document.add_object(page)
+            })
+            .collect::<Vec<_>>();
+        document.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages",
+                "Kids" => page_ids.iter().copied().map(Object::Reference).collect::<Vec<_>>(),
+                "Count" => page_ids.len() as i64,
+            }),
+        );
+        let catalog_id = document.add_object(dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+        });
+        document.trailer.set("Root", catalog_id);
+        document
     }
 
     #[test]
@@ -369,5 +432,51 @@ mod tests {
         assert!(signals.annotations.is_empty());
         assert!(signals.geometry.is_empty());
         assert!(signals.warnings.is_empty());
+    }
+
+    #[test]
+    fn malformed_geometry_uses_pdfjs_fallback_and_normalization_rules() {
+        let document = document_with_pages(vec![
+            dictionary! {},
+            dictionary! { "MediaBox" => vec![612.into(), 792.into(), 0.into(), 0.into()] },
+            dictionary! {
+                "MediaBox" => vec![0.into(), 0.into(), 200.into(), 300.into()],
+                "Rotate" => 45,
+                "UserUnit" => 0,
+            },
+            dictionary! {
+                "MediaBox" => vec![0.into(), 0.into(), 200.into(), 300.into()],
+                "Rotate" => -90,
+            },
+        ]);
+        let pages = document.get_pages().into_iter().collect::<Vec<_>>();
+        let signals = extract_page_signals(&document, &pages, &[1, 2, 3, 4], true, false);
+        assert_eq!(
+            signals.geometry,
+            vec![
+                json!({"page":1,"width":612.0,"height":792.0,"rotation":0.0,"user_unit":1.0,"view_box":{"left":0.0,"bottom":0.0,"right":612.0,"top":792.0}}),
+                json!({"page":2,"width":612.0,"height":792.0,"rotation":0.0,"user_unit":1.0,"view_box":{"left":0.0,"bottom":0.0,"right":612.0,"top":792.0}}),
+                json!({"page":3,"width":200.0,"height":300.0,"rotation":0.0,"user_unit":1.0,"view_box":{"left":0.0,"bottom":0.0,"right":200.0,"top":300.0}}),
+                json!({"page":4,"width":300.0,"height":200.0,"rotation":270.0,"user_unit":1.0,"view_box":{"left":0.0,"bottom":0.0,"right":200.0,"top":300.0}}),
+            ]
+        );
+    }
+
+    #[test]
+    fn malformed_annotations_consume_the_request_wide_work_budget() {
+        let page = || {
+            dictionary! {
+                "MediaBox" => vec![0.into(), 0.into(), 100.into(), 100.into()],
+                "Annots" => vec![Object::Null; MAX_ANNOTATIONS_PER_PAGE],
+            }
+        };
+        let document = document_with_pages((0..11).map(|_| page()).collect());
+        let pages = document.get_pages().into_iter().collect::<Vec<_>>();
+        let selected = (1..=11).collect::<Vec<_>>();
+        let signals = extract_page_signals(&document, &pages, &selected, false, true);
+        assert!(signals.annotations.is_empty());
+        assert_eq!(signals.warnings, vec![format!(
+            "include_annotations: source reached the {MAX_ANNOTATIONS_PER_SOURCE} annotation work limit."
+        )]);
     }
 }

--- a/crates/pdf-reader-core/src/page_signals.rs
+++ b/crates/pdf-reader-core/src/page_signals.rs
@@ -1,0 +1,373 @@
+use std::collections::HashSet;
+
+use lopdf::{Document, Object, ObjectId};
+use pdf_extract::decode_text_string;
+use serde_json::{json, Value};
+
+const MAX_PARENT_DEPTH: usize = 64;
+const MAX_ANNOTATIONS_PER_PAGE: usize = 1_000;
+const MAX_ANNOTATIONS_PER_SOURCE: usize = 10_000;
+const MAX_STRING_BYTES: usize = 64 * 1024;
+
+#[derive(Default)]
+pub(crate) struct PageSignals {
+    pub geometry: Vec<Value>,
+    pub annotations: Vec<Value>,
+    pub warnings: Vec<String>,
+}
+
+pub(crate) fn extract_page_signals(
+    document: &Document,
+    pages: &[(u32, ObjectId)],
+    selected_pages: &[u32],
+    want_geometry: bool,
+    want_annotations: bool,
+) -> PageSignals {
+    let mut signals = PageSignals::default();
+    let selected: HashSet<u32> = selected_pages.iter().copied().collect();
+    let mut annotation_count = 0usize;
+    for (page, page_id) in pages {
+        if !selected.contains(page) {
+            continue;
+        }
+        if want_geometry {
+            if let Some(value) = page_geometry(document, *page, *page_id) {
+                signals.geometry.push(value);
+            }
+        }
+        if want_annotations && annotation_count < MAX_ANNOTATIONS_PER_SOURCE {
+            let (annotations, truncated) = page_annotations(
+                document,
+                *page,
+                *page_id,
+                (MAX_ANNOTATIONS_PER_SOURCE - annotation_count).min(MAX_ANNOTATIONS_PER_PAGE),
+            );
+            annotation_count += annotations.len();
+            if !annotations.is_empty() {
+                signals.annotations.push(json!({
+                    "page": page,
+                    "annotations": annotations,
+                }));
+            }
+            if truncated {
+                signals.warnings.push(format!(
+                    "include_annotations: page {page} exceeded the bounded annotation limit."
+                ));
+            }
+        }
+    }
+    if want_annotations && annotation_count >= MAX_ANNOTATIONS_PER_SOURCE {
+        signals.warnings.push(format!(
+            "include_annotations: source exceeded the {MAX_ANNOTATIONS_PER_SOURCE} annotation limit."
+        ));
+    }
+    signals
+}
+
+fn page_geometry(document: &Document, page: u32, page_id: ObjectId) -> Option<Value> {
+    let media = inherited_array(document, page_id, b"MediaBox")?;
+    let media = box_values(document, media)?;
+    let crop = inherited_array(document, page_id, b"CropBox")
+        .and_then(|value| box_values(document, value))
+        .and_then(|crop| intersect_boxes(media, crop))
+        .unwrap_or(media);
+    let rotation = inherited_number(document, page_id, b"Rotate")
+        .unwrap_or(0.0)
+        .rem_euclid(360.0);
+    // PDF.js exposes page.userUnit from the page dictionary itself; unlike
+    // MediaBox/CropBox/Rotate, a Pages-node UserUnit is not inherited there.
+    let user_unit = page_number(document, page_id, b"UserUnit").unwrap_or(1.0);
+    if !user_unit.is_finite() || user_unit <= 0.0 {
+        return None;
+    }
+    let base_width = (crop[2] - crop[0]).abs() * user_unit;
+    let base_height = (crop[3] - crop[1]).abs() * user_unit;
+    let quarter_turn =
+        (rotation - 90.0).abs() < f64::EPSILON || (rotation - 270.0).abs() < f64::EPSILON;
+    let (width, height) = if quarter_turn {
+        (base_height, base_width)
+    } else {
+        (base_width, base_height)
+    };
+    if !width.is_finite() || !height.is_finite() {
+        return None;
+    }
+    Some(json!({
+        "page": page,
+        "width": width,
+        "height": height,
+        "rotation": rotation,
+        "user_unit": user_unit,
+        "view_box": {
+            "left": crop[0], "bottom": crop[1], "right": crop[2], "top": crop[3],
+        },
+    }))
+}
+
+fn page_annotations(
+    document: &Document,
+    page: u32,
+    page_id: ObjectId,
+    limit: usize,
+) -> (Vec<Value>, bool) {
+    let Some(annots) = inherited_array(document, page_id, b"Annots") else {
+        return (Vec::new(), false);
+    };
+    let Ok(values) = resolve(document, annots).and_then(Object::as_array) else {
+        return (Vec::new(), false);
+    };
+    let truncated = values.len() > limit;
+    let annotations = values
+        .iter()
+        .take(limit)
+        .filter_map(|value| normalize_annotation(document, page, value))
+        .collect();
+    (annotations, truncated)
+}
+
+fn normalize_annotation(document: &Document, page: u32, value: &Object) -> Option<Value> {
+    let id = match value {
+        Object::Reference((object, generation)) => Some(if *generation == 0 {
+            format!("{object}R")
+        } else {
+            format!("{object}R{generation}")
+        }),
+        _ => None,
+    };
+    let dict = resolve(document, value).ok()?.as_dict().ok()?;
+    let subtype = name_value(dict.get(b"Subtype").ok()?);
+    let contents = dict
+        .get(b"Contents")
+        .ok()
+        .and_then(|value| decoded_string(document, value));
+    let title = dict
+        .get(b"T")
+        .ok()
+        .and_then(|value| decoded_string(document, value));
+    let rect = dict
+        .get(b"Rect")
+        .ok()
+        .and_then(|value| box_values(document, value));
+    let dest = dict
+        .get(b"Dest")
+        .ok()
+        .and_then(|value| destination(document, value));
+    let url = dict
+        .get(b"A")
+        .ok()
+        .and_then(|value| resolve(document, value).ok())
+        .and_then(|value| value.as_dict().ok())
+        .filter(|action| action.get(b"S").ok().and_then(name_value).as_deref() == Some("URI"))
+        .and_then(|action| action.get(b"URI").ok())
+        .and_then(|value| decoded_string(document, value));
+
+    if id.is_none()
+        && subtype.is_none()
+        && contents.is_none()
+        && title.is_none()
+        && url.is_none()
+        && dest.is_none()
+    {
+        return None;
+    }
+    let mut output = serde_json::Map::new();
+    output.insert("page".into(), json!(page));
+    if let Some(value) = id {
+        output.insert("id".into(), json!(value));
+    }
+    if let Some(value) = subtype.filter(|value| !value.trim().is_empty()) {
+        output.insert("subtype".into(), json!(value));
+    }
+    if let Some(value) = contents.filter(|value| !value.trim().is_empty()) {
+        output.insert("contents".into(), json!(value));
+    }
+    if let Some(value) = title.filter(|value| !value.trim().is_empty()) {
+        output.insert("title".into(), json!(value));
+    }
+    if let Some(value) = url.filter(|value| !value.is_empty()) {
+        output.insert("url".into(), json!(value));
+    }
+    if let Some(value) = dest {
+        output.insert("dest".into(), value);
+    }
+    if let Some(value) = rect {
+        output.insert(
+            "bounding_box".into(),
+            json!({
+                "left": value[0].min(value[2]), "bottom": value[1].min(value[3]),
+                "right": value[0].max(value[2]), "top": value[1].max(value[3]),
+            }),
+        );
+    }
+    Some(Value::Object(output))
+}
+
+fn inherited_array<'a>(
+    document: &'a Document,
+    page_id: ObjectId,
+    key: &[u8],
+) -> Option<&'a Object> {
+    inherited(document, page_id, key)
+}
+
+fn inherited_number(document: &Document, page_id: ObjectId, key: &[u8]) -> Option<f64> {
+    let value = inherited(document, page_id, key)?;
+    number(resolve(document, value).ok()?)
+}
+
+fn page_number(document: &Document, page_id: ObjectId, key: &[u8]) -> Option<f64> {
+    let dict = document.get_object(page_id).ok()?.as_dict().ok()?;
+    number(resolve(document, dict.get(key).ok()?).ok()?)
+}
+
+fn inherited<'a>(document: &'a Document, mut id: ObjectId, key: &[u8]) -> Option<&'a Object> {
+    let mut visited = HashSet::new();
+    for _ in 0..MAX_PARENT_DEPTH {
+        if !visited.insert(id) {
+            return None;
+        }
+        let dict = document.get_object(id).ok()?.as_dict().ok()?;
+        if let Ok(value) = dict.get(key) {
+            return Some(value);
+        }
+        id = dict.get(b"Parent").ok()?.as_reference().ok()?;
+    }
+    None
+}
+
+fn resolve<'a>(document: &'a Document, value: &'a Object) -> Result<&'a Object, lopdf::Error> {
+    match value {
+        Object::Reference(id) => document.get_object(*id),
+        _ => Ok(value),
+    }
+}
+
+fn box_values(document: &Document, value: &Object) -> Option<[f64; 4]> {
+    let values = resolve(document, value).ok()?.as_array().ok()?;
+    if values.len() < 4 {
+        return None;
+    }
+    let parsed = [
+        number(resolve(document, &values[0]).ok()?)?,
+        number(resolve(document, &values[1]).ok()?)?,
+        number(resolve(document, &values[2]).ok()?)?,
+        number(resolve(document, &values[3]).ok()?)?,
+    ];
+    parsed
+        .iter()
+        .all(|value| value.is_finite())
+        .then_some(parsed)
+}
+
+fn number(value: &Object) -> Option<f64> {
+    match value {
+        Object::Integer(value) => Some(*value as f64),
+        Object::Real(value) => Some(f64::from(*value)),
+        _ => None,
+    }
+}
+
+fn intersect_boxes(a: [f64; 4], b: [f64; 4]) -> Option<[f64; 4]> {
+    let a = [
+        a[0].min(a[2]),
+        a[1].min(a[3]),
+        a[0].max(a[2]),
+        a[1].max(a[3]),
+    ];
+    let b = [
+        b[0].min(b[2]),
+        b[1].min(b[3]),
+        b[0].max(b[2]),
+        b[1].max(b[3]),
+    ];
+    let value = [
+        a[0].max(b[0]),
+        a[1].max(b[1]),
+        a[2].min(b[2]),
+        a[3].min(b[3]),
+    ];
+    (value[0] < value[2] && value[1] < value[3]).then_some(value)
+}
+
+fn name_value(value: &Object) -> Option<String> {
+    value
+        .as_name()
+        .ok()
+        .map(|value| String::from_utf8_lossy(value).into_owned())
+}
+
+fn decoded_string(document: &Document, value: &Object) -> Option<String> {
+    let value = resolve(document, value).ok()?;
+    let decoded = decode_text_string(value).ok()?;
+    (decoded.len() <= MAX_STRING_BYTES).then_some(decoded)
+}
+
+fn destination(document: &Document, value: &Object) -> Option<Value> {
+    let value = resolve(document, value).ok()?;
+    match value {
+        Object::String(_, _) => decoded_string(document, value).map(Value::String),
+        Object::Name(value) => Some(Value::String(String::from_utf8_lossy(value).into_owned())),
+        Object::Array(values) if values.len() <= 8 => Some(Value::Array(
+            values
+                .iter()
+                .filter_map(|value| match resolve(document, value).ok()? {
+                    Object::Integer(value) => Some(json!(value)),
+                    Object::Real(value) => Some(json!(value)),
+                    Object::Name(value) => Some(json!(String::from_utf8_lossy(value))),
+                    Object::Null => Some(Value::Null),
+                    Object::Reference((object, generation)) => Some(json!([object, generation])),
+                    _ => None,
+                })
+                .collect(),
+        )),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_document() -> Document {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../test/fixtures/differential/v3014-behavior-v1.pdf");
+        Document::load(path).expect("load immutable signal fixture")
+    }
+
+    #[test]
+    fn geometry_and_link_annotation_match_the_frozen_v3014_subset() {
+        let document = fixture_document();
+        let pages = document.get_pages().into_iter().collect::<Vec<_>>();
+        let signals = extract_page_signals(&document, &pages, &[1], true, true);
+        assert_eq!(signals.warnings, Vec::<String>::new());
+        assert_eq!(
+            signals.geometry,
+            vec![json!({
+                "page": 1, "width": 1460.0, "height": 1120.0, "rotation": 90.0,
+                "user_unit": 2.0,
+                "view_box": { "left": 20.0, "bottom": 30.0, "right": 580.0, "top": 760.0 },
+            })]
+        );
+        assert_eq!(
+            signals.annotations,
+            vec![json!({
+                "page": 1,
+                "annotations": [{
+                    "page": 1, "id": "11R", "subtype": "Link",
+                    "contents": "  Linked note  ", "url": "https://example.com/a",
+                    "bounding_box": { "left": 50.0, "bottom": 150.0, "right": 100.0, "top": 200.0 },
+                }],
+            })]
+        );
+    }
+
+    #[test]
+    fn selected_page_without_annotations_produces_no_placeholder_group() {
+        let document = fixture_document();
+        let pages = document.get_pages().into_iter().collect::<Vec<_>>();
+        let signals = extract_page_signals(&document, &pages, &[2], false, true);
+        assert!(signals.annotations.is_empty());
+        assert!(signals.geometry.is_empty());
+        assert!(signals.warnings.is_empty());
+    }
+}

--- a/crates/pdf-reader-core/src/read_pdf.rs
+++ b/crates/pdf-reader-core/src/read_pdf.rs
@@ -5,9 +5,11 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::text_index::{extract_pdf_text, PdfInfo, TextIndexError, TextIndexErrorCode};
+use crate::text_index::{
+    extract_pdf_text_from_document, PdfInfo, TextIndexError, TextIndexErrorCode,
+};
 use crate::url_fetch::{cleanup_temp_file, fetch_url_to_temp_file};
-use crate::{hash_file, FileHash, HashError, ENGINE_NAME, ENGINE_VERSION};
+use crate::{HashError, ENGINE_NAME, ENGINE_VERSION};
 
 pub const READ_PDF_ROUTE: &str = "rust-read-pdf-v1";
 
@@ -562,27 +564,15 @@ pub(crate) fn rebuild_structured_outputs(
     }
 }
 
-fn build_data(
-    pages: &[crate::document_twin::PageText],
-    total_pages: u32,
-    input: &ReadPdfInput,
-    pdf_info: Option<&PdfInfo>,
-    explicit_page_selection: bool,
-) -> ReadPdfData {
-    use crate::document_twin::{
-        build_accessibility_report, build_document_ast, build_document_map, build_elements,
-        build_layout_diagnostics, build_page_geometry, build_page_labels, build_safety_findings,
-        build_tables, build_trust_report, empty_structure_arrays,
-    };
+#[derive(Default)]
+struct BuildSignals {
+    page_geometry: Option<Value>,
+    annotations: Option<Value>,
+    warnings: Vec<String>,
+}
 
-    let full_text = join_page_text(pages);
-    let text_chars = full_text.chars().count();
-    let mut warnings = Vec::new();
-
-    // auto is resolved in read_pdf_from_value for JSON callers; programmatic callers
-    // should set auto explicitly. Default remains true only when auto is None and no
-    // include flags are set (bool defaults are false, so all-false means sources-only).
-    let any_include = input.include_metadata
+fn has_any_include(input: &ReadPdfInput) -> bool {
+    input.include_metadata
         || input.include_page_count
         || input.include_full_text
         || input.include_markdown
@@ -608,17 +598,45 @@ fn build_data(
         || input.include_ocr_text_layer
         || input.include_visual_enrichments
         || input.include_trust_report
-        || input.include_accessibility_report;
-    let auto = if input.auto_policy_resolved {
+        || input.include_accessibility_report
+}
+
+fn auto_enabled(input: &ReadPdfInput) -> bool {
+    if input.auto_policy_resolved {
         false
     } else {
-        match input.auto {
-            Some(v) => v,
-            // Presence of true include flags implies manual mode when auto omitted.
-            // (JSON path sets auto explicitly via read_pdf_from_value for key presence.)
-            None => !any_include,
-        }
+        input.auto.unwrap_or_else(|| !has_any_include(input))
+    }
+}
+
+fn build_data(
+    pages: &[crate::document_twin::PageText],
+    total_pages: u32,
+    input: &ReadPdfInput,
+    pdf_info: Option<&PdfInfo>,
+    explicit_page_selection: bool,
+    signals: BuildSignals,
+) -> ReadPdfData {
+    use crate::document_twin::{
+        build_accessibility_report, build_document_ast, build_document_map, build_elements,
+        build_layout_diagnostics, build_page_labels, build_safety_findings, build_tables,
+        build_trust_report, empty_structure_arrays,
     };
+
+    let BuildSignals {
+        page_geometry,
+        annotations,
+        mut warnings,
+    } = signals;
+    let full_text = join_page_text(pages);
+    let text_chars = full_text.chars().count();
+
+    // auto is resolved in read_pdf_from_value for JSON callers; programmatic callers
+    // should set auto explicitly. Default remains true only when auto is None and no
+    // include flags are set (bool defaults are false, so all-false means sources-only).
+    // Presence of true include flags implies manual mode when auto is omitted.
+    // (JSON path resolves preset flags before reaching this function.)
+    let auto = auto_enabled(input);
     let detail = input.auto_detail.as_deref().unwrap_or("balanced");
     let auto_full = auto && detail == "full";
     let auto_balanced = auto && matches!(detail, "balanced" | "full");
@@ -755,8 +773,7 @@ fn build_data(
         None
     };
 
-    let (outline, annotations, form_fields, attachments, structure_trees) =
-        empty_structure_arrays();
+    let (outline, _, form_fields, attachments, structure_trees) = empty_structure_arrays();
 
     let mut data = ReadPdfData {
         num_pages: want_page_count.then_some(total_pages),
@@ -978,10 +995,7 @@ fn build_data(
         );
     }
     if want_annotations {
-        data.annotations = Some(annotations);
-        warnings.push(
-            "include_annotations: annotation records are empty on the pure-Rust text path.".into(),
-        );
+        data.annotations = annotations;
     }
     if want_forms {
         data.form_fields = Some(form_fields);
@@ -1000,9 +1014,7 @@ fn build_data(
         data.page_labels = Some(build_page_labels(total_pages));
     }
     if want_geometry {
-        data.page_geometry = Some(build_page_geometry(
-            &pages.iter().map(|page| page.page).collect::<Vec<_>>(),
-        ));
+        data.page_geometry = page_geometry;
     }
     if want_permissions {
         data.permissions = Some(json!([]));
@@ -1097,8 +1109,8 @@ fn read_local_pdf_filtered(
     pages_spec: &Option<Value>,
     source_label: &str,
 ) -> Result<ReadPdfSourceResult, ReadPdfError> {
-    let _hash: FileHash = hash_file(path, DEFAULT_MAX_FILE_BYTES)?;
-    let extracted = extract_pdf_text(path, DEFAULT_MAX_FILE_BYTES)?;
+    let parsed = crate::cos_document::ParsedPdf::load(path, DEFAULT_MAX_FILE_BYTES)?;
+    let extracted = extract_pdf_text_from_document(&parsed.document)?;
     let total_pages = extracted.pages.len().max(1) as u32;
     let pages = extracted
         .pages
@@ -1107,7 +1119,7 @@ fn read_local_pdf_filtered(
         .collect::<Vec<_>>();
     let explicit_pages = parse_page_spec(pages_spec)?;
     let auto_pages = if explicit_pages.is_none()
-        && input.auto.unwrap_or(false)
+        && auto_enabled(input)
         && input.auto_detail.as_deref().unwrap_or("balanced") != "full"
     {
         Some(evenly_sample_pages(
@@ -1119,12 +1131,31 @@ fn read_local_pdf_filtered(
     };
     let requested_pages = explicit_pages.as_deref().or(auto_pages.as_deref());
     let (selected, invalid_pages) = select_pages(&pages, requested_pages);
+    let selected_page_numbers = selected.iter().map(|page| page.page).collect::<Vec<_>>();
+    let auto = auto_enabled(input);
+    let want_geometry = input.include_page_geometry || auto;
+    let want_annotations =
+        input.include_annotations || (auto && input.auto_detail.as_deref() == Some("full"));
+    let signals = crate::page_signals::extract_page_signals(
+        &parsed.document,
+        &parsed.pages,
+        &selected_page_numbers,
+        want_geometry,
+        want_annotations,
+    );
+    let geometry = (!signals.geometry.is_empty()).then(|| json!(signals.geometry));
+    let annotations = (!signals.annotations.is_empty()).then(|| json!(signals.annotations));
     let mut data = build_data(
         &selected,
         total_pages,
         input,
         Some(&extracted.info),
         explicit_pages.is_some(),
+        BuildSignals {
+            page_geometry: geometry,
+            annotations,
+            warnings: signals.warnings,
+        },
     );
     if !invalid_pages.is_empty() {
         data.warnings.get_or_insert_with(Vec::new).push(format!(
@@ -1432,7 +1463,9 @@ mod tests {
         assert!(data.trust_report.is_some());
         assert!(data.accessibility_report.is_some());
         assert!(data.outline.is_some());
-        assert!(data.annotations.is_some());
+        // TS 3.0.14 omits optional page-signal fields when the document has no
+        // qualifying records; an empty placeholder is not capability parity.
+        assert!(data.annotations.is_none());
         assert!(data.page_labels.is_some());
         assert!(data.page_geometry.is_some());
         assert!(data.permissions.is_some());
@@ -1480,6 +1513,7 @@ mod tests {
             &input,
             None,
             true,
+            BuildSignals::default(),
         );
         assert_eq!(mixed.ocr_candidate_pages, vec![4, 7]);
 
@@ -1498,6 +1532,7 @@ mod tests {
             &input,
             None,
             true,
+            BuildSignals::default(),
         );
         assert_eq!(selectable.ocr_candidate_pages, vec![2, 5]);
         assert!(serde_json::to_value(selectable)
@@ -1594,6 +1629,7 @@ mod tests {
             },
             None,
             true,
+            BuildSignals::default(),
         );
         assert!(data.full_text.is_none());
         assert_eq!(data.page_texts, Some(pages));
@@ -1623,6 +1659,7 @@ mod tests {
             },
             None,
             false,
+            BuildSignals::default(),
         );
         let serialized = serde_json::to_value(data).expect("serialize data");
         assert!(serialized.get("num_pages").is_none());
@@ -1645,6 +1682,10 @@ mod tests {
             },
             None,
             false,
+            BuildSignals {
+                page_geometry: Some(json!([])),
+                ..BuildSignals::default()
+            },
         );
         assert!(data.markdown.is_some());
         assert!(data.tables.is_some());

--- a/crates/pdf-reader-core/src/text_index.rs
+++ b/crates/pdf-reader-core/src/text_index.rs
@@ -263,9 +263,15 @@ pub fn extract_pdf_text(
             TextIndexError::extraction_failed(format!("Failed to extract PDF text: {err}"))
         })?;
     }
-    let info = read_pdf_info(&doc);
+    extract_pdf_text_from_document(&doc)
+}
+
+pub(crate) fn extract_pdf_text_from_document(
+    doc: &Document,
+) -> Result<ExtractedPdfText, TextIndexError> {
+    let info = read_pdf_info(doc);
     let mut output = TextItemOutput::default();
-    output_doc(&doc, &mut output).map_err(|err| {
+    output_doc(doc, &mut output).map_err(|err| {
         TextIndexError::extraction_failed(format!("Failed to extract PDF text: {err}"))
     })?;
 

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -38,12 +38,12 @@
       "include_accessibility_report": "PARTIAL",
       "include_metadata": "PARTIAL",
       "include_outline": "STUB",
-      "include_annotations": "STUB",
+      "include_annotations": "PARTIAL",
       "include_form_fields": "STUB",
       "include_attachments": "STUB",
       "include_structure_tree": "STUB",
       "include_page_labels": "STUB",
-      "include_page_geometry": "STUB",
+      "include_page_geometry": "PARTIAL",
       "include_permissions": "STUB",
       "include_images": "STUB",
       "include_ocr_text_layer": "PARTIAL",
@@ -71,17 +71,17 @@
     }
   },
   "claimedForDifferential": [
-    "exact 10-case immutable TS v3.0.14 behavior subset: full text, page selection/order/duplicates, metadata, literal search, case sensitivity, whole word, Unicode, UTF-16 offsets, missing and malformed inputs, and mixed-source partial success",
+    "exact 11-case immutable TS v3.0.14 behavior subset: full text, page selection/order/duplicates, metadata, literal search, case sensitivity, whole word, Unicode, UTF-16 offsets, missing and malformed inputs, mixed-source partial success, inherited crop/media/rotation geometry with page UserUnit, and an indirect Link/URI annotation",
     "exact 16-case immutable TS v3.0.14 render/crop/command-provider semantic subset over stdio: defaults, page selection and warnings, region ordering, padding and fractional bounds, rotated pages, mixed-source and late-provider partial success, all-source failure, MCP image indexing, standalone OCR normalization, read_pdf OCR text-layer/map fusion, boxed OCR table projection into elements/chunks/markdown/html/document_ast/document_map, rich region-analysis normalization, plain-text truncation, and truthful provenance; exact pdf.js pixels and antialiasing are not claimed",
     "DNS-pinned URL fetch: one resolution per redirect hop, reject mixed public/non-public answers, disable ambient proxies, and revalidate every redirect; still PARTIAL because resolver timeout and TLS-SNI fixtures remain open",
     "auto off when include_* keys are present"
   ],
   "explicitlyNotClaimed": [
-    "complete TS 3.0.14 semantic parity outside the immutable 10-case subset",
-    "text/search geometry, geometry-perfect pdf.js boxes, and general bounding-box parity",
+    "complete TS 3.0.14 semantic parity outside the immutable 11-case subset",
+    "text/search geometry, geometry-perfect pdf.js boxes outside the frozen page-geometry subset, direct-annotation PDF.js presentation normalization, non-Link annotation/action parity, and general bounding-box parity",
     "render/crop/OCR/analyze/read-fusion/table-projection semantic parity outside the immutable 16-case subset, including exact pdf.js pixels and antialiasing",
     "OCR success paths outside the opt-in command JSON/plain-text subset, including tesseract-tsv; mixed selectable/OCR table continuation and full AST hierarchy parity; analyze_regions HTTP and preset providers",
-    "COS outline/annotations/forms",
+    "COS outline/forms, page labels, permissions, attachments, and structure trees",
     "cross-platform npm native binary",
     "npm library exports for pure-Rust",
     "2.0x/3.3x industry benchmark headline"

--- a/scripts/check-pure-rust-matrix.ts
+++ b/scripts/check-pure-rust-matrix.ts
@@ -19,6 +19,13 @@ const matrix = JSON.parse(
     search_pdf: Record<string, string>;
   };
 };
+const behaviorCorpus = JSON.parse(
+  readFileSync(join(root, 'scripts/differential/fixtures/v3014-behavior-corpus.json'), 'utf8')
+) as { cases: Array<{ id: string }> };
+const differentialWorkflow = readFileSync(
+  join(root, '.github/workflows/rust-parity-differential.yml'),
+  'utf8'
+);
 
 const failures: string[] = [];
 if (!matrix.productTruth.dropInFor3014 && !String(matrix.productTruth.publishedStable).includes('3.0.14')) {
@@ -46,6 +53,15 @@ if (matrix.productTruth.dropInFor3014) {
 }
 if (!matrix.productTruth.dropInFor3014 && matrix.productTruth.publishFreeze !== true) {
   failures.push('publishFreeze must remain true while dropInFor3014 is false');
+}
+const behaviorCaseCount = behaviorCorpus.cases.length;
+if (
+  !differentialWorkflow.includes(`.caseCount == ${behaviorCaseCount}`) ||
+  !differentialWorkflow.includes(`.passed == ${behaviorCaseCount}`)
+) {
+  failures.push(
+    `rust parity workflow must require the exact ${behaviorCaseCount}/${behaviorCaseCount} behavior corpus`
+  );
 }
 if (failures.length) {
   console.error(failures.join('\n'));

--- a/scripts/differential/check-v3014-behavior-differential.ts
+++ b/scripts/differential/check-v3014-behavior-differential.ts
@@ -66,8 +66,8 @@ function verifyAuthority(): Record<string, string> {
     }
   }
   const ids = corpus.cases.map((entry) => entry.id);
-  if (ids.length !== 10 || new Set(ids).size !== ids.length) {
-    throw new Error(`behavior corpus must contain 10 unique cases (got ${ids.length})`);
+  if (ids.length !== 11 || new Set(ids).size !== ids.length) {
+    throw new Error(`behavior corpus must contain 11 unique cases (got ${ids.length})`);
   }
   if (JSON.stringify(ids.sort()) !== JSON.stringify(Object.keys(oracle.expectations).sort())) {
     throw new Error('corpus and oracle case IDs differ');
@@ -184,6 +184,35 @@ function canonicalRead(id: string, envelope: Record<string, unknown>): Json {
           text: normalizeText(String((page as Record<string, unknown>).text ?? '')),
         }))
       : [];
+  }
+  if (id === 'read-page-signals') {
+    canonical.page_geometry = Array.isArray(data.page_geometry)
+      ? data.page_geometry.map((entry) => {
+          const geometry = entry as Record<string, unknown>;
+          const box = geometry.view_box as Record<string, unknown>;
+          return {
+            page: Number(geometry.page), width: Number(geometry.width), height: Number(geometry.height),
+            rotation: Number(geometry.rotation), user_unit: Number(geometry.user_unit),
+            view_box: { left: Number(box.left), bottom: Number(box.bottom), right: Number(box.right), top: Number(box.top) },
+          };
+        })
+      : null;
+    canonical.annotations = Array.isArray(data.annotations)
+      ? data.annotations.map((group) => {
+          const value = group as Record<string, unknown>;
+          return {
+            page: Number(value.page),
+            annotations: ((value.annotations ?? []) as Array<Record<string, unknown>>).map((entry) => {
+              const box = entry.bounding_box as Record<string, unknown>;
+              return {
+                page: Number(entry.page), id: String(entry.id), subtype: String(entry.subtype),
+                contents: String(entry.contents), url: String(entry.url),
+                bounding_box: { left: Number(box.left), bottom: Number(box.bottom), right: Number(box.right), top: Number(box.top) },
+              };
+            }),
+          };
+        })
+      : null;
   }
   canonical.warnings = warnings(data.warnings);
   return canonical;

--- a/scripts/differential/fixtures/v3014-behavior-corpus.json
+++ b/scripts/differential/fixtures/v3014-behavior-corpus.json
@@ -36,6 +36,17 @@
       }
     },
     {
+      "id": "read-page-signals",
+      "tool": "read_pdf",
+      "input": {
+        "sources": [{ "fixture": "v3014-behavior-v1.pdf", "pages": [1] }],
+        "auto": false,
+        "include_annotations": true,
+        "include_page_geometry": true,
+        "include_page_count": true
+      }
+    },
+    {
       "id": "search-ci-all",
       "tool": "search_pdf",
       "input": {

--- a/scripts/differential/fixtures/v3014-behavior-fixtures.json
+++ b/scripts/differential/fixtures/v3014-behavior-fixtures.json
@@ -4,8 +4,8 @@
   "fixtures": [
     {
       "path": "test/fixtures/differential/v3014-behavior-v1.pdf",
-      "bytes": 1559,
-      "sha256": "b457e7452b3fc57d1d7c1416600b71a3ce928c1e966a39e19ef462508064be38"
+      "bytes": 1902,
+      "sha256": "83a35c0c6df341de05df0a261f845a2ac925f010502dd0bfc8af730aa2c2c6c4"
     },
     {
       "path": "test/fixtures/differential/v3014-malformed-v1.pdf",

--- a/scripts/differential/fixtures/v3014-behavior-oracle.json
+++ b/scripts/differential/fixtures/v3014-behavior-oracle.json
@@ -10,14 +10,21 @@
       "src/pdf/readCoordinator.ts": "827cb1018a8621287de154132c0a00a00188497b84622a168a343d0df3ce5eca",
       "src/pdf/search.ts": "ef0a1916d1399e1e807294a8170577bd59a285c73180389f82f05ec5e38d1521",
       "src/pdf/autoReadPolicy.ts": "168b5b00ae00229a7cf2c0e84b68e1bb41e288eefe957bd46e3f84db2af9537a",
-      "src/pdf/pdfSession.ts": "15c147e45deac7b1b219aeb904e0a653f22d055d3446822fb88cca3fbc7c3459"
+      "src/pdf/pdfSession.ts": "15c147e45deac7b1b219aeb904e0a653f22d055d3446822fb88cca3fbc7c3459",
+      "src/pdf/extractor.ts": "3fd4b3e6ad257efcc89a9fc4faa82ff50caa809bae9829ec6dab12767304c1c0",
+      "src/types/pdf/geometry.ts": "71849d3a8e619440230efbae941aa5cddd8e391da36fc420aeb6a0ba550172ec"
     }
   },
   "normalization": {
     "version": 1,
     "text": "Unicode NFC and CRLF-to-LF only",
     "errors": "stable category plus bounded source-independent meaning",
-    "excluded": ["absolute source path", "timestamps", "bbox", "provenance", "snippet"]
+    "excluded": [
+      "absolute source path",
+      "timestamps",
+      "provenance",
+      "snippet"
+    ]
   },
   "expectations": {
     "read-all-metadata": {
@@ -39,8 +46,14 @@
       "outcome": "success",
       "num_pages": 3,
       "page_texts": [
-        { "page": 1, "text": "PAGE_ONE_ALPHANeedle at start. cat catalog CAT." },
-        { "page": 3, "text": "PAGE_THREE_GAMMAneedle tail NEEDLE" }
+        {
+          "page": 1,
+          "text": "PAGE_ONE_ALPHANeedle at start. cat catalog CAT."
+        },
+        {
+          "page": 3,
+          "text": "PAGE_THREE_GAMMAneedle tail NEEDLE"
+        }
       ],
       "warnings": []
     },
@@ -48,53 +61,178 @@
       "outcome": "success",
       "num_pages": 3,
       "page_texts": [
-        { "page": 2, "text": "PAGE_TWO_BETAprefix Needle suffixCafé résumé" }
+        {
+          "page": 2,
+          "text": "PAGE_TWO_BETAprefix Needle suffixCafé résumé"
+        }
       ],
-      "warnings": [{ "category": "page_out_of_range", "requested": [9], "total": 3 }]
+      "warnings": [
+        {
+          "category": "page_out_of_range",
+          "requested": [
+            9
+          ],
+          "total": 3
+        }
+      ]
+    },
+    "read-page-signals": {
+      "outcome": "success",
+      "num_pages": 3,
+      "page_geometry": [
+        {
+          "page": 1,
+          "width": 1460,
+          "height": 1120,
+          "rotation": 90,
+          "user_unit": 2,
+          "view_box": {
+            "left": 20,
+            "bottom": 30,
+            "right": 580,
+            "top": 760
+          }
+        }
+      ],
+      "annotations": [
+        {
+          "page": 1,
+          "annotations": [
+            {
+              "page": 1,
+              "id": "11R",
+              "subtype": "Link",
+              "contents": "  Linked note  ",
+              "url": "https://example.com/a",
+              "bounding_box": {
+                "left": 50,
+                "bottom": 150,
+                "right": 100,
+                "top": 200
+              }
+            }
+          ]
+        }
+      ],
+      "warnings": []
     },
     "search-ci-all": {
       "outcome": "success",
       "num_pages": 3,
-      "searched_pages": [1, 2, 3],
+      "searched_pages": [
+        1,
+        2,
+        3
+      ],
       "matches": [
-        { "page": 1, "text": "Needle", "match_start": 0, "match_end": 6, "text_item_index": 1 },
-        { "page": 2, "text": "Needle", "match_start": 7, "match_end": 13, "text_item_index": 1 },
-        { "page": 3, "text": "needle", "match_start": 0, "match_end": 6, "text_item_index": 1 },
-        { "page": 3, "text": "NEEDLE", "match_start": 12, "match_end": 18, "text_item_index": 1 }
+        {
+          "page": 1,
+          "text": "Needle",
+          "match_start": 0,
+          "match_end": 6,
+          "text_item_index": 1
+        },
+        {
+          "page": 2,
+          "text": "Needle",
+          "match_start": 7,
+          "match_end": 13,
+          "text_item_index": 1
+        },
+        {
+          "page": 3,
+          "text": "needle",
+          "match_start": 0,
+          "match_end": 6,
+          "text_item_index": 1
+        },
+        {
+          "page": 3,
+          "text": "NEEDLE",
+          "match_start": 12,
+          "match_end": 18,
+          "text_item_index": 1
+        }
       ]
     },
     "search-cs-upper": {
       "outcome": "success",
       "num_pages": 3,
-      "searched_pages": [1, 2, 3],
+      "searched_pages": [
+        1,
+        2,
+        3
+      ],
       "matches": [
-        { "page": 3, "text": "NEEDLE", "match_start": 12, "match_end": 18, "text_item_index": 1 }
+        {
+          "page": 3,
+          "text": "NEEDLE",
+          "match_start": 12,
+          "match_end": 18,
+          "text_item_index": 1
+        }
       ]
     },
     "search-whole-word": {
       "outcome": "success",
       "num_pages": 3,
-      "searched_pages": [1, 2, 3],
+      "searched_pages": [
+        1,
+        2,
+        3
+      ],
       "matches": [
-        { "page": 1, "text": "cat", "match_start": 17, "match_end": 20, "text_item_index": 1 },
-        { "page": 1, "text": "CAT", "match_start": 29, "match_end": 32, "text_item_index": 1 }
+        {
+          "page": 1,
+          "text": "cat",
+          "match_start": 17,
+          "match_end": 20,
+          "text_item_index": 1
+        },
+        {
+          "page": 1,
+          "text": "CAT",
+          "match_start": 29,
+          "match_end": 32,
+          "text_item_index": 1
+        }
       ]
     },
     "search-selected-unicode": {
       "outcome": "success",
       "num_pages": 3,
-      "searched_pages": [2],
+      "searched_pages": [
+        2
+      ],
       "matches": [
-        { "page": 2, "text": "Café", "match_start": 0, "match_end": 4, "text_item_index": 2 }
+        {
+          "page": 2,
+          "text": "Café",
+          "match_start": 0,
+          "match_end": 4,
+          "text_item_index": 2
+        }
       ]
     },
-    "read-missing-file": { "outcome": "error", "category": "file_not_found" },
-    "read-malformed": { "outcome": "error", "category": "invalid_pdf" },
+    "read-missing-file": {
+      "outcome": "error",
+      "category": "file_not_found"
+    },
+    "read-malformed": {
+      "outcome": "error",
+      "category": "invalid_pdf"
+    },
     "read-mixed-source-partial": {
       "outcome": "success",
       "results": [
-        { "success": true, "num_pages": 3 },
-        { "success": false, "category": "file_not_found" }
+        {
+          "success": true,
+          "num_pages": 3
+        },
+        {
+          "success": false,
+          "category": "file_not_found"
+        }
       ]
     }
   }

--- a/scripts/differential/generate-v3014-behavior-fixtures.ts
+++ b/scripts/differential/generate-v3014-behavior-fixtures.ts
@@ -30,10 +30,10 @@ function buildPdf(): Buffer {
 
   const objects = new Map<number, string>([
     [1, '<< /Type /Catalog /Pages 2 0 R >>'],
-    [2, '<< /Type /Pages /Kids [3 0 R 5 0 R 7 0 R] /Count 3 >>'],
+    [2, '<< /Type /Pages /Kids [3 0 R 5 0 R 7 0 R] /Count 3 /MediaBox [0 0 612 792] /CropBox [20 30 580 760] /Rotate 90 /UserUnit 2 >>'],
     [
       3,
-      '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 9 0 R >> >> /Contents 4 0 R >>',
+      '<< /Type /Page /Parent 2 0 R /UserUnit 2 /Resources << /Font << /F1 9 0 R >> >> /Contents 4 0 R /Annots [11 0 R] >>',
     ],
     [4, `<< /Length ${Buffer.byteLength(pageStreams[0]!, 'latin1')} >>\nstream\n${pageStreams[0]}endstream`],
     [
@@ -51,6 +51,11 @@ function buildPdf(): Buffer {
       10,
       '<< /Title (Parity Corpus V1) /Author (Sylphx Oracle) /Subject (TS 3.0.14 behavioral contract) /Keywords (parity multipage search) /Creator (fixture-generator-v1) /Producer (fixture-generator-v1) >>',
     ],
+    [
+      11,
+      '<< /Type /Annot /Subtype /Link /Contents (  Linked note  ) /Rect [100 200 50 150] /A << /S /URI /URI (https://example.com/a) >> >>',
+    ],
+    [12, '<< /Type /Annot /Subtype /Text /Contents () /Rect [1 2 1 2] >>'],
   ]);
 
   const chunks: Buffer[] = [Buffer.from('%PDF-1.4\n%\xe2\xe3\xcf\xd3\n', 'latin1')];

--- a/scripts/differential/v3014-baseline-runner.ts
+++ b/scripts/differential/v3014-baseline-runner.ts
@@ -86,6 +86,10 @@ async function readCase(id: string, input: Record<string, unknown>) {
       text: normalizeText(page.text),
     }));
   }
+  if (id === 'read-page-signals') {
+    output.page_geometry = first.data?.page_geometry ?? null;
+    output.annotations = first.data?.annotations ?? null;
+  }
   output.warnings = canonicalWarnings(first.data?.warnings);
   return output;
 }

--- a/scripts/run-pdf-reader-differential.sh
+++ b/scripts/run-pdf-reader-differential.sh
@@ -69,7 +69,7 @@ echo "--- deterministic v3.0.14 behavior fixtures + baseline replay ---" | tee -
 bun "$REPO_ROOT/scripts/differential/generate-v3014-behavior-fixtures.ts" 2>&1 | tee -a "$LOG"
 bun "$REPO_ROOT/scripts/differential/capture-v3014-behavior-oracle.ts" 2>&1 | tee -a "$LOG"
 
-echo "--- immutable v3.0.14 behavior differential (10 exact cases) ---" | tee -a "$LOG"
+echo "--- immutable v3.0.14 behavior differential (11 exact cases) ---" | tee -a "$LOG"
 bun "$REPO_ROOT/scripts/differential/check-v3014-behavior-differential.ts" \
   --output "$V3014_BEHAVIOR_JSON" >>"$LOG"
 

--- a/test/fixtures/differential/v3014-behavior-v1.pdf
+++ b/test/fixtures/differential/v3014-behavior-v1.pdf
@@ -4,10 +4,10 @@
 << /Type /Catalog /Pages 2 0 R >>
 endobj
 2 0 obj
-<< /Type /Pages /Kids [3 0 R 5 0 R 7 0 R] /Count 3 >>
+<< /Type /Pages /Kids [3 0 R 5 0 R 7 0 R] /Count 3 /MediaBox [0 0 612 792] /CropBox [20 30 580 760] /Rotate 90 /UserUnit 2 >>
 endobj
 3 0 obj
-<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 9 0 R >> >> /Contents 4 0 R >>
+<< /Type /Page /Parent 2 0 R /UserUnit 2 /Resources << /Font << /F1 9 0 R >> >> /Contents 4 0 R /Annots [11 0 R] >>
 endobj
 4 0 obj
 << /Length 94 >>
@@ -59,21 +59,29 @@ endobj
 10 0 obj
 << /Title (Parity Corpus V1) /Author (Sylphx Oracle) /Subject (TS 3.0.14 behavioral contract) /Keywords (parity multipage search) /Creator (fixture-generator-v1) /Producer (fixture-generator-v1) >>
 endobj
+11 0 obj
+<< /Type /Annot /Subtype /Link /Contents (  Linked note  ) /Rect [100 200 50 150] /A << /S /URI /URI (https://example.com/a) >> >>
+endobj
+12 0 obj
+<< /Type /Annot /Subtype /Text /Contents () /Rect [1 2 1 2] >>
+endobj
 xref
-0 11
+0 13
 0000000000 65535 f 
 0000000015 00000 n 
 0000000064 00000 n 
-0000000133 00000 n 
-0000000259 00000 n 
-0000000402 00000 n 
-0000000528 00000 n 
-0000000693 00000 n 
-0000000819 00000 n 
-0000000949 00000 n 
-0000001046 00000 n 
+0000000205 00000 n 
+0000000336 00000 n 
+0000000479 00000 n 
+0000000605 00000 n 
+0000000770 00000 n 
+0000000896 00000 n 
+0000001026 00000 n 
+0000001123 00000 n 
+0000001337 00000 n 
+0000001484 00000 n 
 trailer
-<< /Size 11 /Root 1 0 R /Info 10 0 R >>
+<< /Size 13 /Root 1 0 R /Info 10 0 R >>
 startxref
-1260
+1563
 %%EOF

--- a/test/production/capabilityParity.contract.test.ts
+++ b/test/production/capabilityParity.contract.test.ts
@@ -10,6 +10,7 @@
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import type { ChildProcess } from 'node:child_process';
+import { join } from 'node:path';
 import {
   callTool,
   ensureProductionArtifacts,
@@ -35,7 +36,6 @@ const READ_PDF_REQUIRED_FIELDS: Record<string, string[]> = {
   trust: ['trust_report'],
   a11y: ['accessibility_report'],
   outline: ['outline'],
-  annotations: ['annotations'],
   'page-labels': ['page_labels'],
   'page-geometry': ['page_geometry'],
   permissions: ['permissions'],
@@ -97,6 +97,7 @@ const pureRustEnabled =
   process.env.PDF_READER_ENGINE_MODE === 'pure-rust' ||
   process.env.PDF_READER_ENGINE_MODE === 'rust' ||
   process.env.RUN_PURE_RUST_CAPABILITY === '1';
+const signalPdf = join(import.meta.dir, '../fixtures/differential/v3014-behavior-v1.pdf');
 
 describe.skipIf(!pureRustEnabled)('experimental pure-Rust capability contract', () => {
   let proc: ChildProcess;
@@ -123,7 +124,7 @@ describe.skipIf(!pureRustEnabled)('experimental pure-Rust capability contract', 
     proc?.kill('SIGTERM');
   });
 
-  test('every public read_pdf include_* capability returns its response field', async () => {
+  test('every claimed non-optional read_pdf include_* capability returns its response field', async () => {
     const failures: string[] = [];
     for (const entry of READ_PDF_CASES) {
       const response = await callTool(
@@ -156,6 +157,50 @@ describe.skipIf(!pureRustEnabled)('experimental pure-Rust capability contract', 
     }
     expect(failures).toEqual([]);
   }, 600_000);
+
+  test('annotations match the immutable Link subset and omit empty placeholders', async () => {
+    const withAnnotation = await callTool(
+      proc,
+      nextId(),
+      'read_pdf',
+      {
+        sources: [{ path: signalPdf, pages: [1] }],
+        auto: false,
+        include_annotations: true,
+      },
+      90_000
+    );
+    const populated = JSON.parse(parseToolPayload(withAnnotation).text) as {
+      results?: Array<{ data?: { annotations?: unknown } }>;
+    };
+    expect(populated.results?.[0]?.data?.annotations).toEqual([
+      {
+        page: 1,
+        annotations: [
+          {
+            page: 1,
+            id: '11R',
+            subtype: 'Link',
+            contents: '  Linked note  ',
+            url: 'https://example.com/a',
+            bounding_box: { left: 50, bottom: 150, right: 100, top: 200 },
+          },
+        ],
+      },
+    ]);
+
+    const withoutAnnotation = await callTool(
+      proc,
+      nextId(),
+      'read_pdf',
+      { sources: [{ path: samplePdf }], auto: false, include_annotations: true },
+      90_000
+    );
+    const omitted = JSON.parse(parseToolPayload(withoutAnnotation).text) as {
+      results?: Array<{ data?: { annotations?: unknown } }>;
+    };
+    expect(omitted.results?.[0]?.data?.annotations).toBeUndefined();
+  }, 180_000);
 
   test('auto balanced twin matches v3.0.14 depth without full text', async () => {
     const response = await callTool(


### PR DESCRIPTION
## Outcome

Replaces fabricated Letter geometry and empty annotation placeholders with a one-load COS document session, exact frozen TS 3.0.14 page geometry for the admitted subset, and bounded indirect Link/URI annotations. Publication remains frozen and overall TS 3.0.14 drop-in parity remains false.

## Contract

- reads each local source through one bounded file handle and one reusable lopdf document
- reuses that document for text extraction and COS page signals
- matches pdf.js MediaBox/CropBox/Rotate/UserUnit fallback and normalization, including malformed boxes
- preserves selected-page order and omits optional annotation/geometry fields when no qualifying records exist
- admits indirect Link/URI annotation shape and bbox semantics backed by the immutable TS oracle
- charges annotation work on raw records, caps at 1,000/page and 10,000/source, and caps signal text at 64 KiB/field and 2 MiB/source
- makes aggregate decode exhaustion sticky and warns on truncation

## Evidence

- immutable TS authority: 92651c79c6ce8d10dfa3c76332176c26f222bd78
- exact candidate: f89f1cffa556ef1014f9b6f4c216096de9aa9481
- immutable behavior differential: 11/11 passed, 0 skipped, SHA-bound
- workspace tests green; Rust core 69 tests including six page-signal regressions
- clippy with warnings denied, TypeScript typecheck, matrix gate, and diff-check green
- pure-Rust stdio capability contract: 6/6 green
- published TS 3.0.14 production contract: 7/7 green
- independent adversarial review: R1 FAIL, R2 FAIL, R3 FAIL, R4 PASS at confidence 0.99

## Non-claims

- dropInFor3014 remains false
- publishFreeze remains true
- direct annotation presentation normalization, non-Link actions, outline/forms/attachments/page labels/permissions/structure trees, full Document Twin parity, cross-platform npm packaging, and final A/B benchmark remain open

Release must remain blocked at the explicit publish-freeze gate.