### PR TITLE
feat(rust): add bounded catalog signal parity

### DIFF
--- a/.github/workflows/rust-parity-differential.yml
+++ b/.github/workflows/rust-parity-differential.yml
@@ -134,7 +134,7 @@ jobs:
           jq -e --arg sha "$CANDIDATE_SHA" '
             .profile == "pdf_reader_v3014_behavior_result" and
             .candidateSha == $sha and .pass == true and
-            .caseCount == 11 and .passed == 11 and .skipped == 0
+            .caseCount == 12 and .passed == 12 and .skipped == 0
           ' "$BEHAVIOR_ARTIFACT" >/dev/null || {
             echo "::error::v3.0.14 behavior result is incomplete, failing, or not SHA-bound"
             exit 1

--- a/crates/pdf-reader-core/src/catalog_signals.rs
+++ b/crates/pdf-reader-core/src/catalog_signals.rs
@@ -234,9 +234,9 @@ fn extract_page_labels(
     }
     let root = catalog.get(b"PageLabels").ok()?.clone();
     let mut ranges = Vec::new();
-    let mut path = HashSet::new();
+    let mut processed = HashSet::new();
     let mut invalid = false;
-    collect_label_ranges(walker, &root, 0, &mut path, &mut ranges, &mut invalid);
+    collect_label_ranges(walker, &root, 0, &mut processed, &mut ranges, &mut invalid);
     if invalid || walker.truncated || walker.failed {
         return None;
     }
@@ -276,7 +276,7 @@ fn collect_label_ranges(
     walker: &mut Walker<'_>,
     value: &Object,
     depth: usize,
-    path: &mut HashSet<ObjectId>,
+    processed: &mut HashSet<ObjectId>,
     output: &mut Vec<LabelRange>,
     invalid: &mut bool,
 ) {
@@ -287,16 +287,13 @@ fn collect_label_ranges(
     walker.entries += 1;
     let id = value.as_reference().ok();
     if let Some(id) = id {
-        if !path.insert(id) {
+        if !processed.insert(id) {
             walker.truncated = true;
             return;
         }
     }
     let Some(dict) = walker.dict(value) else {
         *invalid = true;
-        if let Some(id) = id {
-            path.remove(&id);
-        }
         return;
     };
     if let Ok(value) = dict.get(b"Kids") {
@@ -312,11 +309,14 @@ fn collect_label_ranges(
             return;
         }
         for kid in &kids {
-            collect_label_ranges(walker, kid, depth + 1, path, output, invalid);
+            collect_label_ranges(walker, kid, depth + 1, processed, output, invalid);
             if walker.truncated {
                 return;
             }
         }
+        // PDF.js treats a node with Kids as an internal node and ignores a
+        // same-node Nums entry.
+        return;
     }
     if let Ok(value) = dict.get(b"Nums") {
         let Some(nums) = walker
@@ -403,9 +403,6 @@ fn collect_label_ranges(
             });
         }
     }
-    if let Some(id) = id {
-        path.remove(&id);
-    }
 }
 
 fn format_label(style: Option<&[u8]>, number: u32) -> Option<String> {
@@ -467,7 +464,9 @@ fn extract_outline(walker: &mut Walker<'_>, catalog: &Dictionary) -> Option<Vec<
         return None;
     }
     let mut path = HashSet::new();
-    let items = outline_siblings(walker, first, 0, &mut path);
+    let mut processed = HashSet::new();
+    processed.insert(first.as_reference().ok()?);
+    let items = outline_siblings(walker, first, 0, &mut path, &mut processed);
     (!walker.truncated && !walker.failed).then_some(items)
 }
 
@@ -476,6 +475,7 @@ fn outline_siblings(
     mut current: Object,
     depth: usize,
     path: &mut HashSet<ObjectId>,
+    processed: &mut HashSet<ObjectId>,
 ) -> Vec<OutlineItem> {
     let mut output = Vec::new();
     let mut siblings = HashSet::new();
@@ -494,27 +494,63 @@ fn outline_siblings(
         let Some(dict) = walker.dict(&current) else {
             break;
         };
-        let next = dict.get(b"Next").ok().cloned();
-        if let Some(mut item) = normalize_outline_item(walker, &dict) {
-            if walker.entries >= MAX_ENTRIES {
-                walker.truncated = true;
-                break;
-            }
-            walker.entries += 1;
-            if let Ok(first) = dict.get(b"First") {
-                if first.as_reference().is_ok() {
-                    let children = outline_siblings(walker, first.clone(), depth + 1, path);
-                    if !children.is_empty() {
-                        item.items = Some(children);
-                    }
+        if walker.entries >= MAX_ENTRIES {
+            walker.truncated = true;
+            break;
+        }
+        walker.entries += 1;
+        let child = dict
+            .get(b"First")
+            .ok()
+            .cloned()
+            .filter(|value| value.as_reference().is_ok())
+            .and_then(|value| {
+                let child_id = value.as_reference().ok()?;
+                if path.contains(&child_id) {
+                    walker.truncated = true;
+                    None
+                } else if processed.insert(child_id) {
+                    Some(value)
+                } else {
+                    None
                 }
+            });
+        // PDF.js admits both First and Next refs to its global processed set
+        // while processing the current item, before either queued item runs.
+        let next = dict
+            .get(b"Next")
+            .ok()
+            .cloned()
+            .filter(|value| value.as_reference().is_ok())
+            .and_then(|value| {
+                let next_id = value.as_reference().ok()?;
+                if siblings.contains(&next_id) || path.contains(&next_id) {
+                    walker.truncated = true;
+                    None
+                } else if processed.insert(next_id) {
+                    Some(value)
+                } else {
+                    None
+                }
+            });
+        let mut item = normalize_outline_item(walker, &dict);
+        let mut children = Vec::new();
+        if let Some(first) = child {
+            children = outline_siblings(walker, first, depth + 1, path, processed);
+        }
+        if let Some(mut item) = item.take() {
+            if !children.is_empty() {
+                item.items = Some(children);
             }
             output.push(item);
         }
         if let Some(id) = current_id {
             path.remove(&id);
         }
-        let Some(value) = next.filter(|value| value.as_reference().is_ok()) else {
+        if walker.truncated {
+            break;
+        }
+        let Some(value) = next else {
             break;
         };
         current = value;
@@ -953,5 +989,111 @@ mod tests {
             },
         );
         assert!(out.outline.is_none());
+    }
+
+    #[test]
+    fn duplicate_number_tree_reference_omits_the_whole_surface() {
+        let mut doc = document(dictionary! {});
+        let leaf = doc.add_object(dictionary! {
+            "Nums"=>vec![0.into(),Object::Dictionary(dictionary!{"S"=>"D"})],
+        });
+        let labels = doc.add_object(dictionary! {"Kids"=>vec![leaf.into(),leaf.into()]});
+        doc.catalog_mut().unwrap().set("PageLabels", labels);
+        let out = extract_catalog_signals(
+            &doc,
+            None,
+            1,
+            CatalogSignalRequest {
+                page_labels: true,
+                permissions: false,
+                outline: false,
+            },
+        );
+        assert!(out.page_labels.is_none());
+    }
+
+    #[test]
+    fn number_tree_kids_take_precedence_over_same_node_nums() {
+        let mut doc = document(dictionary! {});
+        let leaf = doc.add_object(dictionary! {
+            "Nums"=>vec![0.into(),Object::Dictionary(dictionary!{"S"=>"D"})],
+        });
+        let labels = doc.add_object(dictionary! {
+            "Kids"=>vec![leaf.into()],
+            "Nums"=>vec![0.into(),Object::Dictionary(dictionary!{"P"=>Object::string_literal("wrong")})],
+        });
+        doc.catalog_mut().unwrap().set("PageLabels", labels);
+        let out = extract_catalog_signals(
+            &doc,
+            None,
+            2,
+            CatalogSignalRequest {
+                page_labels: true,
+                permissions: false,
+                outline: false,
+            },
+        );
+        assert_eq!(out.page_labels, Some(vec!["1".into(), "2".into()]));
+    }
+
+    #[test]
+    fn shared_outline_reference_is_emitted_only_on_first_pdfjs_branch() {
+        let mut doc = document(dictionary! {});
+        let shared = doc.add_object(dictionary! {"Title"=>Object::string_literal("Shared")});
+        let second = doc.add_object(dictionary! {
+            "Title"=>Object::string_literal("Second"),
+            "First"=>shared,
+        });
+        let first = doc.add_object(dictionary! {
+            "Title"=>Object::string_literal("First"),
+            "First"=>shared,
+            "Next"=>second,
+        });
+        let outlines = doc.add_object(dictionary! {"First"=>first});
+        doc.catalog_mut().unwrap().set("Outlines", outlines);
+        let out = extract_catalog_signals(
+            &doc,
+            None,
+            0,
+            CatalogSignalRequest {
+                page_labels: false,
+                permissions: false,
+                outline: true,
+            },
+        );
+        let value = serde_json::to_value(out.outline).unwrap();
+        assert_eq!(value[0]["items"][0]["title"], "Shared");
+        assert!(value[1].get("items").is_none());
+    }
+
+    #[test]
+    fn outline_first_and_next_are_globally_admitted_before_child_runs() {
+        let mut doc = document(dictionary! {});
+        let shared = doc.add_object(dictionary! {"Title"=>Object::string_literal("Shared")});
+        let child = doc.add_object(dictionary! {
+            "Title"=>Object::string_literal("Child"),
+            "First"=>shared,
+        });
+        let first = doc.add_object(dictionary! {
+            "Title"=>Object::string_literal("First"),
+            "First"=>child,
+            "Next"=>shared,
+        });
+        let outlines = doc.add_object(dictionary! {"First"=>first});
+        doc.catalog_mut().unwrap().set("Outlines", outlines);
+        let out = extract_catalog_signals(
+            &doc,
+            None,
+            0,
+            CatalogSignalRequest {
+                page_labels: false,
+                permissions: false,
+                outline: true,
+            },
+        );
+        let value = serde_json::to_value(out.outline).unwrap();
+        assert_eq!(value[0]["items"][0]["title"], "Child");
+        assert!(value[0]["items"][0].get("items").is_none());
+        assert_eq!(value[1]["title"], "Shared");
     }
 }

--- a/crates/pdf-reader-core/src/catalog_signals.rs
+++ b/crates/pdf-reader-core/src/catalog_signals.rs
@@ -1,0 +1,720 @@
+use std::collections::HashSet;
+
+use lopdf::{Dictionary, Document, Object, ObjectId};
+use pdf_extract::decode_text_string;
+use serde::Serialize;
+
+use crate::cos_document::EncryptionFacts;
+
+const MAX_REFERENCE_DEPTH: usize = 64;
+const MAX_TREE_DEPTH: usize = 64;
+const MAX_OBJECT_WORK: usize = 100_000;
+const MAX_ENTRIES: usize = 10_000;
+const MAX_STRING_BYTES: usize = 64 * 1024;
+const MAX_TEXT_BYTES: usize = 2 * 1024 * 1024;
+
+#[derive(Default)]
+pub(crate) struct CatalogSignals {
+    pub page_labels: Option<Vec<String>>,
+    pub mark_info: Option<MarkInfo>,
+    pub permissions: Option<Vec<String>>,
+    pub outline: Option<Vec<OutlineItem>>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct MarkInfo {
+    #[serde(rename = "Marked")]
+    marked: bool,
+    #[serde(rename = "UserProperties")]
+    user_properties: bool,
+    #[serde(rename = "Suspects")]
+    suspects: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct OutlineItem {
+    title: String,
+    bold: bool,
+    italic: bool,
+    color: Vec<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    url: Option<String>,
+    dest: Destination,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    items: Option<Vec<OutlineItem>>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum Destination {
+    Text(String),
+    Parts(Vec<DestinationPart>),
+    Null,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum DestinationPart {
+    Integer(i64),
+    Real(f64),
+    Text(String),
+    Name { name: String },
+    Reference { num: u32, gen: u16 },
+    Null,
+}
+
+pub(crate) struct CatalogSignalRequest {
+    pub page_labels: bool,
+    pub permissions: bool,
+    pub outline: bool,
+}
+
+pub(crate) fn extract_catalog_signals(
+    document: &Document,
+    encryption_facts: Option<EncryptionFacts>,
+    num_pages: u32,
+    request: CatalogSignalRequest,
+) -> CatalogSignals {
+    let mut output = CatalogSignals::default();
+    let Ok(catalog) = document.catalog().cloned() else {
+        return output;
+    };
+    if request.page_labels {
+        let mut walker = Walker::new(document);
+        output.page_labels = extract_page_labels(&mut walker, &catalog, num_pages);
+    }
+    if request.permissions {
+        output.permissions = extract_permissions(encryption_facts);
+        let mut walker = Walker::new(document);
+        output.mark_info = extract_mark_info(&mut walker, &catalog);
+    }
+    if request.outline {
+        let mut walker = Walker::new(document);
+        output.outline = extract_outline(&mut walker, &catalog);
+    }
+    output
+}
+
+struct Walker<'a> {
+    document: &'a Document,
+    work: usize,
+    entries: usize,
+    text_remaining: usize,
+    truncated: bool,
+}
+
+impl<'a> Walker<'a> {
+    fn new(document: &'a Document) -> Self {
+        Self {
+            document,
+            work: 0,
+            entries: 0,
+            text_remaining: MAX_TEXT_BYTES,
+            truncated: false,
+        }
+    }
+
+    fn resolve_owned(&mut self, value: &Object) -> Option<Object> {
+        let mut current = value.clone();
+        let mut visited = HashSet::new();
+        for _ in 0..MAX_REFERENCE_DEPTH {
+            self.work += 1;
+            if self.work > MAX_OBJECT_WORK {
+                self.truncated = true;
+                return None;
+            }
+            let Object::Reference(id) = current else {
+                return Some(current);
+            };
+            if !visited.insert(id) {
+                self.truncated = true;
+                return None;
+            }
+            current = self.document.get_object(id).ok()?.clone();
+        }
+        self.truncated = true;
+        None
+    }
+
+    fn dict(&mut self, value: &Object) -> Option<Dictionary> {
+        self.resolve_owned(value)?.as_dict().ok().cloned()
+    }
+
+    fn text(&mut self, value: &Object) -> Option<String> {
+        let value = self.resolve_owned(value)?;
+        let raw_len = match &value {
+            Object::String(bytes, _) | Object::Name(bytes) => bytes.len(),
+            _ => return None,
+        };
+        if raw_len > MAX_STRING_BYTES || raw_len > self.text_remaining {
+            self.truncated = true;
+            return None;
+        }
+        let decoded = match &value {
+            Object::Name(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+            _ => decode_text_string(&value).ok()?,
+        };
+        if decoded.len() > MAX_STRING_BYTES || decoded.len() > self.text_remaining {
+            self.truncated = true;
+            return None;
+        }
+        self.text_remaining -= decoded.len();
+        Some(decoded)
+    }
+}
+
+fn extract_mark_info(walker: &mut Walker<'_>, catalog: &Dictionary) -> Option<MarkInfo> {
+    let dict = walker.dict(catalog.get(b"MarkInfo").ok()?)?;
+    let mut boolean = |key: &[u8]| {
+        dict.get(key)
+            .ok()
+            .and_then(|value| walker.resolve_owned(value))
+            .and_then(|value| value.as_bool().ok())
+    };
+    let value = MarkInfo {
+        marked: boolean(b"Marked").unwrap_or(false),
+        user_properties: boolean(b"UserProperties").unwrap_or(false),
+        suspects: boolean(b"Suspects").unwrap_or(false),
+    };
+    Some(value)
+}
+
+fn extract_permissions(facts: Option<EncryptionFacts>) -> Option<Vec<String>> {
+    let facts = facts?;
+    let raw = facts.permissions?;
+    let bits = (raw as i32) as u32;
+    let mut labels = Vec::new();
+    for (flag, label) in [
+        (4, "print"),
+        (8, "modify"),
+        (16, "copy"),
+        (32, "annotate"),
+        (256, "fill_forms"),
+        (512, "copy_for_accessibility"),
+        (1024, "assemble"),
+        (2048, "print_high_quality"),
+    ] {
+        if bits & flag != 0 {
+            labels.push(label.to_string());
+        }
+    }
+    (!labels.is_empty()).then_some(labels)
+}
+
+#[derive(Clone)]
+struct LabelRange {
+    start: u32,
+    style: Option<Vec<u8>>,
+    prefix: String,
+    first: u32,
+}
+
+fn extract_page_labels(
+    walker: &mut Walker<'_>,
+    catalog: &Dictionary,
+    num_pages: u32,
+) -> Option<Vec<String>> {
+    if num_pages as usize > MAX_ENTRIES {
+        walker.truncated = true;
+        return None;
+    }
+    let root = catalog.get(b"PageLabels").ok()?.clone();
+    let mut ranges = Vec::new();
+    let mut path = HashSet::new();
+    let mut invalid = false;
+    collect_label_ranges(walker, &root, 0, &mut path, &mut ranges, &mut invalid);
+    if invalid || walker.truncated {
+        return None;
+    }
+    ranges.sort_by_key(|range| range.start);
+    ranges.dedup_by_key(|range| range.start);
+    let mut labels = Vec::with_capacity(num_pages as usize);
+    let default_range = LabelRange {
+        start: 0,
+        style: None,
+        prefix: String::new(),
+        first: 1,
+    };
+    let mut active: &LabelRange = &default_range;
+    let mut next = 0usize;
+    let mut label_bytes_remaining = MAX_TEXT_BYTES;
+    for page_index in 0..num_pages {
+        while next < ranges.len() && ranges[next].start <= page_index {
+            active = &ranges[next];
+            next += 1;
+        }
+        let range = active;
+        let number = range
+            .first
+            .saturating_add(page_index.saturating_sub(range.start));
+        let suffix = format_label(range.style.as_deref(), number)?;
+        let label_bytes = range.prefix.len().checked_add(suffix.len())?;
+        if label_bytes > MAX_STRING_BYTES || label_bytes > label_bytes_remaining {
+            return None;
+        }
+        label_bytes_remaining -= label_bytes;
+        labels.push(format!("{}{}", range.prefix, suffix));
+    }
+    Some(labels)
+}
+
+fn collect_label_ranges(
+    walker: &mut Walker<'_>,
+    value: &Object,
+    depth: usize,
+    path: &mut HashSet<ObjectId>,
+    output: &mut Vec<LabelRange>,
+    invalid: &mut bool,
+) {
+    if depth >= MAX_TREE_DEPTH || output.len() >= MAX_ENTRIES {
+        walker.truncated = true;
+        return;
+    }
+    let id = value.as_reference().ok();
+    if let Some(id) = id {
+        if !path.insert(id) {
+            walker.truncated = true;
+            return;
+        }
+    }
+    let Some(dict) = walker.dict(value) else {
+        if let Some(id) = id {
+            path.remove(&id);
+        }
+        return;
+    };
+    if let Ok(kids) = dict.get(b"Kids").and_then(Object::as_array) {
+        for kid in kids.iter().take(MAX_ENTRIES.saturating_sub(output.len())) {
+            collect_label_ranges(walker, kid, depth + 1, path, output, invalid);
+        }
+    }
+    if let Ok(nums) = dict.get(b"Nums").and_then(Object::as_array) {
+        for pair in nums
+            .chunks_exact(2)
+            .take(MAX_ENTRIES.saturating_sub(output.len()))
+        {
+            let Some(start) = walker
+                .resolve_owned(&pair[0])
+                .and_then(|value| value.as_i64().ok())
+                .and_then(|n| u32::try_from(n).ok())
+            else {
+                *invalid = true;
+                continue;
+            };
+            let Some(spec) = walker.dict(&pair[1]) else {
+                *invalid = true;
+                continue;
+            };
+            if let Ok(value) = spec.get(b"Type") {
+                let valid = walker
+                    .resolve_owned(value)
+                    .and_then(|value| value.as_name().ok().map(<[u8]>::to_vec))
+                    .is_some_and(|name| name == b"PageLabel");
+                if !valid {
+                    *invalid = true;
+                    continue;
+                }
+            }
+            let style = if let Ok(value) = spec.get(b"S") {
+                let Some(style) = walker
+                    .resolve_owned(value)
+                    .and_then(|value| value.as_name().ok().map(<[u8]>::to_vec))
+                else {
+                    *invalid = true;
+                    continue;
+                };
+                Some(style)
+            } else {
+                None
+            };
+            if style
+                .as_deref()
+                .is_some_and(|value| !matches!(value, b"D" | b"R" | b"r" | b"A" | b"a"))
+            {
+                *invalid = true;
+                continue;
+            }
+            let prefix = if let Ok(value) = spec.get(b"P") {
+                let Some(prefix) = walker.text(value) else {
+                    *invalid = true;
+                    continue;
+                };
+                prefix
+            } else {
+                String::new()
+            };
+            let first = if let Ok(value) = spec.get(b"St") {
+                let Some(value) = value
+                    .as_i64()
+                    .ok()
+                    .and_then(|n| u32::try_from(n).ok())
+                    .filter(|n| *n > 0)
+                else {
+                    *invalid = true;
+                    continue;
+                };
+                value
+            } else {
+                1
+            };
+            output.push(LabelRange {
+                start,
+                style,
+                prefix,
+                first,
+            });
+        }
+        if nums.len() % 2 != 0 {
+            walker.truncated = true;
+        }
+    }
+    if let Some(id) = id {
+        path.remove(&id);
+    }
+}
+
+fn format_label(style: Option<&[u8]>, number: u32) -> Option<String> {
+    match style {
+        None => Some(String::new()),
+        Some(b"D") => Some(number.to_string()),
+        Some(b"R") => roman(number, false),
+        Some(b"r") => roman(number, true),
+        Some(b"A") => alphabetic(number, false),
+        Some(b"a") => alphabetic(number, true),
+        _ => None,
+    }
+}
+
+fn alphabetic(number: u32, lower: bool) -> Option<String> {
+    if number == 0 {
+        return None;
+    }
+    let ch = ((number - 1) % 26) as u8 + if lower { b'a' } else { b'A' };
+    let repetitions = ((number - 1) / 26 + 1) as usize;
+    if repetitions > MAX_STRING_BYTES {
+        return None;
+    }
+    Some(std::iter::repeat_n(char::from(ch), repetitions).collect())
+}
+
+fn roman(mut number: u32, lower: bool) -> Option<String> {
+    if number == 0 || number > 3999 {
+        return None;
+    }
+    let mut out = String::new();
+    for (value, token) in [
+        (1000, "M"),
+        (900, "CM"),
+        (500, "D"),
+        (400, "CD"),
+        (100, "C"),
+        (90, "XC"),
+        (50, "L"),
+        (40, "XL"),
+        (10, "X"),
+        (9, "IX"),
+        (5, "V"),
+        (4, "IV"),
+        (1, "I"),
+    ] {
+        while number >= value {
+            number -= value;
+            out.push_str(token);
+        }
+    }
+    Some(if lower { out.to_lowercase() } else { out })
+}
+
+fn extract_outline(walker: &mut Walker<'_>, catalog: &Dictionary) -> Option<Vec<OutlineItem>> {
+    let root = walker.dict(catalog.get(b"Outlines").ok()?)?;
+    let first = root.get(b"First").ok()?.clone();
+    let mut path = HashSet::new();
+    Some(outline_siblings(walker, first, 0, &mut path))
+}
+
+fn outline_siblings(
+    walker: &mut Walker<'_>,
+    mut current: Object,
+    depth: usize,
+    path: &mut HashSet<ObjectId>,
+) -> Vec<OutlineItem> {
+    let mut output = Vec::new();
+    let mut siblings = HashSet::new();
+    while output.len() < MAX_ENTRIES {
+        if depth >= MAX_TREE_DEPTH {
+            walker.truncated = true;
+            break;
+        }
+        if let Ok(id) = current.as_reference() {
+            if !siblings.insert(id) || !path.insert(id) {
+                walker.truncated = true;
+                break;
+            }
+        }
+        let current_id = current.as_reference().ok();
+        let Some(dict) = walker.dict(&current) else {
+            break;
+        };
+        let next = dict.get(b"Next").ok().cloned();
+        if let Some(mut item) = normalize_outline_item(walker, &dict) {
+            if walker.entries >= MAX_ENTRIES {
+                walker.truncated = true;
+                break;
+            }
+            walker.entries += 1;
+            if let Ok(first) = dict.get(b"First") {
+                let children = outline_siblings(walker, first.clone(), depth + 1, path);
+                if !children.is_empty() {
+                    item.items = Some(children);
+                }
+            }
+            output.push(item);
+        }
+        if let Some(id) = current_id {
+            path.remove(&id);
+        }
+        let Some(value) = next else { break };
+        current = value;
+    }
+    if output.len() >= MAX_ENTRIES {
+        walker.truncated = true;
+    }
+    output
+}
+
+fn normalize_outline_item(walker: &mut Walker<'_>, dict: &Dictionary) -> Option<OutlineItem> {
+    let title = walker.text(dict.get(b"Title").ok()?)?.trim().to_string();
+    if title.is_empty() {
+        return None;
+    }
+    let flags = dict
+        .get(b"F")
+        .ok()
+        .and_then(|v| v.as_i64().ok())
+        .unwrap_or(0);
+    let color = dict
+        .get(b"C")
+        .ok()
+        .and_then(|v| v.as_array().ok())
+        .filter(|v| v.len() == 3)
+        .and_then(|v| v.iter().map(finite_number).collect::<Option<Vec<_>>>())
+        .map(|values| {
+            values
+                .into_iter()
+                .map(|value| (value.clamp(0.0, 1.0) * 255.0).round() as u8)
+                .collect()
+        })
+        .unwrap_or_else(|| vec![0, 0, 0]);
+    let direct_dest = dict
+        .get(b"Dest")
+        .ok()
+        .and_then(|v| normalized_destination(walker, v));
+    let action = dict.get(b"A").ok().and_then(|v| walker.dict(v));
+    let action_kind = action
+        .as_ref()
+        .and_then(|a| a.get(b"S").ok())
+        .and_then(|v| v.as_name().ok());
+    let url = action
+        .as_ref()
+        .filter(|_| action_kind == Some(b"URI"))
+        .and_then(|a| a.get(b"URI").ok())
+        .and_then(|v| walker.text(v));
+    let action_dest = action
+        .as_ref()
+        .filter(|_| action_kind == Some(b"GoTo"))
+        .and_then(|a| a.get(b"D").ok())
+        .and_then(|v| normalized_destination(walker, v));
+    // PDF.js initializes every outline destination to null, including items
+    // with no action or with an unsupported action. The TS sanitizer retains
+    // null because the member is defined.
+    let dest = direct_dest.or(action_dest).unwrap_or(Destination::Null);
+    Some(OutlineItem {
+        title,
+        bold: flags & 2 != 0,
+        italic: flags & 1 != 0,
+        color,
+        url,
+        dest,
+        items: None,
+    })
+}
+
+fn finite_number(value: &Object) -> Option<f64> {
+    let n = match value {
+        Object::Integer(v) => *v as f64,
+        Object::Real(v) => f64::from(*v),
+        _ => return None,
+    };
+    n.is_finite().then_some(n)
+}
+
+fn normalized_destination(walker: &mut Walker<'_>, value: &Object) -> Option<Destination> {
+    let value = walker.resolve_owned(value)?;
+    match &value {
+        Object::String(_, _) | Object::Name(_) => walker.text(&value).map(Destination::Text),
+        Object::Array(parts) if parts.len() <= 8 => {
+            let mut output = Vec::new();
+            for part in parts {
+                output.push(match part {
+                    Object::Integer(v) => DestinationPart::Integer(*v),
+                    Object::Real(v) if v.is_finite() => DestinationPart::Real(f64::from(*v)),
+                    Object::String(_, _) => DestinationPart::Text(walker.text(part)?),
+                    Object::Name(_) => DestinationPart::Name {
+                        name: walker.text(part)?,
+                    },
+                    Object::Reference((num, gen)) => DestinationPart::Reference {
+                        num: *num,
+                        gen: *gen,
+                    },
+                    Object::Null => DestinationPart::Null,
+                    _ => return None,
+                });
+            }
+            Some(Destination::Parts(output))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lopdf::dictionary;
+
+    fn document(catalog_extra: Dictionary) -> Document {
+        let mut document = Document::with_version("1.7");
+        let pages = document
+            .add_object(dictionary! {"Type"=>"Pages","Kids"=>Vec::<Object>::new(),"Count"=>0});
+        let mut catalog = dictionary! {"Type"=>"Catalog","Pages"=>pages};
+        catalog.extend(&catalog_extra);
+        let root = document.add_object(catalog);
+        document.trailer.set("Root", root);
+        document
+    }
+
+    #[test]
+    fn expands_number_tree_labels_and_mark_info() {
+        let doc = document(dictionary! {
+            "PageLabels"=>dictionary!{"Nums"=>vec![0.into(),Object::Dictionary(dictionary!{"S"=>"r"}),2.into(),Object::Dictionary(dictionary!{"P"=>Object::string_literal("A-"),"S"=>"D","St"=>3})]},
+            "MarkInfo"=>dictionary!{"Marked"=>true,"Suspects"=>false},
+        });
+        let out = extract_catalog_signals(
+            &doc,
+            None,
+            4,
+            CatalogSignalRequest {
+                page_labels: true,
+                permissions: true,
+                outline: false,
+            },
+        );
+        assert_eq!(
+            out.page_labels,
+            Some(vec!["i".into(), "ii".into(), "A-3".into(), "A-4".into()])
+        );
+        assert_eq!(
+            serde_json::to_value(out.mark_info).unwrap(),
+            serde_json::json!({"Marked":true,"UserProperties":false,"Suspects":false})
+        );
+    }
+
+    #[test]
+    fn preserves_nested_outline_styles_and_safe_actions() {
+        let mut doc = document(dictionary! {});
+        let child=doc.add_object(dictionary!{"Title"=>Object::string_literal("Child"),"A"=>dictionary!{"S"=>"URI","URI"=>Object::string_literal("https://example.com")}});
+        let first=doc.add_object(dictionary!{"Title"=>Object::string_literal("Root"),"F"=>3,"C"=>vec![1.into(),0.into(),0.into()],"First"=>child});
+        let outlines = doc.add_object(dictionary! {"First"=>first});
+        doc.catalog_mut().unwrap().set("Outlines", outlines);
+        let out = extract_catalog_signals(
+            &doc,
+            None,
+            0,
+            CatalogSignalRequest {
+                page_labels: false,
+                permissions: false,
+                outline: true,
+            },
+        );
+        let value = serde_json::to_value(out.outline).unwrap();
+        assert_eq!(value[0]["title"], "Root");
+        assert_eq!(value[0]["bold"], true);
+        assert_eq!(value[0]["items"][0]["url"], "https://example.com");
+    }
+
+    #[test]
+    fn permission_bits_match_pdfjs_p_flag_enumeration() {
+        let facts = EncryptionFacts {
+            permissions: Some(4 | 8 | 256),
+        };
+        assert_eq!(
+            extract_permissions(Some(facts)),
+            Some(vec!["print".into(), "modify".into(), "fill_forms".into()])
+        );
+    }
+
+    #[test]
+    fn mark_info_defaults_missing_and_non_boolean_keys_to_false() {
+        let doc = document(dictionary! {
+            "MarkInfo"=>dictionary!{"Marked"=>true,"Suspects"=>1},
+        });
+        let out = extract_catalog_signals(
+            &doc,
+            None,
+            0,
+            CatalogSignalRequest {
+                page_labels: false,
+                permissions: true,
+                outline: false,
+            },
+        );
+        assert_eq!(
+            serde_json::to_value(out.mark_info).unwrap(),
+            serde_json::json!({"Marked":true,"UserProperties":false,"Suspects":false})
+        );
+    }
+
+    #[test]
+    fn outline_without_action_retains_pdfjs_null_destination() {
+        let mut doc = document(dictionary! {});
+        let first = doc.add_object(dictionary! {
+            "Title"=>Object::string_literal("Plain"),
+        });
+        let outlines = doc.add_object(dictionary! {"First"=>first});
+        doc.catalog_mut().unwrap().set("Outlines", outlines);
+        let out = extract_catalog_signals(
+            &doc,
+            None,
+            0,
+            CatalogSignalRequest {
+                page_labels: false,
+                permissions: false,
+                outline: true,
+            },
+        );
+        let value = serde_json::to_value(out.outline).unwrap();
+        assert_eq!(value[0]["dest"], serde_json::Value::Null);
+        assert_eq!(value[0]["bold"], false);
+        assert_eq!(value[0]["color"], serde_json::json!([0, 0, 0]));
+    }
+
+    #[test]
+    fn invalid_page_label_dictionary_omits_the_whole_surface() {
+        let doc = document(dictionary! {
+            "PageLabels"=>dictionary!{"Nums"=>vec![
+                0.into(),
+                Object::Dictionary(dictionary!{"S"=>"Bogus"}),
+            ]},
+        });
+        let out = extract_catalog_signals(
+            &doc,
+            None,
+            2,
+            CatalogSignalRequest {
+                page_labels: true,
+                permissions: false,
+                outline: false,
+            },
+        );
+        assert!(out.page_labels.is_none());
+    }
+}

--- a/crates/pdf-reader-core/src/catalog_signals.rs
+++ b/crates/pdf-reader-core/src/catalog_signals.rs
@@ -299,19 +299,33 @@ fn collect_label_ranges(
         }
         return;
     };
-    if let Ok(kids) = dict.get(b"Kids").and_then(Object::as_array) {
+    if let Ok(value) = dict.get(b"Kids") {
+        let Some(kids) = walker
+            .resolve_owned(value)
+            .and_then(|value| value.as_array().ok().cloned())
+        else {
+            *invalid = true;
+            return;
+        };
         if kids.len() > MAX_ENTRIES {
             walker.truncated = true;
             return;
         }
-        for kid in kids {
+        for kid in &kids {
             collect_label_ranges(walker, kid, depth + 1, path, output, invalid);
             if walker.truncated {
                 return;
             }
         }
     }
-    if let Ok(nums) = dict.get(b"Nums").and_then(Object::as_array) {
+    if let Ok(value) = dict.get(b"Nums") {
+        let Some(nums) = walker
+            .resolve_owned(value)
+            .and_then(|value| value.as_array().ok().cloned())
+        else {
+            *invalid = true;
+            return;
+        };
         if nums.len() % 2 != 0 || nums.len() / 2 > MAX_ENTRIES.saturating_sub(output.len()) {
             walker.truncated = true;
             return;
@@ -449,6 +463,9 @@ fn roman(mut number: u32, lower: bool) -> Option<String> {
 fn extract_outline(walker: &mut Walker<'_>, catalog: &Dictionary) -> Option<Vec<OutlineItem>> {
     let root = walker.dict(catalog.get(b"Outlines").ok()?)?;
     let first = root.get(b"First").ok()?.clone();
+    if first.as_reference().is_err() {
+        return None;
+    }
     let mut path = HashSet::new();
     let items = outline_siblings(walker, first, 0, &mut path);
     (!walker.truncated && !walker.failed).then_some(items)
@@ -485,9 +502,11 @@ fn outline_siblings(
             }
             walker.entries += 1;
             if let Ok(first) = dict.get(b"First") {
-                let children = outline_siblings(walker, first.clone(), depth + 1, path);
-                if !children.is_empty() {
-                    item.items = Some(children);
+                if first.as_reference().is_ok() {
+                    let children = outline_siblings(walker, first.clone(), depth + 1, path);
+                    if !children.is_empty() {
+                        item.items = Some(children);
+                    }
                 }
             }
             output.push(item);
@@ -495,7 +514,9 @@ fn outline_siblings(
         if let Some(id) = current_id {
             path.remove(&id);
         }
-        let Some(value) = next else { break };
+        let Some(value) = next.filter(|value| value.as_reference().is_ok()) else {
+            break;
+        };
         current = value;
     }
     if output.len() >= MAX_ENTRIES {
@@ -541,7 +562,7 @@ fn normalize_outline_item(walker: &mut Walker<'_>, dict: &Dictionary) -> Option<
         .filter(|_| action_kind == Some(b"URI"))
         .and_then(|a| a.get(b"URI").ok())
         .and_then(|v| walker.text(v))
-        .and_then(|value| safe_outline_url(&value));
+        .and_then(|value| safe_outline_url(walker, &value));
     let action_dest = action
         .as_ref()
         .filter(|_| action_kind == Some(b"GoTo"))
@@ -562,10 +583,25 @@ fn normalize_outline_item(walker: &mut Walker<'_>, dict: &Dictionary) -> Option<
     })
 }
 
-fn safe_outline_url(value: &str) -> Option<String> {
+fn safe_outline_url(walker: &mut Walker<'_>, value: &str) -> Option<String> {
     let parsed = url::Url::parse(value).ok()?;
-    matches!(parsed.scheme(), "http" | "https" | "ftp" | "mailto" | "tel")
-        .then(|| parsed.to_string())
+    if !matches!(parsed.scheme(), "http" | "https" | "ftp" | "mailto" | "tel") {
+        return None;
+    }
+    let normalized = parsed.to_string();
+    if normalized.len() > MAX_STRING_BYTES {
+        walker.text_remaining = 0;
+        walker.truncated = true;
+        return None;
+    }
+    let expansion = normalized.len().saturating_sub(value.len());
+    if expansion > walker.text_remaining {
+        walker.text_remaining = 0;
+        walker.truncated = true;
+        return None;
+    }
+    walker.text_remaining -= expansion;
+    Some(normalized)
 }
 
 fn finite_number(value: &Object) -> Option<f64> {
@@ -851,5 +887,71 @@ mod tests {
             },
         );
         assert!(out.mark_info.is_none());
+    }
+
+    #[test]
+    fn indirect_number_tree_array_is_resolved() {
+        let mut doc = document(dictionary! {});
+        let nums = doc.add_object(Object::Array(vec![
+            0.into(),
+            Object::Dictionary(dictionary! {"S"=>"D"}),
+        ]));
+        let labels = doc.add_object(dictionary! {"Nums"=>nums});
+        doc.catalog_mut().unwrap().set("PageLabels", labels);
+        let out = extract_catalog_signals(
+            &doc,
+            None,
+            2,
+            CatalogSignalRequest {
+                page_labels: true,
+                permissions: false,
+                outline: false,
+            },
+        );
+        assert_eq!(out.page_labels, Some(vec!["1".into(), "2".into()]));
+    }
+
+    #[test]
+    fn direct_outline_link_is_omitted_like_pdfjs() {
+        let doc = document(dictionary! {
+            "Outlines"=>dictionary!{"First"=>dictionary!{"Title"=>Object::string_literal("Direct")}},
+        });
+        let out = extract_catalog_signals(
+            &doc,
+            None,
+            0,
+            CatalogSignalRequest {
+                page_labels: false,
+                permissions: false,
+                outline: true,
+            },
+        );
+        assert!(out.outline.is_none());
+    }
+
+    #[test]
+    fn url_normalization_expansion_respects_the_field_cap() {
+        let mut doc = document(dictionary! {});
+        let oversized_after_normalization = format!("https://example.com/{}", "\"".repeat(30_000));
+        let first = doc.add_object(dictionary! {
+            "Title"=>Object::string_literal("Expanded"),
+            "A"=>dictionary!{
+                "S"=>"URI",
+                "URI"=>Object::string_literal(oversized_after_normalization),
+            },
+        });
+        let outlines = doc.add_object(dictionary! {"First"=>first});
+        doc.catalog_mut().unwrap().set("Outlines", outlines);
+        let out = extract_catalog_signals(
+            &doc,
+            None,
+            0,
+            CatalogSignalRequest {
+                page_labels: false,
+                permissions: false,
+                outline: true,
+            },
+        );
+        assert!(out.outline.is_none());
     }
 }

--- a/crates/pdf-reader-core/src/catalog_signals.rs
+++ b/crates/pdf-reader-core/src/catalog_signals.rs
@@ -101,6 +101,7 @@ struct Walker<'a> {
     entries: usize,
     text_remaining: usize,
     truncated: bool,
+    failed: bool,
 }
 
 impl<'a> Walker<'a> {
@@ -111,6 +112,7 @@ impl<'a> Walker<'a> {
             entries: 0,
             text_remaining: MAX_TEXT_BYTES,
             truncated: false,
+            failed: false,
         }
     }
 
@@ -130,7 +132,11 @@ impl<'a> Walker<'a> {
                 self.truncated = true;
                 return None;
             }
-            current = self.document.get_object(id).ok()?.clone();
+            let Ok(next) = self.document.get_object(id) else {
+                self.failed = true;
+                return None;
+            };
+            current = next.clone();
         }
         self.truncated = true;
         None
@@ -147,14 +153,22 @@ impl<'a> Walker<'a> {
             _ => return None,
         };
         if raw_len > MAX_STRING_BYTES || raw_len > self.text_remaining {
+            self.text_remaining = 0;
             self.truncated = true;
             return None;
         }
         let decoded = match &value {
             Object::Name(bytes) => String::from_utf8_lossy(bytes).into_owned(),
-            _ => decode_text_string(&value).ok()?,
+            _ => match decode_text_string(&value) {
+                Ok(value) => value,
+                Err(_) => {
+                    self.failed = true;
+                    return None;
+                }
+            },
         };
         if decoded.len() > MAX_STRING_BYTES || decoded.len() > self.text_remaining {
+            self.text_remaining = 0;
             self.truncated = true;
             return None;
         }
@@ -176,7 +190,7 @@ fn extract_mark_info(walker: &mut Walker<'_>, catalog: &Dictionary) -> Option<Ma
         user_properties: boolean(b"UserProperties").unwrap_or(false),
         suspects: boolean(b"Suspects").unwrap_or(false),
     };
-    Some(value)
+    (!walker.truncated && !walker.failed).then_some(value)
 }
 
 fn extract_permissions(facts: Option<EncryptionFacts>) -> Option<Vec<String>> {
@@ -223,7 +237,7 @@ fn extract_page_labels(
     let mut path = HashSet::new();
     let mut invalid = false;
     collect_label_ranges(walker, &root, 0, &mut path, &mut ranges, &mut invalid);
-    if invalid || walker.truncated {
+    if invalid || walker.truncated || walker.failed {
         return None;
     }
     ranges.sort_by_key(|range| range.start);
@@ -266,10 +280,11 @@ fn collect_label_ranges(
     output: &mut Vec<LabelRange>,
     invalid: &mut bool,
 ) {
-    if depth >= MAX_TREE_DEPTH || output.len() >= MAX_ENTRIES {
+    if depth >= MAX_TREE_DEPTH || output.len() >= MAX_ENTRIES || walker.entries >= MAX_ENTRIES {
         walker.truncated = true;
         return;
     }
+    walker.entries += 1;
     let id = value.as_reference().ok();
     if let Some(id) = id {
         if !path.insert(id) {
@@ -278,21 +293,30 @@ fn collect_label_ranges(
         }
     }
     let Some(dict) = walker.dict(value) else {
+        *invalid = true;
         if let Some(id) = id {
             path.remove(&id);
         }
         return;
     };
     if let Ok(kids) = dict.get(b"Kids").and_then(Object::as_array) {
-        for kid in kids.iter().take(MAX_ENTRIES.saturating_sub(output.len())) {
+        if kids.len() > MAX_ENTRIES {
+            walker.truncated = true;
+            return;
+        }
+        for kid in kids {
             collect_label_ranges(walker, kid, depth + 1, path, output, invalid);
+            if walker.truncated {
+                return;
+            }
         }
     }
     if let Ok(nums) = dict.get(b"Nums").and_then(Object::as_array) {
-        for pair in nums
-            .chunks_exact(2)
-            .take(MAX_ENTRIES.saturating_sub(output.len()))
-        {
+        if nums.len() % 2 != 0 || nums.len() / 2 > MAX_ENTRIES.saturating_sub(output.len()) {
+            walker.truncated = true;
+            return;
+        }
+        for pair in nums.chunks_exact(2) {
             let Some(start) = walker
                 .resolve_owned(&pair[0])
                 .and_then(|value| value.as_i64().ok())
@@ -364,9 +388,6 @@ fn collect_label_ranges(
                 first,
             });
         }
-        if nums.len() % 2 != 0 {
-            walker.truncated = true;
-        }
     }
     if let Some(id) = id {
         path.remove(&id);
@@ -429,7 +450,8 @@ fn extract_outline(walker: &mut Walker<'_>, catalog: &Dictionary) -> Option<Vec<
     let root = walker.dict(catalog.get(b"Outlines").ok()?)?;
     let first = root.get(b"First").ok()?.clone();
     let mut path = HashSet::new();
-    Some(outline_siblings(walker, first, 0, &mut path))
+    let items = outline_siblings(walker, first, 0, &mut path);
+    (!walker.truncated && !walker.failed).then_some(items)
 }
 
 fn outline_siblings(
@@ -518,7 +540,8 @@ fn normalize_outline_item(walker: &mut Walker<'_>, dict: &Dictionary) -> Option<
         .as_ref()
         .filter(|_| action_kind == Some(b"URI"))
         .and_then(|a| a.get(b"URI").ok())
-        .and_then(|v| walker.text(v));
+        .and_then(|v| walker.text(v))
+        .and_then(|value| safe_outline_url(&value));
     let action_dest = action
         .as_ref()
         .filter(|_| action_kind == Some(b"GoTo"))
@@ -537,6 +560,12 @@ fn normalize_outline_item(walker: &mut Walker<'_>, dict: &Dictionary) -> Option<
         dest,
         items: None,
     })
+}
+
+fn safe_outline_url(value: &str) -> Option<String> {
+    let parsed = url::Url::parse(value).ok()?;
+    matches!(parsed.scheme(), "http" | "https" | "ftp" | "mailto" | "tel")
+        .then(|| parsed.to_string())
 }
 
 fn finite_number(value: &Object) -> Option<f64> {
@@ -638,7 +667,7 @@ mod tests {
         let value = serde_json::to_value(out.outline).unwrap();
         assert_eq!(value[0]["title"], "Root");
         assert_eq!(value[0]["bold"], true);
-        assert_eq!(value[0]["items"][0]["url"], "https://example.com");
+        assert_eq!(value[0]["items"][0]["url"], "https://example.com/");
     }
 
     #[test]
@@ -716,5 +745,111 @@ mod tests {
             },
         );
         assert!(out.page_labels.is_none());
+    }
+
+    #[test]
+    fn decoded_text_expansion_sticky_exhausts_the_source_budget() {
+        let doc = document(dictionary! {});
+        let mut walker = Walker::new(&doc);
+        walker.text_remaining = 1;
+        assert!(walker.text(&Object::string_literal(vec![0x80])).is_none());
+        assert_eq!(walker.text_remaining, 0);
+        assert!(walker.text(&Object::string_literal("x")).is_none());
+    }
+
+    #[test]
+    fn unsafe_outline_uri_is_omitted_and_destination_remains_null() {
+        let mut doc = document(dictionary! {});
+        let first = doc.add_object(dictionary! {
+            "Title"=>Object::string_literal("Unsafe"),
+            "A"=>dictionary!{"S"=>"URI","URI"=>Object::string_literal("javascript:alert(1)")},
+        });
+        let outlines = doc.add_object(dictionary! {"First"=>first});
+        doc.catalog_mut().unwrap().set("Outlines", outlines);
+        let out = extract_catalog_signals(
+            &doc,
+            None,
+            0,
+            CatalogSignalRequest {
+                page_labels: false,
+                permissions: false,
+                outline: true,
+            },
+        );
+        let value = serde_json::to_value(out.outline).unwrap();
+        assert!(value[0].get("url").is_none());
+        assert_eq!(value[0]["dest"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn outline_cycle_omits_the_whole_surface() {
+        let mut doc = document(dictionary! {});
+        let first = doc.add_object(dictionary! {"Title"=>Object::string_literal("Cycle")});
+        doc.get_object_mut(first)
+            .unwrap()
+            .as_dict_mut()
+            .unwrap()
+            .set("Next", first);
+        let outlines = doc.add_object(dictionary! {"First"=>first});
+        doc.catalog_mut().unwrap().set("Outlines", outlines);
+        let out = extract_catalog_signals(
+            &doc,
+            None,
+            0,
+            CatalogSignalRequest {
+                page_labels: false,
+                permissions: false,
+                outline: true,
+            },
+        );
+        assert!(out.outline.is_none());
+    }
+
+    #[test]
+    fn page_label_overflow_omits_only_that_surface() {
+        let mut doc = document(dictionary! {});
+        let excessive_kids = (0..=MAX_ENTRIES)
+            .map(|_| Object::Dictionary(Dictionary::new()))
+            .collect::<Vec<_>>();
+        let labels = doc.add_object(dictionary! {"Kids"=>excessive_kids});
+        doc.catalog_mut().unwrap().set("PageLabels", labels);
+
+        let first = doc.add_object(dictionary! {"Title"=>Object::string_literal("Still valid")});
+        let outlines = doc.add_object(dictionary! {"First"=>first});
+        doc.catalog_mut().unwrap().set("Outlines", outlines);
+
+        let out = extract_catalog_signals(
+            &doc,
+            None,
+            1,
+            CatalogSignalRequest {
+                page_labels: true,
+                permissions: false,
+                outline: true,
+            },
+        );
+        assert!(out.page_labels.is_none());
+        assert_eq!(out.outline.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn mark_info_reference_cycle_omits_instead_of_inventing_false() {
+        let mut doc = document(dictionary! {});
+        let cycle = doc.add_object(Object::Null);
+        *doc.get_object_mut(cycle).unwrap() = Object::Reference(cycle);
+        doc.catalog_mut()
+            .unwrap()
+            .set("MarkInfo", dictionary! {"Marked"=>cycle});
+        let out = extract_catalog_signals(
+            &doc,
+            None,
+            0,
+            CatalogSignalRequest {
+                page_labels: false,
+                permissions: true,
+                outline: false,
+            },
+        );
+        assert!(out.mark_info.is_none());
     }
 }

--- a/crates/pdf-reader-core/src/catalog_signals.rs
+++ b/crates/pdf-reader-core/src/catalog_signals.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 
 use lopdf::{Dictionary, Document, Object, ObjectId};
 use pdf_extract::decode_text_string;
@@ -31,7 +31,7 @@ pub(crate) struct MarkInfo {
     suspects: bool,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub(crate) struct OutlineItem {
     title: String,
     bold: bool,
@@ -44,7 +44,7 @@ pub(crate) struct OutlineItem {
     items: Option<Vec<OutlineItem>>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[serde(untagged)]
 enum Destination {
     Text(String),
@@ -52,7 +52,7 @@ enum Destination {
     Null,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[serde(untagged)]
 enum DestinationPart {
     Integer(i64),
@@ -460,105 +460,73 @@ fn roman(mut number: u32, lower: bool) -> Option<String> {
 fn extract_outline(walker: &mut Walker<'_>, catalog: &Dictionary) -> Option<Vec<OutlineItem>> {
     let root = walker.dict(catalog.get(b"Outlines").ok()?)?;
     let first = root.get(b"First").ok()?.clone();
-    if first.as_reference().is_err() {
-        return None;
-    }
-    let mut path = HashSet::new();
+    let first_id = first.as_reference().ok()?;
     let mut processed = HashSet::new();
-    processed.insert(first.as_reference().ok()?);
-    let items = outline_siblings(walker, first, 0, &mut path, &mut processed);
-    (!walker.truncated && !walker.failed).then_some(items)
-}
+    processed.insert(first_id);
+    let mut arena = vec![OutlineArenaNode::default()];
+    let mut queue = VecDeque::from([(first, 0usize, 0usize)]);
 
-fn outline_siblings(
-    walker: &mut Walker<'_>,
-    mut current: Object,
-    depth: usize,
-    path: &mut HashSet<ObjectId>,
-    processed: &mut HashSet<ObjectId>,
-) -> Vec<OutlineItem> {
-    let mut output = Vec::new();
-    let mut siblings = HashSet::new();
-    while output.len() < MAX_ENTRIES {
-        if depth >= MAX_TREE_DEPTH {
+    while let Some((value, parent, depth)) = queue.pop_front() {
+        if depth >= MAX_TREE_DEPTH || walker.entries >= MAX_ENTRIES {
             walker.truncated = true;
             break;
         }
-        if let Ok(id) = current.as_reference() {
-            if !siblings.insert(id) || !path.insert(id) {
-                walker.truncated = true;
-                break;
-            }
-        }
-        let current_id = current.as_reference().ok();
-        let Some(dict) = walker.dict(&current) else {
+        let Some(object) = walker.resolve_owned(&value) else {
             break;
         };
-        if walker.entries >= MAX_ENTRIES {
-            walker.truncated = true;
+        if matches!(object, Object::Null) {
+            continue;
+        }
+        let Ok(dict) = object.as_dict() else {
+            walker.failed = true;
             break;
-        }
+        };
         walker.entries += 1;
-        let child = dict
-            .get(b"First")
-            .ok()
-            .cloned()
-            .filter(|value| value.as_reference().is_ok())
-            .and_then(|value| {
-                let child_id = value.as_reference().ok()?;
-                if path.contains(&child_id) {
-                    walker.truncated = true;
-                    None
-                } else if processed.insert(child_id) {
-                    Some(value)
-                } else {
-                    None
-                }
-            });
-        // PDF.js admits both First and Next refs to its global processed set
-        // while processing the current item, before either queued item runs.
-        let next = dict
-            .get(b"Next")
-            .ok()
-            .cloned()
-            .filter(|value| value.as_reference().is_ok())
-            .and_then(|value| {
-                let next_id = value.as_reference().ok()?;
-                if siblings.contains(&next_id) || path.contains(&next_id) {
-                    walker.truncated = true;
-                    None
-                } else if processed.insert(next_id) {
-                    Some(value)
-                } else {
-                    None
-                }
-            });
-        let mut item = normalize_outline_item(walker, &dict);
-        let mut children = Vec::new();
-        if let Some(first) = child {
-            children = outline_siblings(walker, first, depth + 1, path, processed);
+        let node = arena.len();
+        arena.push(OutlineArenaNode {
+            item: normalize_outline_item(walker, dict),
+            children: Vec::new(),
+        });
+        arena[parent].children.push(node);
+
+        for (key, child_parent, child_depth) in [
+            (b"First".as_slice(), node, depth + 1),
+            (b"Next".as_slice(), parent, depth),
+        ] {
+            let Ok(next) = dict.get(key) else { continue };
+            let Ok(next_id) = next.as_reference() else {
+                continue;
+            };
+            if processed.insert(next_id) {
+                queue.push_back((next.clone(), child_parent, child_depth));
+            }
         }
-        if let Some(mut item) = item.take() {
+    }
+    if walker.truncated || walker.failed {
+        return None;
+    }
+    Some(build_outline_children(&arena, 0))
+}
+
+#[derive(Default)]
+struct OutlineArenaNode {
+    item: Option<OutlineItem>,
+    children: Vec<usize>,
+}
+
+fn build_outline_children(arena: &[OutlineArenaNode], parent: usize) -> Vec<OutlineItem> {
+    arena[parent]
+        .children
+        .iter()
+        .filter_map(|child| {
+            let mut item = arena[*child].item.as_ref()?.clone();
+            let children = build_outline_children(arena, *child);
             if !children.is_empty() {
                 item.items = Some(children);
             }
-            output.push(item);
-        }
-        if let Some(id) = current_id {
-            path.remove(&id);
-        }
-        if walker.truncated {
-            break;
-        }
-        let Some(value) = next else {
-            break;
-        };
-        current = value;
-    }
-    if output.len() >= MAX_ENTRIES {
-        walker.truncated = true;
-    }
-    output
+            Some(item)
+        })
+        .collect()
 }
 
 fn normalize_outline_item(walker: &mut Walker<'_>, dict: &Dictionary) -> Option<OutlineItem> {
@@ -854,7 +822,7 @@ mod tests {
     }
 
     #[test]
-    fn outline_cycle_omits_the_whole_surface() {
+    fn outline_cycle_is_suppressed_by_pdfjs_global_processed_set() {
         let mut doc = document(dictionary! {});
         let first = doc.add_object(dictionary! {"Title"=>Object::string_literal("Cycle")});
         doc.get_object_mut(first)
@@ -874,7 +842,9 @@ mod tests {
                 outline: true,
             },
         );
-        assert!(out.outline.is_none());
+        let value = serde_json::to_value(out.outline).unwrap();
+        assert_eq!(value.as_array().unwrap().len(), 1);
+        assert_eq!(value[0]["title"], "Cycle");
     }
 
     #[test]
@@ -1095,5 +1065,47 @@ mod tests {
         assert_eq!(value[0]["items"][0]["title"], "Child");
         assert!(value[0]["items"][0].get("items").is_none());
         assert_eq!(value[1]["title"], "Shared");
+    }
+
+    #[test]
+    fn outline_fifo_assigns_deep_shared_ref_to_earlier_queued_sibling() {
+        let mut doc = document(dictionary! {});
+        let z = doc.add_object(dictionary! {"Title"=>Object::string_literal("Z")});
+        let x = doc.add_object(dictionary! {
+            "Title"=>Object::string_literal("X"),
+            "First"=>z,
+        });
+        let b = doc.add_object(dictionary! {
+            "Title"=>Object::string_literal("B"),
+            "First"=>z,
+        });
+        let c = doc.add_object(dictionary! {
+            "Title"=>Object::string_literal("C"),
+            "First"=>x,
+        });
+        let a = doc.add_object(dictionary! {
+            "Title"=>Object::string_literal("A"),
+            "First"=>c,
+            "Next"=>b,
+        });
+        let outlines = doc.add_object(dictionary! {"First"=>a});
+        doc.catalog_mut().unwrap().set("Outlines", outlines);
+        let out = extract_catalog_signals(
+            &doc,
+            None,
+            0,
+            CatalogSignalRequest {
+                page_labels: false,
+                permissions: false,
+                outline: true,
+            },
+        );
+        let value = serde_json::to_value(out.outline).unwrap();
+        assert_eq!(value[0]["title"], "A");
+        assert_eq!(value[0]["items"][0]["title"], "C");
+        assert_eq!(value[0]["items"][0]["items"][0]["title"], "X");
+        assert!(value[0]["items"][0]["items"][0].get("items").is_none());
+        assert_eq!(value[1]["title"], "B");
+        assert_eq!(value[1]["items"][0]["title"], "Z");
     }
 }

--- a/crates/pdf-reader-core/src/cos_document.rs
+++ b/crates/pdf-reader-core/src/cos_document.rs
@@ -54,9 +54,10 @@ impl ParsedPdf {
         }
         let source_hash = format!("{:x}", Sha256::digest(&bytes));
         let mut document = Document::load_mem(&bytes).map_err(extraction_error)?;
-        let encryption_facts = document
-            .is_encrypted()
-            .then(|| read_encryption_facts(&document));
+        // lopdf automatically decrypts PDFs that accept the empty password and
+        // preserves the decoded security state. Capture /P from either the raw
+        // Encrypt dictionary or that preserved state before any explicit decrypt.
+        let encryption_facts = read_encryption_facts(&document);
         if document.is_encrypted() {
             document.decrypt("").map_err(|error| {
                 extraction_error(format!(
@@ -74,21 +75,21 @@ impl ParsedPdf {
     }
 }
 
-fn read_encryption_facts(document: &Document) -> EncryptionFacts {
-    let dictionary = document
-        .trailer
-        .get(b"Encrypt")
-        .ok()
-        .and_then(|value| match value {
-            lopdf::Object::Reference(id) => document.get_object(*id).ok(),
-            value => Some(value),
-        })
-        .and_then(|value| value.as_dict().ok());
-    EncryptionFacts {
-        permissions: dictionary
-            .and_then(|dict| dict.get(b"P").ok())
-            .and_then(|value| value.as_i64().ok()),
+fn read_encryption_facts(document: &Document) -> Option<EncryptionFacts> {
+    if let Ok(dictionary) = document.get_encrypted() {
+        return Some(EncryptionFacts {
+            permissions: dictionary
+                .get(b"P")
+                .ok()
+                .and_then(|value| value.as_i64().ok()),
+        });
     }
+    document
+        .encryption_state
+        .as_ref()
+        .map(|state| EncryptionFacts {
+            permissions: Some(state.permissions().p_value() as i64),
+        })
 }
 
 fn invalid_request(path: &Path, error: std::io::Error) -> TextIndexError {

--- a/crates/pdf-reader-core/src/cos_document.rs
+++ b/crates/pdf-reader-core/src/cos_document.rs
@@ -10,8 +10,14 @@ use crate::text_index::{TextIndexError, TextIndexErrorCode};
 pub(crate) struct ParsedPdf {
     pub document: Document,
     pub pages: Vec<(u32, ObjectId)>,
+    pub encryption_facts: Option<EncryptionFacts>,
     #[allow(dead_code)]
     pub source_hash: String,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct EncryptionFacts {
+    pub permissions: Option<i64>,
 }
 
 impl ParsedPdf {
@@ -48,6 +54,9 @@ impl ParsedPdf {
         }
         let source_hash = format!("{:x}", Sha256::digest(&bytes));
         let mut document = Document::load_mem(&bytes).map_err(extraction_error)?;
+        let encryption_facts = document
+            .is_encrypted()
+            .then(|| read_encryption_facts(&document));
         if document.is_encrypted() {
             document.decrypt("").map_err(|error| {
                 extraction_error(format!(
@@ -59,8 +68,26 @@ impl ParsedPdf {
         Ok(Self {
             document,
             pages,
+            encryption_facts,
             source_hash,
         })
+    }
+}
+
+fn read_encryption_facts(document: &Document) -> EncryptionFacts {
+    let dictionary = document
+        .trailer
+        .get(b"Encrypt")
+        .ok()
+        .and_then(|value| match value {
+            lopdf::Object::Reference(id) => document.get_object(*id).ok(),
+            value => Some(value),
+        })
+        .and_then(|value| value.as_dict().ok());
+    EncryptionFacts {
+        permissions: dictionary
+            .and_then(|dict| dict.get(b"P").ok())
+            .and_then(|value| value.as_i64().ok()),
     }
 }
 

--- a/crates/pdf-reader-core/src/lib.rs
+++ b/crates/pdf-reader-core/src/lib.rs
@@ -1,5 +1,6 @@
 //! Rust hashing, SSRF-safe fetch, and text-index primitives for pdf-reader-mcp.
 
+mod catalog_signals;
 mod cos_document;
 pub mod document_twin;
 pub mod legacy;

--- a/crates/pdf-reader-core/src/ocr_fusion.rs
+++ b/crates/pdf-reader-core/src/ocr_fusion.rs
@@ -275,6 +275,7 @@ mod tests {
                     page_labels: None,
                     page_geometry: None,
                     permissions: None,
+                    mark_info: None,
                     ocr_text_layer: None,
                     visual_enrichments: None,
                     visual_enrichment_candidates: None,

--- a/crates/pdf-reader-core/src/read_pdf.rs
+++ b/crates/pdf-reader-core/src/read_pdf.rs
@@ -143,6 +143,8 @@ pub struct ReadPdfData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub permissions: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub mark_info: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ocr_text_layer: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub visual_enrichments: Option<Value>,
@@ -568,6 +570,10 @@ pub(crate) fn rebuild_structured_outputs(
 struct BuildSignals {
     page_geometry: Option<Value>,
     annotations: Option<Value>,
+    page_labels: Option<Value>,
+    permissions: Option<Value>,
+    mark_info: Option<Value>,
+    outline: Option<Value>,
     warnings: Vec<String>,
 }
 
@@ -609,6 +615,27 @@ fn auto_enabled(input: &ReadPdfInput) -> bool {
     }
 }
 
+fn requires_text_extraction(input: &ReadPdfInput) -> bool {
+    auto_enabled(input)
+        || input.include_full_text
+        || input.include_markdown
+        || input.include_chunks
+        || input.include_elements
+        || input.include_text_layer
+        || input.include_document_map
+        || input.include_images
+        || input.include_tables
+        || input.include_html
+        || input.include_semantic_hints
+        || input.include_safety_findings
+        || input.include_layout_diagnostics
+        || input.include_document_ast
+        || input.include_ocr_text_layer
+        || input.include_visual_enrichments
+        || input.include_trust_report
+        || input.include_accessibility_report
+}
+
 fn build_data(
     pages: &[crate::document_twin::PageText],
     total_pages: u32,
@@ -619,13 +646,17 @@ fn build_data(
 ) -> ReadPdfData {
     use crate::document_twin::{
         build_accessibility_report, build_document_ast, build_document_map, build_elements,
-        build_layout_diagnostics, build_page_labels, build_safety_findings, build_tables,
-        build_trust_report, empty_structure_arrays,
+        build_layout_diagnostics, build_safety_findings, build_tables, build_trust_report,
+        empty_structure_arrays,
     };
 
     let BuildSignals {
         page_geometry,
         annotations,
+        page_labels,
+        permissions,
+        mark_info,
+        outline,
         mut warnings,
     } = signals;
     let full_text = join_page_text(pages);
@@ -773,7 +804,7 @@ fn build_data(
         None
     };
 
-    let (outline, _, form_fields, attachments, structure_trees) = empty_structure_arrays();
+    let (_, _, form_fields, attachments, structure_trees) = empty_structure_arrays();
 
     let mut data = ReadPdfData {
         num_pages: want_page_count.then_some(total_pages),
@@ -802,6 +833,7 @@ fn build_data(
         page_labels: None,
         page_geometry: None,
         permissions: None,
+        mark_info: None,
         ocr_text_layer: None,
         visual_enrichments: None,
         visual_enrichment_candidates: None,
@@ -988,11 +1020,7 @@ fn build_data(
         data.accessibility_report = a11y;
     }
     if want_outline {
-        data.outline = Some(outline);
-        warnings.push(
-            "include_outline: outline entries are empty until COS outline parsing is enabled."
-                .into(),
-        );
+        data.outline = outline;
     }
     if want_annotations {
         data.annotations = annotations;
@@ -1011,13 +1039,14 @@ fn build_data(
         );
     }
     if want_labels {
-        data.page_labels = Some(build_page_labels(total_pages));
+        data.page_labels = page_labels;
     }
     if want_geometry {
         data.page_geometry = page_geometry;
     }
     if want_permissions {
-        data.permissions = Some(json!([]));
+        data.permissions = permissions;
+        data.mark_info = mark_info;
     }
     if want_visual {
         data.visual_enrichments = Some(json!([]));
@@ -1110,13 +1139,24 @@ fn read_local_pdf_filtered(
     source_label: &str,
 ) -> Result<ReadPdfSourceResult, ReadPdfError> {
     let parsed = crate::cos_document::ParsedPdf::load(path, DEFAULT_MAX_FILE_BYTES)?;
-    let extracted = extract_pdf_text_from_document(&parsed.document)?;
-    let total_pages = extracted.pages.len().max(1) as u32;
-    let pages = extracted
-        .pages
-        .iter()
-        .map(|page| page.text.clone())
-        .collect::<Vec<_>>();
+    let requires_text = requires_text_extraction(input);
+    let (pages, pdf_info) = if requires_text {
+        let extracted = extract_pdf_text_from_document(&parsed.document)?;
+        (
+            extracted
+                .pages
+                .into_iter()
+                .map(|page| page.text)
+                .collect::<Vec<_>>(),
+            extracted.info,
+        )
+    } else {
+        (
+            vec![String::new(); parsed.pages.len().max(1)],
+            crate::text_index::read_pdf_info(&parsed.document),
+        )
+    };
+    let total_pages = parsed.pages.len().max(1) as u32;
     let explicit_pages = parse_page_spec(pages_spec)?;
     let auto_pages = if explicit_pages.is_none()
         && auto_enabled(input)
@@ -1145,15 +1185,30 @@ fn read_local_pdf_filtered(
     );
     let geometry = (!signals.geometry.is_empty()).then(|| json!(signals.geometry));
     let annotations = (!signals.annotations.is_empty()).then(|| json!(signals.annotations));
+    let auto_full = auto && input.auto_detail.as_deref() == Some("full");
+    let catalog_signals = crate::catalog_signals::extract_catalog_signals(
+        &parsed.document,
+        parsed.encryption_facts,
+        total_pages,
+        crate::catalog_signals::CatalogSignalRequest {
+            page_labels: input.include_page_labels || auto_full,
+            permissions: input.include_permissions || auto_full,
+            outline: input.include_outline || auto_full,
+        },
+    );
     let mut data = build_data(
         &selected,
         total_pages,
         input,
-        Some(&extracted.info),
+        Some(&pdf_info),
         explicit_pages.is_some(),
         BuildSignals {
             page_geometry: geometry,
             annotations,
+            page_labels: catalog_signals.page_labels.map(|value| json!(value)),
+            permissions: catalog_signals.permissions.map(|value| json!(value)),
+            mark_info: catalog_signals.mark_info.map(|value| json!(value)),
+            outline: catalog_signals.outline.map(|value| json!(value)),
             warnings: signals.warnings,
         },
     );
@@ -1462,13 +1517,14 @@ mod tests {
         assert!(data.document_ast.is_some());
         assert!(data.trust_report.is_some());
         assert!(data.accessibility_report.is_some());
-        assert!(data.outline.is_some());
+        assert!(data.outline.is_none());
         // TS 3.0.14 omits optional page-signal fields when the document has no
         // qualifying records; an empty placeholder is not capability parity.
         assert!(data.annotations.is_none());
-        assert!(data.page_labels.is_some());
+        assert!(data.page_labels.is_none());
         assert!(data.page_geometry.is_some());
-        assert!(data.permissions.is_some());
+        assert!(data.permissions.is_none());
+        assert!(data.mark_info.is_none());
         assert!(data.form_fields.is_some());
         assert!(data.attachments.is_some());
         assert!(data.structure_trees.is_some());
@@ -1640,6 +1696,18 @@ mod tests {
         assert_eq!(evenly_sample_pages(10, 5), vec![1, 3, 6, 8, 10]);
         assert_eq!(evenly_sample_pages(3, 5), vec![1, 2, 3]);
         assert_eq!(evenly_sample_pages(10, 1), vec![1]);
+    }
+
+    #[test]
+    fn catalog_only_flags_do_not_require_text_extraction() {
+        let input = ReadPdfInput {
+            auto: Some(false),
+            include_outline: true,
+            include_page_labels: true,
+            include_permissions: true,
+            ..Default::default()
+        };
+        assert!(!requires_text_extraction(&input));
     }
 
     #[test]

--- a/crates/pdf-reader-core/src/read_pdf.rs
+++ b/crates/pdf-reader-core/src/read_pdf.rs
@@ -1397,6 +1397,7 @@ pub fn read_pdf_from_value(input: &Value) -> Result<ReadPdfResponse, ReadPdfErro
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lopdf::{EncryptionState, EncryptionVersion, Permissions};
 
     #[test]
     fn reads_fixture() {
@@ -1425,6 +1426,60 @@ mod tests {
             .unwrap()
             .full_text
             .is_some());
+    }
+
+    #[test]
+    fn encrypted_pdf_permissions_are_captured_before_blank_password_decrypt() {
+        let fixture =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test/fixtures/sample.pdf");
+        if !fixture.is_file() {
+            return;
+        }
+        let mut document = lopdf::Document::load(&fixture).expect("load source fixture");
+        let permissions = Permissions::PRINTABLE
+            | Permissions::COPYABLE
+            | Permissions::FILLABLE
+            | Permissions::COPYABLE_FOR_ACCESSIBILITY;
+        let state = EncryptionState::try_from(EncryptionVersion::V2 {
+            document: &document,
+            owner_password: "catalog-test-owner",
+            user_password: "",
+            key_length: 128,
+            permissions,
+        })
+        .expect("build deterministic standard-security state");
+        document.encrypt(&state).expect("encrypt fixture");
+        let temp = tempfile::tempdir().expect("tempdir");
+        let encrypted = temp.path().join("catalog-permissions.pdf");
+        document.save(&encrypted).expect("save encrypted fixture");
+        let parsed = crate::cos_document::ParsedPdf::load(&encrypted, DEFAULT_MAX_FILE_BYTES)
+            .expect("parse encrypted fixture");
+        assert_eq!(
+            parsed.encryption_facts.and_then(|facts| facts.permissions),
+            Some(permissions.p_value() as i64)
+        );
+
+        let response = read_pdf(&ReadPdfInput {
+            sources: vec![ReadPdfSource {
+                path: Some(encrypted.to_string_lossy().to_string()),
+                url: None,
+                pages: None,
+            }],
+            auto: Some(false),
+            include_permissions: true,
+            ..Default::default()
+        })
+        .expect("read encrypted fixture");
+        let data = response.results[0].data.as_ref().expect("data");
+        assert_eq!(
+            data.permissions,
+            Some(json!([
+                "print",
+                "copy",
+                "fill_forms",
+                "copy_for_accessibility"
+            ]))
+        );
     }
 
     #[test]

--- a/crates/pdf-reader-core/src/text_index.rs
+++ b/crates/pdf-reader-core/src/text_index.rs
@@ -213,7 +213,7 @@ impl OutputDev for TextItemOutput {
     }
 }
 
-fn read_pdf_info(doc: &Document) -> PdfInfo {
+pub(crate) fn read_pdf_info(doc: &Document) -> PdfInfo {
     let mut fields = BTreeMap::new();
     let info_object = doc
         .trailer

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -37,14 +37,14 @@
       "include_trust_report": "PARTIAL",
       "include_accessibility_report": "PARTIAL",
       "include_metadata": "PARTIAL",
-      "include_outline": "STUB",
+      "include_outline": "PARTIAL",
       "include_annotations": "PARTIAL",
       "include_form_fields": "STUB",
       "include_attachments": "STUB",
       "include_structure_tree": "STUB",
-      "include_page_labels": "STUB",
+      "include_page_labels": "PARTIAL",
       "include_page_geometry": "PARTIAL",
-      "include_permissions": "STUB",
+      "include_permissions": "PARTIAL",
       "include_images": "STUB",
       "include_ocr_text_layer": "PARTIAL",
       "include_visual_enrichments": "STUB",
@@ -71,17 +71,17 @@
     }
   },
   "claimedForDifferential": [
-    "exact 11-case immutable TS v3.0.14 behavior subset: full text, page selection/order/duplicates, metadata, literal search, case sensitivity, whole word, Unicode, UTF-16 offsets, missing and malformed inputs, mixed-source partial success, inherited crop/media/rotation geometry with page UserUnit, and an indirect Link/URI annotation",
+    "exact 12-case immutable TS v3.0.14 behavior subset: full text, page selection/order/duplicates, metadata, literal search, case sensitivity, whole word, Unicode, UTF-16 offsets, missing and malformed inputs, mixed-source partial success, inherited crop/media/rotation geometry with page UserUnit, an indirect Link/URI annotation, and common catalog signals (nested URI/destination outline, PageLabels ranges, MarkInfo, and unencrypted permissions omission)",
     "exact 16-case immutable TS v3.0.14 render/crop/command-provider semantic subset over stdio: defaults, page selection and warnings, region ordering, padding and fractional bounds, rotated pages, mixed-source and late-provider partial success, all-source failure, MCP image indexing, standalone OCR normalization, read_pdf OCR text-layer/map fusion, boxed OCR table projection into elements/chunks/markdown/html/document_ast/document_map, rich region-analysis normalization, plain-text truncation, and truthful provenance; exact pdf.js pixels and antialiasing are not claimed",
     "DNS-pinned URL fetch: one resolution per redirect hop, reject mixed public/non-public answers, disable ambient proxies, and revalidate every redirect; still PARTIAL because resolver timeout and TLS-SNI fixtures remain open",
     "auto off when include_* keys are present"
   ],
   "explicitlyNotClaimed": [
-    "complete TS 3.0.14 semantic parity outside the immutable 11-case subset",
+    "complete TS 3.0.14 semantic parity outside the immutable 12-case subset",
     "text/search geometry, geometry-perfect pdf.js boxes outside the frozen page-geometry subset, direct-annotation PDF.js presentation normalization, non-Link annotation/action parity, and general bounding-box parity",
     "render/crop/OCR/analyze/read-fusion/table-projection semantic parity outside the immutable 16-case subset, including exact pdf.js pixels and antialiasing",
     "OCR success paths outside the opt-in command JSON/plain-text subset, including tesseract-tsv; mixed selectable/OCR table continuation and full AST hierarchy parity; analyze_regions HTTP and preset providers",
-    "COS outline/forms, page labels, permissions, attachments, and structure trees",
+    "full COS outline/PageLabels/permissions parity outside the frozen common catalog subset; AcroForm fields, attachments, and structure trees",
     "cross-platform npm native binary",
     "npm library exports for pure-Rust",
     "2.0x/3.3x industry benchmark headline"

--- a/scripts/differential/check-v3014-behavior-differential.ts
+++ b/scripts/differential/check-v3014-behavior-differential.ts
@@ -43,6 +43,17 @@ const git = (...args: string[]): Buffer => {
 };
 const normalizeText = (value: string): string =>
   value.replaceAll('\r\n', '\n').normalize('NFC');
+const canonicalJson = (value: Json): Json => {
+  if (Array.isArray(value)) return value.map(canonicalJson);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, canonicalJson(entry)])
+    );
+  }
+  return value;
+};
 
 function verifyAuthority(): Record<string, string> {
   const commit = git('rev-list', '-n', '1', oracle.baseline.tag).toString().trim();
@@ -66,8 +77,8 @@ function verifyAuthority(): Record<string, string> {
     }
   }
   const ids = corpus.cases.map((entry) => entry.id);
-  if (ids.length !== 11 || new Set(ids).size !== ids.length) {
-    throw new Error(`behavior corpus must contain 11 unique cases (got ${ids.length})`);
+  if (ids.length !== 12 || new Set(ids).size !== ids.length) {
+    throw new Error(`behavior corpus must contain 12 unique cases (got ${ids.length})`);
   }
   if (JSON.stringify(ids.sort()) !== JSON.stringify(Object.keys(oracle.expectations).sort())) {
     throw new Error('corpus and oracle case IDs differ');
@@ -214,6 +225,12 @@ function canonicalRead(id: string, envelope: Record<string, unknown>): Json {
         })
       : null;
   }
+  if (id === 'read-catalog-signals') {
+    canonical.outline = (data.outline ?? null) as Json;
+    canonical.page_labels = (data.page_labels ?? null) as Json;
+    canonical.permissions = (data.permissions ?? null) as Json;
+    canonical.mark_info = (data.mark_info ?? null) as Json;
+  }
   canonical.warnings = warnings(data.warnings);
   return canonical;
 }
@@ -246,7 +263,11 @@ for (const entry of corpus.cases) {
   const actual = entry.tool === 'read_pdf' ? canonicalRead(entry.id, envelope) : canonicalSearch(envelope);
   const expected = oracle.expectations[entry.id]!;
   observations[entry.id] = actual;
-  if (JSON.stringify(actual) !== JSON.stringify(expected)) failures.push({ id: entry.id, expected, actual });
+  // JSON object member ordering is not semantic; array ordering and exact
+  // field presence/value shapes remain strict.
+  if (JSON.stringify(canonicalJson(actual)) !== JSON.stringify(canonicalJson(expected))) {
+    failures.push({ id: entry.id, expected, actual });
+  }
 }
 const report = {
   schemaVersion: 1,

--- a/scripts/differential/fixtures/v3014-behavior-corpus.json
+++ b/scripts/differential/fixtures/v3014-behavior-corpus.json
@@ -47,6 +47,18 @@
       }
     },
     {
+      "id": "read-catalog-signals",
+      "tool": "read_pdf",
+      "input": {
+        "sources": [{ "fixture": "v3014-behavior-v1.pdf" }],
+        "auto": false,
+        "include_outline": true,
+        "include_page_labels": true,
+        "include_permissions": true,
+        "include_page_count": true
+      }
+    },
+    {
       "id": "search-ci-all",
       "tool": "search_pdf",
       "input": {

--- a/scripts/differential/fixtures/v3014-behavior-fixtures.json
+++ b/scripts/differential/fixtures/v3014-behavior-fixtures.json
@@ -4,8 +4,8 @@
   "fixtures": [
     {
       "path": "test/fixtures/differential/v3014-behavior-v1.pdf",
-      "bytes": 1902,
-      "sha256": "83a35c0c6df341de05df0a261f845a2ac925f010502dd0bfc8af730aa2c2c6c4"
+      "bytes": 2539,
+      "sha256": "f5156a648e0cacb690bc5cf762f2be11dc62adfaa7e8d56fa6f4e45bdbef7267"
     },
     {
       "path": "test/fixtures/differential/v3014-malformed-v1.pdf",

--- a/scripts/differential/fixtures/v3014-behavior-oracle.json
+++ b/scripts/differential/fixtures/v3014-behavior-oracle.json
@@ -116,6 +116,57 @@
       ],
       "warnings": []
     },
+    "read-catalog-signals": {
+      "outcome": "success",
+      "num_pages": 3,
+      "outline": [
+        {
+          "title": "External docs",
+          "bold": true,
+          "italic": true,
+          "color": [
+            64,
+            128,
+            191
+          ],
+          "url": "https://example.com/docs",
+          "dest": null,
+          "items": [
+            {
+              "title": "Page three",
+              "bold": false,
+              "italic": false,
+              "color": [
+                0,
+                0,
+                0
+              ],
+              "dest": [
+                {
+                  "num": 7,
+                  "gen": 0
+                },
+                {
+                  "name": "Fit"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "page_labels": [
+        "P-1",
+        "iv",
+        "AA"
+      ],
+      "permissions": null,
+      "mark_info": {
+        "Marked": true,
+        "UserProperties": true,
+        "Suspects": false
+      },
+      "warnings": []
+    },
     "search-ci-all": {
       "outcome": "success",
       "num_pages": 3,

--- a/scripts/differential/generate-v3014-behavior-fixtures.ts
+++ b/scripts/differential/generate-v3014-behavior-fixtures.ts
@@ -29,7 +29,10 @@ function buildPdf(): Buffer {
   );
 
   const objects = new Map<number, string>([
-    [1, '<< /Type /Catalog /Pages 2 0 R >>'],
+    [
+      1,
+      '<< /Type /Catalog /Pages 2 0 R /PageLabels 13 0 R /MarkInfo 14 0 R /Outlines 15 0 R >>',
+    ],
     [2, '<< /Type /Pages /Kids [3 0 R 5 0 R 7 0 R] /Count 3 /MediaBox [0 0 612 792] /CropBox [20 30 580 760] /Rotate 90 /UserUnit 2 >>'],
     [
       3,
@@ -56,6 +59,14 @@ function buildPdf(): Buffer {
       '<< /Type /Annot /Subtype /Link /Contents (  Linked note  ) /Rect [100 200 50 150] /A << /S /URI /URI (https://example.com/a) >> >>',
     ],
     [12, '<< /Type /Annot /Subtype /Text /Contents () /Rect [1 2 1 2] >>'],
+    [13, '<< /Nums [0 << /S /D /P (P-) >> 1 << /S /r /St 4 >> 2 << /S /A /St 27 >>] >>'],
+    [14, '<< /Marked true /Suspects false /UserProperties true >>'],
+    [15, '<< /Type /Outlines /First 16 0 R /Last 16 0 R /Count 2 >>'],
+    [
+      16,
+      '<< /Title (External docs) /Parent 15 0 R /First 17 0 R /Last 17 0 R /Count 1 /F 3 /C [0.25 0.5 0.75] /A << /S /URI /URI (https://example.com/docs) >> >>',
+    ],
+    [17, '<< /Title (Page three) /Parent 16 0 R /Dest [7 0 R /Fit] >>'],
   ]);
 
   const chunks: Buffer[] = [Buffer.from('%PDF-1.4\n%\xe2\xe3\xcf\xd3\n', 'latin1')];

--- a/scripts/differential/v3014-baseline-runner.ts
+++ b/scripts/differential/v3014-baseline-runner.ts
@@ -90,6 +90,12 @@ async function readCase(id: string, input: Record<string, unknown>) {
     output.page_geometry = first.data?.page_geometry ?? null;
     output.annotations = first.data?.annotations ?? null;
   }
+  if (id === 'read-catalog-signals') {
+    output.outline = first.data?.outline ?? null;
+    output.page_labels = first.data?.page_labels ?? null;
+    output.permissions = first.data?.permissions ?? null;
+    output.mark_info = first.data?.mark_info ?? null;
+  }
   output.warnings = canonicalWarnings(first.data?.warnings);
   return output;
 }

--- a/scripts/run-pdf-reader-differential.sh
+++ b/scripts/run-pdf-reader-differential.sh
@@ -69,7 +69,7 @@ echo "--- deterministic v3.0.14 behavior fixtures + baseline replay ---" | tee -
 bun "$REPO_ROOT/scripts/differential/generate-v3014-behavior-fixtures.ts" 2>&1 | tee -a "$LOG"
 bun "$REPO_ROOT/scripts/differential/capture-v3014-behavior-oracle.ts" 2>&1 | tee -a "$LOG"
 
-echo "--- immutable v3.0.14 behavior differential (11 exact cases) ---" | tee -a "$LOG"
+echo "--- immutable v3.0.14 behavior differential (12 exact cases) ---" | tee -a "$LOG"
 bun "$REPO_ROOT/scripts/differential/check-v3014-behavior-differential.ts" \
   --output "$V3014_BEHAVIOR_JSON" >>"$LOG"
 

--- a/test/fixtures/differential/v3014-behavior-v1.pdf
+++ b/test/fixtures/differential/v3014-behavior-v1.pdf
@@ -1,7 +1,7 @@
 %PDF-1.4
 %‚„œ”
 1 0 obj
-<< /Type /Catalog /Pages 2 0 R >>
+<< /Type /Catalog /Pages 2 0 R /PageLabels 13 0 R /MarkInfo 14 0 R /Outlines 15 0 R >>
 endobj
 2 0 obj
 << /Type /Pages /Kids [3 0 R 5 0 R 7 0 R] /Count 3 /MediaBox [0 0 612 792] /CropBox [20 30 580 760] /Rotate 90 /UserUnit 2 >>
@@ -65,23 +65,43 @@ endobj
 12 0 obj
 << /Type /Annot /Subtype /Text /Contents () /Rect [1 2 1 2] >>
 endobj
+13 0 obj
+<< /Nums [0 << /S /D /P (P-) >> 1 << /S /r /St 4 >> 2 << /S /A /St 27 >>] >>
+endobj
+14 0 obj
+<< /Marked true /Suspects false /UserProperties true >>
+endobj
+15 0 obj
+<< /Type /Outlines /First 16 0 R /Last 16 0 R /Count 2 >>
+endobj
+16 0 obj
+<< /Title (External docs) /Parent 15 0 R /First 17 0 R /Last 17 0 R /Count 1 /F 3 /C [0.25 0.5 0.75] /A << /S /URI /URI (https://example.com/docs) >> >>
+endobj
+17 0 obj
+<< /Title (Page three) /Parent 16 0 R /Dest [7 0 R /Fit] >>
+endobj
 xref
-0 13
+0 18
 0000000000 65535 f 
 0000000015 00000 n 
-0000000064 00000 n 
-0000000205 00000 n 
-0000000336 00000 n 
-0000000479 00000 n 
-0000000605 00000 n 
-0000000770 00000 n 
-0000000896 00000 n 
-0000001026 00000 n 
-0000001123 00000 n 
-0000001337 00000 n 
-0000001484 00000 n 
+0000000117 00000 n 
+0000000258 00000 n 
+0000000389 00000 n 
+0000000532 00000 n 
+0000000658 00000 n 
+0000000823 00000 n 
+0000000949 00000 n 
+0000001079 00000 n 
+0000001176 00000 n 
+0000001390 00000 n 
+0000001537 00000 n 
+0000001616 00000 n 
+0000001709 00000 n 
+0000001781 00000 n 
+0000001855 00000 n 
+0000002024 00000 n 
 trailer
-<< /Size 13 /Root 1 0 R /Info 10 0 R >>
+<< /Size 18 /Root 1 0 R /Info 10 0 R >>
 startxref
-1563
+2100
 %%EOF

--- a/test/production/capabilityParity.contract.test.ts
+++ b/test/production/capabilityParity.contract.test.ts
@@ -35,10 +35,7 @@ const READ_PDF_REQUIRED_FIELDS: Record<string, string[]> = {
   layout: ['layout_diagnostics'],
   trust: ['trust_report'],
   a11y: ['accessibility_report'],
-  outline: ['outline'],
-  'page-labels': ['page_labels'],
   'page-geometry': ['page_geometry'],
-  permissions: ['permissions'],
   forms: ['form_fields'],
   attachments: ['attachments'],
   structure: ['structure_trees'],
@@ -200,6 +197,121 @@ describe.skipIf(!pureRustEnabled)('experimental pure-Rust capability contract', 
       results?: Array<{ data?: { annotations?: unknown } }>;
     };
     expect(omitted.results?.[0]?.data?.annotations).toBeUndefined();
+  }, 180_000);
+
+  test('catalog signals match the immutable v3.0.14 subset and omit unavailable values', async () => {
+    const outlineResponse = await callTool(
+      proc,
+      nextId(),
+      'read_pdf',
+      {
+        sources: [{ path: signalPdf }],
+        auto: false,
+        include_outline: true,
+      },
+      90_000
+    );
+    const outlineData = (
+      JSON.parse(parseToolPayload(outlineResponse).text) as {
+        results?: Array<{ data?: Record<string, unknown> }>;
+      }
+    ).results?.[0]?.data;
+    expect(outlineData?.outline).toEqual([
+      {
+        title: 'External docs',
+        bold: true,
+        italic: true,
+        color: [64, 128, 191],
+        url: 'https://example.com/docs',
+        dest: null,
+        items: [
+          {
+            title: 'Page three',
+            bold: false,
+            italic: false,
+            color: [0, 0, 0],
+            dest: [{ num: 7, gen: 0 }, { name: 'Fit' }],
+          },
+        ],
+      },
+    ]);
+    expect(outlineData?.page_labels).toBeUndefined();
+    expect(outlineData?.permissions).toBeUndefined();
+    expect(outlineData?.mark_info).toBeUndefined();
+
+    const pageLabelsResponse = await callTool(
+      proc,
+      nextId(),
+      'read_pdf',
+      {
+        sources: [{ path: signalPdf }],
+        auto: false,
+        include_page_labels: true,
+      },
+      90_000
+    );
+    const pageLabelsData = (
+      JSON.parse(parseToolPayload(pageLabelsResponse).text) as {
+        results?: Array<{ data?: Record<string, unknown> }>;
+      }
+    ).results?.[0]?.data;
+    expect(pageLabelsData?.page_labels).toEqual(['P-1', 'iv', 'AA']);
+    expect(pageLabelsData?.outline).toBeUndefined();
+    expect(pageLabelsData?.permissions).toBeUndefined();
+    expect(pageLabelsData?.mark_info).toBeUndefined();
+
+    const permissionsResponse = await callTool(
+      proc,
+      nextId(),
+      'read_pdf',
+      {
+        sources: [{ path: signalPdf }],
+        auto: false,
+        include_permissions: true,
+      },
+      90_000
+    );
+    const permissionsData = (
+      JSON.parse(parseToolPayload(permissionsResponse).text) as {
+        results?: Array<{ data?: Record<string, unknown> }>;
+      }
+    ).results?.[0]?.data;
+    expect(permissionsData?.permissions).toBeUndefined();
+    expect(permissionsData?.mark_info).toEqual({
+      Marked: true,
+      UserProperties: true,
+      Suspects: false,
+    });
+    expect(permissionsData?.outline).toBeUndefined();
+    expect(permissionsData?.page_labels).toBeUndefined();
+
+    const withoutSignals = await callTool(
+      proc,
+      nextId(),
+      'read_pdf',
+      {
+        sources: [{ path: samplePdf }],
+        auto: false,
+        include_outline: true,
+        include_page_labels: true,
+        include_permissions: true,
+      },
+      90_000
+    );
+    const omitted = JSON.parse(parseToolPayload(withoutSignals).text) as {
+      results?: Array<{
+        data?: {
+          outline?: unknown;
+          page_labels?: unknown;
+          permissions?: unknown;
+          mark_info?: unknown;
+        };
+      }>;
+    };
+    expect(omitted.results?.[0]?.data?.outline).toBeUndefined();
+    expect(omitted.results?.[0]?.data?.page_labels).toBeUndefined();
+    expect(omitted.results?.[0]?.data?.permissions).toBeUndefined();
+    expect(omitted.results?.[0]?.data?.mark_info).toBeUndefined();
   }, 180_000);
 
   test('auto balanced twin matches v3.0.14 depth without full text', async () => {


### PR DESCRIPTION
## Outcome

Adds bounded pure-Rust catalog/trailer primitives for the claimed TS 3.0.14 subset: PageLabels, MarkInfo, permissions, and common outline semantics. Removes fake default labels/empty permissions/outline placeholders and preserves exact omission behavior.

## Safety and parity

- document-only catalog requests avoid text extraction
- unsafe outline URI schemes are omitted
- FIFO/global processed graph semantics match PDF.js
- cycle, work, depth, entry, text, and URL-expansion limits are bounded/fail closed
- encrypted `/P` is recovered through the real blank-password public path
- capability matrix remains `PARTIAL`; `dropInFor3014=false` and publish freeze stay unchanged

## Evidence

- independent review: R1 FAIL, R3 FAIL, R4 FAIL, R5 PASS (confidence 0.97; no P0-P2)
- `cargo test --workspace --no-fail-fast`
- `cargo clippy -p pdf-reader-core --all-targets -- -D warnings`
- immutable TS v3.0.14 behavior differential: 12/12, 0 skipped
- immutable visual differential: 16/16, 0 skipped
- production TS contract and honest matrix checks green

Agent-Author: Codex