### PR TITLE
feat(rust): add bounded forms and attachment parity

### DIFF
--- a/.github/workflows/rust-parity-differential.yml
+++ b/.github/workflows/rust-parity-differential.yml
@@ -134,7 +134,7 @@ jobs:
           jq -e --arg sha "$CANDIDATE_SHA" '
             .profile == "pdf_reader_v3014_behavior_result" and
             .candidateSha == $sha and .pass == true and
-            .caseCount == 12 and .passed == 12 and .skipped == 0
+            .caseCount == 14 and .passed == 14 and .skipped == 0
           ' "$BEHAVIOR_ARTIFACT" >/dev/null || {
             echo "::error::v3.0.14 behavior result is incomplete, failing, or not SHA-bound"
             exit 1

--- a/crates/pdf-reader-core/src/form_attachment_signals.rs
+++ b/crates/pdf-reader-core/src/form_attachment_signals.rs
@@ -1,0 +1,617 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use lopdf::{Dictionary, Document, Object, ObjectId};
+use pdf_extract::decode_text_string;
+use serde::Serialize;
+use serde_json::Value;
+
+const MAX_DEPTH: usize = 64;
+const MAX_OBJECTS: usize = 100_000;
+const MAX_ENTRIES: usize = 10_000;
+const MAX_STRING_BYTES: usize = 64 * 1024;
+const MAX_TEXT_BYTES: usize = 2 * 1024 * 1024;
+
+#[derive(Default)]
+pub(crate) struct FormAttachmentSignals {
+    pub form_fields: Option<Vec<FormField>>,
+    pub attachments: Option<Vec<Attachment>>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct FormField {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    r#type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    value: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    default_value: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    editable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bounding_box: Option<BoxValue>,
+}
+
+#[derive(Debug, Serialize)]
+struct BoxValue {
+    left: f64,
+    bottom: f64,
+    right: f64,
+    top: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct Attachment {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    filename: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    size_bytes: Option<usize>,
+}
+
+#[derive(Clone, Default)]
+struct Inherited {
+    field_type: Option<Object>,
+    flags: Option<Object>,
+    value: Option<Object>,
+    default_value: Option<Object>,
+}
+
+pub(crate) fn extract_form_attachment_signals(
+    document: &Document,
+    pages: &[(u32, ObjectId)],
+    want_forms: bool,
+    want_attachments: bool,
+) -> FormAttachmentSignals {
+    let mut output = FormAttachmentSignals::default();
+    let Ok(catalog) = document.catalog().cloned() else {
+        return output;
+    };
+    if want_forms {
+        let mut walker = Walker::new(document);
+        output.form_fields = extract_forms(&mut walker, &catalog, pages);
+        if walker.limited {
+            output.form_fields = None;
+            output.warnings.push("include_form_fields: COS traversal exceeded the bounded form-field limit; the surface was omitted.".into());
+        }
+    }
+    if want_attachments {
+        let mut walker = Walker::new(document);
+        output.attachments = extract_attachments(&mut walker, &catalog);
+        if walker.limited {
+            output.attachments = None;
+            output.warnings.push("include_attachments: COS traversal exceeded the bounded embedded-file limit; the surface was omitted.".into());
+        }
+    }
+    output
+}
+
+struct Walker<'a> {
+    document: &'a Document,
+    work: usize,
+    entries: usize,
+    text_remaining: usize,
+    failed: bool,
+    limited: bool,
+}
+
+impl<'a> Walker<'a> {
+    fn new(document: &'a Document) -> Self {
+        Self {
+            document,
+            work: 0,
+            entries: 0,
+            text_remaining: MAX_TEXT_BYTES,
+            failed: false,
+            limited: false,
+        }
+    }
+
+    fn resolve(&mut self, value: &Object) -> Option<Object> {
+        let mut value = value.clone();
+        let mut seen = HashSet::new();
+        for _ in 0..MAX_DEPTH {
+            self.work += 1;
+            if self.work > MAX_OBJECTS {
+                self.limited = true;
+                return None;
+            }
+            let Object::Reference(id) = value else {
+                return Some(value);
+            };
+            if !seen.insert(id) {
+                self.failed = true;
+                return None;
+            }
+            let Ok(next) = self.document.get_object(id) else {
+                self.failed = true;
+                return None;
+            };
+            value = next.clone();
+        }
+        self.limited = true;
+        None
+    }
+
+    fn dict(&mut self, value: &Object) -> Option<Dictionary> {
+        self.resolve(value)?.as_dict().ok().cloned()
+    }
+
+    fn text(&mut self, value: &Object) -> Option<String> {
+        let value = self.resolve(value)?;
+        let bytes = match &value {
+            Object::String(bytes, _) | Object::Name(bytes) => bytes,
+            _ => return None,
+        };
+        if bytes.len() > MAX_STRING_BYTES || bytes.len() > self.text_remaining {
+            self.limited = true;
+            return None;
+        }
+        let text = match &value {
+            Object::Name(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+            _ => decode_text_string(&value).ok()?,
+        };
+        if text.len() > MAX_STRING_BYTES || text.len() > self.text_remaining {
+            self.limited = true;
+            return None;
+        }
+        self.text_remaining -= text.len();
+        Some(text)
+    }
+}
+
+fn extract_forms(
+    walker: &mut Walker<'_>,
+    catalog: &Dictionary,
+    pages: &[(u32, ObjectId)],
+) -> Option<Vec<FormField>> {
+    let acroform = walker.dict(catalog.get(b"AcroForm").ok()?)?;
+    let fields = walker.resolve(acroform.get(b"Fields").ok()?)?;
+    let fields = fields.as_array().ok()?.clone();
+    let page_by_id = pages
+        .iter()
+        .map(|(page, id)| (*id, *page))
+        .collect::<HashMap<_, _>>();
+    let mut annotation_pages = HashMap::new();
+    for (page, page_id) in pages {
+        let Ok(page_dict) = walker
+            .document
+            .get_object(*page_id)
+            .and_then(Object::as_dict)
+        else {
+            continue;
+        };
+        if let Ok(annots) = page_dict.get(b"Annots").and_then(Object::as_array) {
+            for annot in annots {
+                if let Ok(id) = annot.as_reference() {
+                    annotation_pages.insert(id, *page);
+                }
+            }
+        }
+    }
+    let mut output = Vec::new();
+    let mut visited = HashSet::new();
+    for field in fields {
+        walk_field(
+            walker,
+            &field,
+            0,
+            "",
+            &Inherited::default(),
+            &page_by_id,
+            &annotation_pages,
+            &mut visited,
+            &mut output,
+        );
+        if walker.failed || walker.limited {
+            return None;
+        }
+    }
+    (!output.is_empty()).then_some(output)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn walk_field(
+    walker: &mut Walker<'_>,
+    value: &Object,
+    depth: usize,
+    parent_name: &str,
+    inherited: &Inherited,
+    page_by_id: &HashMap<ObjectId, u32>,
+    annotation_pages: &HashMap<ObjectId, u32>,
+    visited: &mut HashSet<ObjectId>,
+    output: &mut Vec<FormField>,
+) {
+    if depth >= MAX_DEPTH || output.len() >= MAX_ENTRIES {
+        walker.limited = true;
+        return;
+    }
+    let id = value.as_reference().ok();
+    if let Some(id) = id {
+        if !visited.insert(id) {
+            return;
+        }
+    }
+    let Some(dict) = walker.dict(value) else {
+        walker.failed = false;
+        return;
+    };
+    if dict.get(b"Subtype").ok().and_then(|v| v.as_name().ok()) == Some(b"Link") {
+        return;
+    }
+    let partial = dict
+        .get(b"T")
+        .ok()
+        .and_then(|v| walker.text(v))
+        .unwrap_or_default();
+    let name = match (parent_name.is_empty(), partial.trim().is_empty()) {
+        (true, true) => String::new(),
+        (true, false) => partial.trim().to_string(),
+        (false, true) => parent_name.to_string(),
+        (false, false) => format!("{parent_name}.{}", partial.trim()),
+    };
+    let next = Inherited {
+        field_type: dict
+            .get(b"FT")
+            .ok()
+            .cloned()
+            .or_else(|| inherited.field_type.clone()),
+        flags: dict
+            .get(b"Ff")
+            .ok()
+            .cloned()
+            .or_else(|| inherited.flags.clone()),
+        value: dict
+            .get(b"V")
+            .ok()
+            .cloned()
+            .or_else(|| inherited.value.clone()),
+        default_value: dict
+            .get(b"DV")
+            .ok()
+            .cloned()
+            .or_else(|| inherited.default_value.clone()),
+    };
+    let kids = dict
+        .get(b"Kids")
+        .ok()
+        .and_then(|value| walker.resolve(value))
+        .and_then(|value| value.as_array().ok().cloned());
+    if !name.is_empty() {
+        if kids.is_some() {
+            output.push(FormField {
+                name: name.clone(),
+                r#type: None,
+                value: None,
+                default_value: None,
+                page: None,
+                id: id.map(format_id),
+                editable: None,
+                bounding_box: None,
+            });
+        } else if let Some(field) = normalize_leaf(
+            walker,
+            &dict,
+            id,
+            name.clone(),
+            &next,
+            page_by_id,
+            annotation_pages,
+        ) {
+            output.push(field);
+        }
+    }
+    if let Some(kids) = kids {
+        for kid in kids {
+            walk_field(
+                walker,
+                &kid,
+                depth + 1,
+                &name,
+                &next,
+                page_by_id,
+                annotation_pages,
+                visited,
+                output,
+            );
+        }
+    }
+}
+
+fn normalize_leaf(
+    walker: &mut Walker<'_>,
+    dict: &Dictionary,
+    id: Option<ObjectId>,
+    name: String,
+    inherited: &Inherited,
+    page_by_id: &HashMap<ObjectId, u32>,
+    annotation_pages: &HashMap<ObjectId, u32>,
+) -> Option<FormField> {
+    let ft = inherited
+        .field_type
+        .as_ref()
+        .and_then(|v| walker.resolve(v))
+        .and_then(|v| v.as_name().ok().map(<[u8]>::to_vec));
+    let flags = inherited
+        .flags
+        .as_ref()
+        .and_then(|v| walker.resolve(v))
+        .and_then(|v| v.as_i64().ok())
+        .unwrap_or(0);
+    let field_type = match ft.as_deref() {
+        Some(b"Tx") => Some("text"),
+        Some(b"Btn") if flags & (1 << 16) != 0 => Some("button"),
+        Some(b"Btn") if flags & (1 << 15) != 0 => Some("radiobutton"),
+        Some(b"Btn") => Some("checkbox"),
+        Some(b"Ch") if flags & (1 << 17) != 0 => Some("combobox"),
+        Some(b"Ch") => Some("listbox"),
+        Some(b"Sig") => Some("signature"),
+        _ => None,
+    }
+    .map(str::to_string);
+    let mut value = inherited.value.as_ref().and_then(|v| form_value(walker, v));
+    let mut default_value = inherited
+        .default_value
+        .as_ref()
+        .and_then(|v| form_value(walker, v));
+    match field_type.as_deref() {
+        Some("text") => {
+            default_value.get_or_insert_with(|| Value::String(String::new()));
+        }
+        Some("checkbox" | "radiobutton" | "button") => {
+            value.get_or_insert_with(|| Value::String("Off".into()));
+            default_value.get_or_insert(Value::Null);
+        }
+        Some("listbox" | "combobox") => value = Some(first_choice_value(value)),
+        Some("signature") => {
+            value = Some(Value::Null);
+            default_value = None;
+        }
+        _ => {}
+    }
+    let page = dict
+        .get(b"P")
+        .ok()
+        .and_then(|v| v.as_reference().ok())
+        .and_then(|id| page_by_id.get(&id).copied())
+        .or_else(|| id.and_then(|id| annotation_pages.get(&id).copied()));
+    let bounding_box = dict.get(b"Rect").ok().and_then(|v| rect(walker, v));
+    Some(FormField {
+        name,
+        r#type: field_type.clone(),
+        value,
+        default_value,
+        page,
+        id: id.map(format_id),
+        editable: field_type
+            .as_deref()
+            .filter(|kind| *kind != "signature")
+            .map(|_| flags & 1 == 0),
+        bounding_box: (field_type.as_deref() != Some("signature"))
+            .then_some(bounding_box)
+            .flatten(),
+    })
+}
+
+fn first_choice_value(value: Option<Value>) -> Value {
+    match value {
+        Some(Value::Array(values)) => values.into_iter().next().unwrap_or(Value::Null),
+        Some(value) => value,
+        None => Value::Null,
+    }
+}
+
+fn form_value(walker: &mut Walker<'_>, value: &Object) -> Option<Value> {
+    let value = walker.resolve(value)?;
+    match &value {
+        Object::Null => Some(Value::Null),
+        Object::Boolean(v) => Some(Value::Bool(*v)),
+        Object::Integer(v) => Some((*v).into()),
+        Object::Real(v) => serde_json::Number::from_f64(f64::from(*v)).map(Value::Number),
+        Object::String(_, _) | Object::Name(_) => walker.text(&value).map(Value::String),
+        Object::Array(values) if values.len() <= 256 => values
+            .iter()
+            .map(|v| form_value(walker, v))
+            .collect::<Option<Vec<_>>>()
+            .map(Value::Array),
+        _ => None,
+    }
+}
+
+fn rect(walker: &mut Walker<'_>, value: &Object) -> Option<BoxValue> {
+    let value = walker.resolve(value)?;
+    let values = value.as_array().ok()?;
+    if values.len() < 4 {
+        return None;
+    }
+    let mut n = [0.0; 4];
+    for (index, value) in values.iter().take(4).enumerate() {
+        n[index] = number(&walker.resolve(value)?)?;
+    }
+    Some(BoxValue {
+        left: n[0].min(n[2]),
+        bottom: n[1].min(n[3]),
+        right: n[0].max(n[2]),
+        top: n[1].max(n[3]),
+    })
+}
+
+fn number(value: &Object) -> Option<f64> {
+    let n = match value {
+        Object::Integer(v) => *v as f64,
+        Object::Real(v) => f64::from(*v),
+        _ => return None,
+    };
+    n.is_finite().then_some(n)
+}
+fn format_id((num, generation): ObjectId) -> String {
+    if generation == 0 {
+        format!("{num}R")
+    } else {
+        format!("{num}R{generation}")
+    }
+}
+
+fn extract_attachments(walker: &mut Walker<'_>, catalog: &Dictionary) -> Option<Vec<Attachment>> {
+    let names = walker.dict(catalog.get(b"Names").ok()?)?;
+    let root = names.get(b"EmbeddedFiles").ok()?.clone();
+    let mut queue = VecDeque::from([(root, 0usize)]);
+    let mut visited = HashSet::new();
+    let mut pairs = Vec::new();
+    while let Some((node, depth)) = queue.pop_front() {
+        if depth >= MAX_DEPTH || pairs.len() >= MAX_ENTRIES {
+            walker.limited = true;
+            return None;
+        }
+        if let Ok(id) = node.as_reference() {
+            if !visited.insert(id) {
+                walker.failed = true;
+                return None;
+            }
+        }
+        let dict = walker.dict(&node)?;
+        let kids = dict
+            .get(b"Kids")
+            .ok()
+            .and_then(|value| walker.resolve(value))
+            .and_then(|value| value.as_array().ok().cloned());
+        if let Some(kids) = kids {
+            for kid in kids {
+                queue.push_back((kid, depth + 1));
+            }
+        }
+        let names = dict
+            .get(b"Names")
+            .ok()
+            .and_then(|value| walker.resolve(value))
+            .and_then(|value| value.as_array().ok().cloned());
+        if let Some(names) = names {
+            if names.len() % 2 != 0 {
+                walker.failed = true;
+                return None;
+            }
+            for pair in names.chunks_exact(2) {
+                pairs.push((pair[0].clone(), pair[1].clone()));
+            }
+        }
+    }
+    let mut output: Vec<Attachment> = Vec::new();
+    let mut positions = HashMap::new();
+    for (key, spec) in pairs {
+        walker.entries += 1;
+        if walker.entries > MAX_ENTRIES {
+            walker.limited = true;
+            return None;
+        }
+        let name = walker.text(&key)?;
+        let spec = walker.dict(&spec)?;
+        let filename = filename(walker, &spec);
+        let description = spec
+            .get(b"Desc")
+            .ok()
+            .and_then(|v| walker.text(v))
+            .filter(|v| !v.is_empty());
+        let size_bytes = embedded_size(walker, &spec);
+        let attachment = Attachment {
+            name: name.clone(),
+            filename,
+            description,
+            size_bytes,
+        };
+        if let Some(index) = positions.get(&name).copied() {
+            output[index] = attachment
+        } else {
+            positions.insert(name, output.len());
+            output.push(attachment)
+        }
+    }
+    if walker.failed {
+        return None;
+    }
+    (!output.is_empty()).then_some(output)
+}
+
+fn filename(walker: &mut Walker<'_>, spec: &Dictionary) -> Option<String> {
+    let raw = [b"UF".as_slice(), b"F", b"Unix", b"Mac", b"DOS"]
+        .into_iter()
+        .find_map(|key| spec.get(key).ok().and_then(|v| walker.text(v)));
+    let normalized = raw.unwrap_or_default().replace('\\', "/");
+    Some(
+        normalized
+            .rsplit('/')
+            .find(|part| !part.is_empty())
+            .unwrap_or("unnamed")
+            .to_string(),
+    )
+}
+
+fn embedded_size(walker: &mut Walker<'_>, spec: &Dictionary) -> Option<usize> {
+    let ef = walker.dict(spec.get(b"EF").ok()?)?;
+    let stream = [b"UF".as_slice(), b"F", b"Unix", b"Mac", b"DOS"]
+        .into_iter()
+        .find_map(|key| ef.get(key).ok().cloned())?;
+    let stream = walker.resolve(&stream)?;
+    let stream = stream.as_stream().ok()?;
+    stream
+        .dict
+        .get(b"Filter")
+        .is_err()
+        .then_some(stream.content.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lopdf::{dictionary, Stream};
+    #[test]
+    fn path_filename_is_stripped_and_unfiltered_size_is_actual() {
+        let mut doc = Document::with_version("1.7");
+        let pages =
+            doc.add_object(dictionary! {"Type"=>"Pages","Kids"=>Vec::<Object>::new(),"Count"=>0});
+        let stream = doc.add_object(Stream::new(dictionary! {}, b"hello".to_vec()));
+        let spec=doc.add_object(dictionary!{"UF"=>Object::string_literal(r"C:\reports\a.txt"),"EF"=>dictionary!{"UF"=>stream}});
+        let tree =
+            doc.add_object(dictionary! {"Names"=>vec![Object::string_literal("key"),spec.into()]});
+        let root=doc.add_object(dictionary!{"Type"=>"Catalog","Pages"=>pages,"Names"=>dictionary!{"EmbeddedFiles"=>tree}});
+        doc.trailer.set("Root", root);
+        let out = extract_form_attachment_signals(&doc, &[], false, true);
+        assert_eq!(
+            serde_json::to_value(out.attachments).unwrap(),
+            serde_json::json!([{"name":"key","filename":"a.txt","size_bytes":5}])
+        );
+    }
+
+    #[test]
+    fn frozen_v3014_forms_and_attachments_match_the_real_ts_subset() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../test/fixtures/differential/v3014-behavior-v1.pdf");
+        let document = Document::load(path).expect("load immutable behavior fixture");
+        let pages = document.get_pages().into_iter().collect::<Vec<_>>();
+        let output = extract_form_attachment_signals(&document, &pages, true, true);
+        assert!(output.warnings.is_empty());
+        assert_eq!(
+            serde_json::to_value(output.form_fields).unwrap(),
+            serde_json::json!([
+                {"name":"customer_name","type":"text","value":"Ada Lovelace","default_value":"","page":1,"id":"22R","editable":true,"bounding_box":{"left":72.0,"bottom":635.0,"right":260.0,"top":660.0}},
+                {"name":"profile","id":"24R"},
+                {"name":"profile","type":"text","value":"Grace Hopper","default_value":"Unknown","page":2,"id":"25R","editable":false,"bounding_box":{"left":72.0,"bottom":500.0,"right":260.0,"top":525.0}},
+                {"name":"consent","type":"checkbox","value":"Yes","default_value":null,"page":2,"id":"26R","editable":true,"bounding_box":{"left":72.0,"bottom":450.0,"right":90.0,"top":468.0}},
+                {"name":"tier","type":"listbox","value":"gold","default_value":"silver","page":3,"id":"27R","editable":true,"bounding_box":{"left":72.0,"bottom":400.0,"right":200.0,"top":425.0}}
+            ])
+        );
+        assert_eq!(
+            serde_json::to_value(output.attachments).unwrap(),
+            serde_json::json!([
+                {"name":"source.csv","filename":"source.csv","description":"Source data","size_bytes":19},
+                {"name":"evidence","filename":"report.txt","size_bytes":5}
+            ])
+        );
+    }
+}

--- a/crates/pdf-reader-core/src/form_attachment_signals.rs
+++ b/crates/pdf-reader-core/src/form_attachment_signals.rs
@@ -130,7 +130,7 @@ impl<'a> Walker<'a> {
                 self.failed = true;
                 return None;
             }
-            let Ok(next) = self.document.get_object(id) else {
+            let Some(next) = self.document.objects.get(&id) else {
                 self.failed = true;
                 return None;
             };
@@ -142,6 +142,54 @@ impl<'a> Walker<'a> {
 
     fn dict(&mut self, value: &Object) -> Option<Dictionary> {
         self.resolve(value)?.as_dict().ok().cloned()
+    }
+
+    fn array_bounded(&mut self, value: &Object, max_len: usize) -> Option<Vec<Object>> {
+        let mut reference = value.as_reference().ok();
+        let direct = if reference.is_none() {
+            Some(value)
+        } else {
+            None
+        };
+        let mut seen = HashSet::new();
+        let final_value = if let Some(value) = direct {
+            value
+        } else {
+            let mut resolved = None;
+            for _ in 0..MAX_DEPTH {
+                self.work += 1;
+                if self.work > MAX_OBJECTS {
+                    self.limited = true;
+                    return None;
+                }
+                let id = reference?;
+                if !seen.insert(id) {
+                    self.failed = true;
+                    return None;
+                }
+                let Some(value) = self.document.objects.get(&id) else {
+                    self.failed = true;
+                    return None;
+                };
+                if let Ok(next) = value.as_reference() {
+                    reference = Some(next);
+                } else {
+                    resolved = Some(value);
+                    break;
+                }
+            }
+            let Some(value) = resolved else {
+                self.limited = true;
+                return None;
+            };
+            value
+        };
+        let values = final_value.as_array().ok()?;
+        if values.len() > max_len {
+            self.limited = true;
+            return None;
+        }
+        Some(values.clone())
     }
 
     fn text(&mut self, value: &Object) -> Option<String> {
@@ -173,8 +221,9 @@ fn extract_forms(
     pages: &[(u32, ObjectId)],
 ) -> Option<Vec<FormField>> {
     let acroform = walker.dict(catalog.get(b"AcroForm").ok()?)?;
-    let fields = walker.resolve(acroform.get(b"Fields").ok()?)?;
-    let fields = fields.as_array().ok()?.clone();
+    let mut raw_node_budget = MAX_ENTRIES;
+    let fields = walker.array_bounded(acroform.get(b"Fields").ok()?, raw_node_budget)?;
+    raw_node_budget -= fields.len();
     let page_by_id = pages
         .iter()
         .map(|(page, id)| (*id, *page))
@@ -212,6 +261,7 @@ fn extract_forms(
             &annotation_pages,
             &mut visited,
             &mut output,
+            &mut raw_node_budget,
         );
         if walker.failed || walker.limited {
             return None;
@@ -231,6 +281,7 @@ fn walk_field(
     annotation_pages: &HashMap<ObjectId, u32>,
     visited: &mut HashSet<ObjectId>,
     output: &mut Vec<FormField>,
+    raw_node_budget: &mut usize,
 ) {
     if depth >= MAX_DEPTH || output.len() >= MAX_ENTRIES {
         walker.limited = true;
@@ -287,8 +338,10 @@ fn walk_field(
     let kids = dict
         .get(b"Kids")
         .ok()
-        .and_then(|value| walker.resolve(value))
-        .and_then(|value| value.as_array().ok().cloned());
+        .and_then(|value| walker.array_bounded(value, *raw_node_budget));
+    if let Some(kids) = kids.as_ref() {
+        *raw_node_budget -= kids.len();
+    }
     let public_name = name.trim().to_string();
     if !public_name.is_empty() {
         if kids.is_some() {
@@ -326,6 +379,7 @@ fn walk_field(
                 annotation_pages,
                 visited,
                 output,
+                raw_node_budget,
             );
         }
     }
@@ -486,6 +540,8 @@ fn extract_attachments(walker: &mut Walker<'_>, catalog: &Dictionary) -> Option<
     let names = walker.dict(catalog.get(b"Names").ok()?)?;
     let root = names.get(b"EmbeddedFiles").ok()?.clone();
     let mut queue = VecDeque::from([(root, 0usize)]);
+    let mut tree_node_budget = MAX_ENTRIES.saturating_sub(1);
+    let mut pair_budget = MAX_ENTRIES;
     let mut visited = HashSet::new();
     let mut pairs = Vec::new();
     while let Some((node, depth)) = queue.pop_front() {
@@ -501,7 +557,8 @@ fn extract_attachments(walker: &mut Walker<'_>, catalog: &Dictionary) -> Option<
         }
         let dict = walker.dict(&node)?;
         if let Ok(kids_value) = dict.get(b"Kids") {
-            if let Some(Object::Array(kids)) = walker.resolve(kids_value) {
+            if let Some(kids) = walker.array_bounded(kids_value, tree_node_budget) {
+                tree_node_budget -= kids.len();
                 for kid in kids {
                     queue.push_back((kid, depth + 1));
                 }
@@ -511,13 +568,18 @@ fn extract_attachments(walker: &mut Walker<'_>, catalog: &Dictionary) -> Option<
         let names = dict
             .get(b"Names")
             .ok()
-            .and_then(|value| walker.resolve(value))
-            .and_then(|value| value.as_array().ok().cloned());
+            .and_then(|value| walker.array_bounded(value, pair_budget.saturating_mul(2)));
         if let Some(names) = names {
             if names.len() % 2 != 0 {
                 walker.failed = true;
                 return None;
             }
+            let pair_count = names.len() / 2;
+            if pair_count > pair_budget {
+                walker.limited = true;
+                return None;
+            }
+            pair_budget -= pair_count;
             for pair in names.chunks_exact(2) {
                 pairs.push((pair[0].clone(), pair[1].clone()));
             }
@@ -815,5 +877,98 @@ mod tests {
         let mut walker = Walker::new(&document);
         let spec = dictionary! {"UF"=>Object::string_literal(r"folder/")};
         assert_eq!(filename(&mut walker, &spec), Some("unnamed".into()));
+    }
+
+    fn valid_attachment_tree(document: &mut Document) -> ObjectId {
+        let stream = document.add_object(Stream::new(dictionary! {}, b"x".to_vec()));
+        let spec = document.add_object(
+            dictionary! {"F"=>Object::string_literal("ok.txt"),"EF"=>dictionary!{"F"=>stream}},
+        );
+        document.add_object(dictionary! {"Names"=>vec![Object::string_literal("ok"),spec.into()]})
+    }
+
+    fn valid_form(document: &mut Document) -> ObjectId {
+        document.add_object(dictionary! {
+            "Subtype"=>"Widget","FT"=>"Tx","T"=>Object::string_literal("ok")
+        })
+    }
+
+    #[test]
+    fn root_fields_and_form_kids_have_global_raw_admission_budgets() {
+        for oversized_kids in [false, true] {
+            let (mut document, pages) = base_document();
+            let attachment_tree = valid_attachment_tree(&mut document);
+            let fields = if oversized_kids {
+                let parent = document.add_object(dictionary! {
+                    "T"=>Object::string_literal("parent"),
+                    "Kids"=>vec![Object::Null;MAX_ENTRIES+1]
+                });
+                vec![parent.into()]
+            } else {
+                vec![Object::Null; MAX_ENTRIES + 1]
+            };
+            finish_catalog(
+                &mut document,
+                pages,
+                dictionary! {
+                    "AcroForm"=>dictionary!{"Fields"=>fields},
+                    "Names"=>dictionary!{"EmbeddedFiles"=>attachment_tree}
+                },
+            );
+            let output = extract_form_attachment_signals(&document, &[], true, true);
+            assert!(output.form_fields.is_none());
+            assert!(output.attachments.is_some());
+            assert!(output
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("include_form_fields")));
+        }
+    }
+
+    #[test]
+    fn name_tree_kids_and_pairs_have_global_admission_budgets() {
+        for oversized_pairs in [false, true] {
+            let (mut document, pages) = base_document();
+            let form = valid_form(&mut document);
+            let tree = if oversized_pairs {
+                document.add_object(dictionary! {
+                    "Names"=>vec![Object::Null; (MAX_ENTRIES+1)*2]
+                })
+            } else {
+                document.add_object(dictionary! {
+                    "Kids"=>vec![Object::Null;MAX_ENTRIES+1]
+                })
+            };
+            finish_catalog(
+                &mut document,
+                pages,
+                dictionary! {
+                    "AcroForm"=>dictionary!{"Fields"=>vec![form.into()]},
+                    "Names"=>dictionary!{"EmbeddedFiles"=>tree}
+                },
+            );
+            let output = extract_form_attachment_signals(&document, &[], true, true);
+            assert!(output.form_fields.is_some());
+            assert!(output.attachments.is_none());
+            assert!(output
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("include_attachments")));
+        }
+    }
+
+    #[test]
+    fn bounded_array_resolution_rejects_reference_depth_overflow() {
+        let mut document = Document::with_version("1.7");
+        let mut id = document.add_object(Vec::<Object>::new());
+        for _ in 0..=MAX_DEPTH {
+            id = document.add_object(Object::Reference(id));
+        }
+        let mut walker = Walker::new(&document);
+        assert!(walker
+            .array_bounded(&Object::Reference(id), MAX_ENTRIES)
+            .is_none());
+        assert!(walker.limited);
+        assert!(!walker.failed);
     }
 }

--- a/crates/pdf-reader-core/src/form_attachment_signals.rs
+++ b/crates/pdf-reader-core/src/form_attachment_signals.rs
@@ -16,6 +16,10 @@ pub(crate) struct FormAttachmentSignals {
     pub form_fields: Option<Vec<FormField>>,
     pub attachments: Option<Vec<Attachment>>,
     pub warnings: Vec<String>,
+    #[cfg(test)]
+    form_materialized_array_items: usize,
+    #[cfg(test)]
+    attachment_materialized_array_items: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -56,12 +60,12 @@ pub(crate) struct Attachment {
     size_bytes: Option<usize>,
 }
 
-#[derive(Clone, Default)]
-struct Inherited {
-    field_type: Option<Object>,
-    flags: Option<Object>,
-    value: Option<Object>,
-    default_value: Option<Object>,
+#[derive(Clone, Copy, Default)]
+struct Inherited<'a> {
+    field_type: Option<&'a Object>,
+    flags: Option<&'a Object>,
+    value: Option<&'a Object>,
+    default_value: Option<&'a Object>,
 }
 
 pub(crate) fn extract_form_attachment_signals(
@@ -71,12 +75,18 @@ pub(crate) fn extract_form_attachment_signals(
     want_attachments: bool,
 ) -> FormAttachmentSignals {
     let mut output = FormAttachmentSignals::default();
-    let Ok(catalog) = document.catalog().cloned() else {
+    let Ok(root) = document.trailer.get(b"Root") else {
         return output;
     };
     if want_forms {
         let mut walker = Walker::new(document);
-        output.form_fields = extract_forms(&mut walker, &catalog, pages);
+        output.form_fields = walker
+            .dict(root)
+            .and_then(|catalog| extract_forms(&mut walker, catalog, pages));
+        #[cfg(test)]
+        {
+            output.form_materialized_array_items = walker.materialized_array_items;
+        }
         if walker.limited {
             output.form_fields = None;
             output.warnings.push("include_form_fields: COS traversal exceeded the bounded form-field limit; the surface was omitted.".into());
@@ -84,7 +94,13 @@ pub(crate) fn extract_form_attachment_signals(
     }
     if want_attachments {
         let mut walker = Walker::new(document);
-        output.attachments = extract_attachments(&mut walker, &catalog);
+        output.attachments = walker
+            .dict(root)
+            .and_then(|catalog| extract_attachments(&mut walker, catalog));
+        #[cfg(test)]
+        {
+            output.attachment_materialized_array_items = walker.materialized_array_items;
+        }
         if walker.limited {
             output.attachments = None;
             output.warnings.push("include_attachments: COS traversal exceeded the bounded embedded-file limit; the surface was omitted.".into());
@@ -100,6 +116,8 @@ struct Walker<'a> {
     text_remaining: usize,
     failed: bool,
     limited: bool,
+    #[cfg(test)]
+    materialized_array_items: usize,
 }
 
 impl<'a> Walker<'a> {
@@ -111,11 +129,12 @@ impl<'a> Walker<'a> {
             text_remaining: MAX_TEXT_BYTES,
             failed: false,
             limited: false,
+            #[cfg(test)]
+            materialized_array_items: 0,
         }
     }
 
-    fn resolve(&mut self, value: &Object) -> Option<Object> {
-        let mut value = value.clone();
+    fn resolve(&mut self, mut value: &'a Object) -> Option<&'a Object> {
         let mut seen = HashSet::new();
         for _ in 0..MAX_DEPTH {
             self.work += 1;
@@ -126,75 +145,40 @@ impl<'a> Walker<'a> {
             let Object::Reference(id) = value else {
                 return Some(value);
             };
-            if !seen.insert(id) {
+            if !seen.insert(*id) {
                 self.failed = true;
                 return None;
             }
-            let Some(next) = self.document.objects.get(&id) else {
+            let Some(next) = self.document.objects.get(id) else {
                 self.failed = true;
                 return None;
             };
-            value = next.clone();
+            value = next;
         }
         self.limited = true;
         None
     }
 
-    fn dict(&mut self, value: &Object) -> Option<Dictionary> {
-        self.resolve(value)?.as_dict().ok().cloned()
+    fn dict(&mut self, value: &'a Object) -> Option<&'a Dictionary> {
+        self.resolve(value)?.as_dict().ok()
     }
 
-    fn array_bounded(&mut self, value: &Object, max_len: usize) -> Option<Vec<Object>> {
-        let mut reference = value.as_reference().ok();
-        let direct = if reference.is_none() {
-            Some(value)
-        } else {
-            None
-        };
-        let mut seen = HashSet::new();
-        let final_value = if let Some(value) = direct {
-            value
-        } else {
-            let mut resolved = None;
-            for _ in 0..MAX_DEPTH {
-                self.work += 1;
-                if self.work > MAX_OBJECTS {
-                    self.limited = true;
-                    return None;
-                }
-                let id = reference?;
-                if !seen.insert(id) {
-                    self.failed = true;
-                    return None;
-                }
-                let Some(value) = self.document.objects.get(&id) else {
-                    self.failed = true;
-                    return None;
-                };
-                if let Ok(next) = value.as_reference() {
-                    reference = Some(next);
-                } else {
-                    resolved = Some(value);
-                    break;
-                }
-            }
-            let Some(value) = resolved else {
-                self.limited = true;
-                return None;
-            };
-            value
-        };
-        let values = final_value.as_array().ok()?;
+    fn array_bounded(&mut self, value: &'a Object, max_len: usize) -> Option<Vec<&'a Object>> {
+        let values = self.resolve(value)?.as_array().ok()?;
         if values.len() > max_len {
             self.limited = true;
             return None;
         }
-        Some(values.clone())
+        #[cfg(test)]
+        {
+            self.materialized_array_items += values.len();
+        }
+        Some(values.iter().collect())
     }
 
-    fn text(&mut self, value: &Object) -> Option<String> {
+    fn text(&mut self, value: &'a Object) -> Option<String> {
         let value = self.resolve(value)?;
-        let bytes = match &value {
+        let bytes = match value {
             Object::String(bytes, _) | Object::Name(bytes) => bytes,
             _ => return None,
         };
@@ -202,9 +186,9 @@ impl<'a> Walker<'a> {
             self.limited = true;
             return None;
         }
-        let text = match &value {
+        let text = match value {
             Object::Name(bytes) => String::from_utf8_lossy(bytes).into_owned(),
-            _ => decode_text_string(&value).ok()?,
+            _ => decode_text_string(value).ok()?,
         };
         if text.len() > MAX_STRING_BYTES || text.len() > self.text_remaining {
             self.limited = true;
@@ -215,9 +199,9 @@ impl<'a> Walker<'a> {
     }
 }
 
-fn extract_forms(
-    walker: &mut Walker<'_>,
-    catalog: &Dictionary,
+fn extract_forms<'a>(
+    walker: &mut Walker<'a>,
+    catalog: &'a Dictionary,
     pages: &[(u32, ObjectId)],
 ) -> Option<Vec<FormField>> {
     let acroform = walker.dict(catalog.get(b"AcroForm").ok()?)?;
@@ -253,7 +237,7 @@ fn extract_forms(
         }
         walk_field(
             walker,
-            &field,
+            field,
             0,
             "",
             &Inherited::default(),
@@ -271,12 +255,12 @@ fn extract_forms(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn walk_field(
-    walker: &mut Walker<'_>,
-    value: &Object,
+fn walk_field<'a>(
+    walker: &mut Walker<'a>,
+    value: &'a Object,
     depth: usize,
     parent_name: &str,
-    inherited: &Inherited,
+    inherited: &Inherited<'a>,
     page_by_id: &HashMap<ObjectId, u32>,
     annotation_pages: &HashMap<ObjectId, u32>,
     visited: &mut HashSet<ObjectId>,
@@ -296,7 +280,7 @@ fn walk_field(
     let Some(resolved) = walker.resolve(value) else {
         return;
     };
-    let Ok(dict) = resolved.as_dict().cloned() else {
+    let Ok(dict) = resolved.as_dict() else {
         return;
     };
     if dict.get(b"Subtype").ok().and_then(|v| v.as_name().ok()) == Some(b"Link") {
@@ -314,26 +298,10 @@ fn walk_field(
         (false, false) => format!("{parent_name}.{partial}"),
     };
     let next = Inherited {
-        field_type: dict
-            .get(b"FT")
-            .ok()
-            .cloned()
-            .or_else(|| inherited.field_type.clone()),
-        flags: dict
-            .get(b"Ff")
-            .ok()
-            .cloned()
-            .or_else(|| inherited.flags.clone()),
-        value: dict
-            .get(b"V")
-            .ok()
-            .cloned()
-            .or_else(|| inherited.value.clone()),
-        default_value: dict
-            .get(b"DV")
-            .ok()
-            .cloned()
-            .or_else(|| inherited.default_value.clone()),
+        field_type: dict.get(b"FT").ok().or(inherited.field_type),
+        flags: dict.get(b"Ff").ok().or(inherited.flags),
+        value: dict.get(b"V").ok().or(inherited.value),
+        default_value: dict.get(b"DV").ok().or(inherited.default_value),
     };
     let kids = dict
         .get(b"Kids")
@@ -357,7 +325,7 @@ fn walk_field(
             });
         } else if let Some(field) = normalize_leaf(
             walker,
-            &dict,
+            dict,
             Some(id),
             public_name,
             &next,
@@ -371,7 +339,7 @@ fn walk_field(
         for kid in kids {
             walk_field(
                 walker,
-                &kid,
+                kid,
                 depth + 1,
                 &name,
                 &next,
@@ -385,23 +353,21 @@ fn walk_field(
     }
 }
 
-fn normalize_leaf(
-    walker: &mut Walker<'_>,
-    dict: &Dictionary,
+fn normalize_leaf<'a>(
+    walker: &mut Walker<'a>,
+    dict: &'a Dictionary,
     id: Option<ObjectId>,
     name: String,
-    inherited: &Inherited,
+    inherited: &Inherited<'a>,
     page_by_id: &HashMap<ObjectId, u32>,
     annotation_pages: &HashMap<ObjectId, u32>,
 ) -> Option<FormField> {
     let ft = inherited
         .field_type
-        .as_ref()
         .and_then(|v| walker.resolve(v))
         .and_then(|v| v.as_name().ok().map(<[u8]>::to_vec));
     let flags = inherited
         .flags
-        .as_ref()
         .and_then(|v| walker.resolve(v))
         .and_then(|v| v.as_i64().ok())
         .unwrap_or(0);
@@ -416,11 +382,8 @@ fn normalize_leaf(
         _ => None,
     }
     .map(str::to_string);
-    let raw_value = inherited.value.as_ref().map(|v| form_value(walker, v));
-    let mut default_value = inherited
-        .default_value
-        .as_ref()
-        .and_then(|v| form_value(walker, v));
+    let raw_value = inherited.value.map(|v| form_value(walker, v));
+    let mut default_value = inherited.default_value.and_then(|v| form_value(walker, v));
     let fallback = default_value.clone().filter(|value| !value.is_null());
     let mut value = raw_value.unwrap_or(fallback);
     match field_type.as_deref() {
@@ -482,10 +445,10 @@ fn first_choice_value(value: Option<Value>) -> Value {
     }
 }
 
-fn form_value(walker: &mut Walker<'_>, value: &Object) -> Option<Value> {
+fn form_value<'a>(walker: &mut Walker<'a>, value: &'a Object) -> Option<Value> {
     let value = walker.resolve(value)?;
-    match &value {
-        Object::String(_, _) | Object::Name(_) => walker.text(&value).map(Value::String),
+    match value {
+        Object::String(_, _) | Object::Name(_) => walker.text(value).map(Value::String),
         Object::Array(values) if values.len() <= 256 => {
             let values = values
                 .iter()
@@ -502,7 +465,7 @@ fn form_value(walker: &mut Walker<'_>, value: &Object) -> Option<Value> {
     }
 }
 
-fn rect(walker: &mut Walker<'_>, value: &Object) -> Option<BoxValue> {
+fn rect<'a>(walker: &mut Walker<'a>, value: &'a Object) -> Option<BoxValue> {
     let value = walker.resolve(value)?;
     let values = value.as_array().ok()?;
     if values.len() < 4 {
@@ -510,7 +473,7 @@ fn rect(walker: &mut Walker<'_>, value: &Object) -> Option<BoxValue> {
     }
     let mut n = [0.0; 4];
     for (index, value) in values.iter().take(4).enumerate() {
-        n[index] = number(&walker.resolve(value)?)?;
+        n[index] = number(walker.resolve(value)?)?;
     }
     Some(BoxValue {
         left: n[0].min(n[2]),
@@ -536,9 +499,12 @@ fn format_id((num, generation): ObjectId) -> String {
     }
 }
 
-fn extract_attachments(walker: &mut Walker<'_>, catalog: &Dictionary) -> Option<Vec<Attachment>> {
+fn extract_attachments<'a>(
+    walker: &mut Walker<'a>,
+    catalog: &'a Dictionary,
+) -> Option<Vec<Attachment>> {
     let names = walker.dict(catalog.get(b"Names").ok()?)?;
-    let root = names.get(b"EmbeddedFiles").ok()?.clone();
+    let root = names.get(b"EmbeddedFiles").ok()?;
     let mut queue = VecDeque::from([(root, 0usize)]);
     let mut tree_node_budget = MAX_ENTRIES.saturating_sub(1);
     let mut pair_budget = MAX_ENTRIES;
@@ -555,7 +521,7 @@ fn extract_attachments(walker: &mut Walker<'_>, catalog: &Dictionary) -> Option<
                 return None;
             }
         }
-        let dict = walker.dict(&node)?;
+        let dict = walker.dict(node)?;
         if let Ok(kids_value) = dict.get(b"Kids") {
             if let Some(kids) = walker.array_bounded(kids_value, tree_node_budget) {
                 tree_node_budget -= kids.len();
@@ -581,7 +547,7 @@ fn extract_attachments(walker: &mut Walker<'_>, catalog: &Dictionary) -> Option<
             }
             pair_budget -= pair_count;
             for pair in names.chunks_exact(2) {
-                pairs.push((pair[0].clone(), pair[1].clone()));
+                pairs.push((pair[0], pair[1]));
             }
         }
     }
@@ -593,15 +559,15 @@ fn extract_attachments(walker: &mut Walker<'_>, catalog: &Dictionary) -> Option<
             walker.limited = true;
             return None;
         }
-        let name = walker.text(&key)?;
-        let spec = walker.dict(&spec)?;
-        let filename = filename(walker, &spec);
+        let name = walker.text(key)?;
+        let spec = walker.dict(spec)?;
+        let filename = filename(walker, spec);
         let description = spec
             .get(b"Desc")
             .ok()
             .and_then(|v| walker.text(v))
             .filter(|v| !v.is_empty());
-        let size_bytes = embedded_size(walker, &spec);
+        let size_bytes = embedded_size(walker, spec);
         let attachment = Attachment {
             name: name.clone(),
             filename,
@@ -621,7 +587,7 @@ fn extract_attachments(walker: &mut Walker<'_>, catalog: &Dictionary) -> Option<
     (!output.is_empty()).then_some(output)
 }
 
-fn filename(walker: &mut Walker<'_>, spec: &Dictionary) -> Option<String> {
+fn filename<'a>(walker: &mut Walker<'a>, spec: &'a Dictionary) -> Option<String> {
     let mut raw = None;
     for key in [b"UF".as_slice(), b"F", b"Unix", b"Mac", b"DOS"] {
         if let Ok(value) = spec.get(key) {
@@ -640,12 +606,12 @@ fn filename(walker: &mut Walker<'_>, spec: &Dictionary) -> Option<String> {
     )
 }
 
-fn embedded_size(walker: &mut Walker<'_>, spec: &Dictionary) -> Option<usize> {
+fn embedded_size<'a>(walker: &mut Walker<'a>, spec: &'a Dictionary) -> Option<usize> {
     let ef = walker.dict(spec.get(b"EF").ok()?)?;
     let stream = [b"UF".as_slice(), b"F", b"Unix", b"Mac", b"DOS"]
         .into_iter()
-        .find_map(|key| ef.get(key).ok().cloned())?;
-    let stream = walker.resolve(&stream)?;
+        .find_map(|key| ef.get(key).ok())?;
+    let stream = walker.resolve(stream)?;
     let stream = stream.as_stream().ok()?;
     stream
         .dict
@@ -907,11 +873,12 @@ mod tests {
             } else {
                 vec![Object::Null; MAX_ENTRIES + 1]
             };
+            let acroform = document.add_object(dictionary! {"Fields"=>fields});
             finish_catalog(
                 &mut document,
                 pages,
                 dictionary! {
-                    "AcroForm"=>dictionary!{"Fields"=>fields},
+                    "AcroForm"=>acroform,
                     "Names"=>dictionary!{"EmbeddedFiles"=>attachment_tree}
                 },
             );
@@ -922,6 +889,11 @@ mod tests {
                 .warnings
                 .iter()
                 .any(|warning| warning.contains("include_form_fields")));
+            assert_eq!(
+                output.form_materialized_array_items,
+                usize::from(oversized_kids),
+                "an oversized direct array must not materialize its children"
+            );
         }
     }
 
@@ -954,6 +926,10 @@ mod tests {
                 .warnings
                 .iter()
                 .any(|warning| warning.contains("include_attachments")));
+            assert_eq!(
+                output.attachment_materialized_array_items, 0,
+                "an oversized NameTree collection must fail before item materialization"
+            );
         }
     }
 
@@ -964,10 +940,10 @@ mod tests {
         for _ in 0..=MAX_DEPTH {
             id = document.add_object(Object::Reference(id));
         }
+        document.trailer.set("Root", id);
+        let root = document.trailer.get(b"Root").unwrap();
         let mut walker = Walker::new(&document);
-        assert!(walker
-            .array_bounded(&Object::Reference(id), MAX_ENTRIES)
-            .is_none());
+        assert!(walker.array_bounded(root, MAX_ENTRIES).is_none());
         assert!(walker.limited);
         assert!(!walker.failed);
     }

--- a/crates/pdf-reader-core/src/form_attachment_signals.rs
+++ b/crates/pdf-reader-core/src/form_attachment_signals.rs
@@ -19,6 +19,8 @@ pub(crate) struct FormAttachmentSignals {
     #[cfg(test)]
     form_materialized_array_items: usize,
     #[cfg(test)]
+    form_annotation_materialized_array_items: usize,
+    #[cfg(test)]
     attachment_materialized_array_items: usize,
 }
 
@@ -86,6 +88,8 @@ pub(crate) fn extract_form_attachment_signals(
         #[cfg(test)]
         {
             output.form_materialized_array_items = walker.materialized_array_items;
+            output.form_annotation_materialized_array_items =
+                walker.annotation_materialized_array_items;
         }
         if walker.limited {
             output.form_fields = None;
@@ -114,10 +118,13 @@ struct Walker<'a> {
     work: usize,
     entries: usize,
     text_remaining: usize,
+    form_value_nodes_remaining: usize,
     failed: bool,
     limited: bool,
     #[cfg(test)]
     materialized_array_items: usize,
+    #[cfg(test)]
+    annotation_materialized_array_items: usize,
 }
 
 impl<'a> Walker<'a> {
@@ -127,10 +134,13 @@ impl<'a> Walker<'a> {
             work: 0,
             entries: 0,
             text_remaining: MAX_TEXT_BYTES,
+            form_value_nodes_remaining: MAX_ENTRIES,
             failed: false,
             limited: false,
             #[cfg(test)]
             materialized_array_items: 0,
+            #[cfg(test)]
+            annotation_materialized_array_items: 0,
         }
     }
 
@@ -176,6 +186,19 @@ impl<'a> Walker<'a> {
         Some(values.iter().collect())
     }
 
+    fn annotation_array_bounded(
+        &mut self,
+        value: &'a Object,
+        max_len: usize,
+    ) -> Option<Vec<&'a Object>> {
+        let values = self.array_bounded(value, max_len)?;
+        #[cfg(test)]
+        {
+            self.annotation_materialized_array_items += values.len();
+        }
+        Some(values)
+    }
+
     fn text(&mut self, value: &'a Object) -> Option<String> {
         let value = self.resolve(value)?;
         let bytes = match value {
@@ -208,24 +231,44 @@ fn extract_forms<'a>(
     let mut raw_node_budget = MAX_ENTRIES;
     let fields = walker.array_bounded(acroform.get(b"Fields").ok()?, raw_node_budget)?;
     raw_node_budget -= fields.len();
+    if pages.len() > MAX_ENTRIES {
+        walker.limited = true;
+        return None;
+    }
+    let mut page_annotation_budget = MAX_ENTRIES - pages.len();
+    let mut admitted_annotations = Vec::new();
+    for (page, page_id) in pages {
+        let Some(page_value) = walker.document.objects.get(page_id) else {
+            continue;
+        };
+        let Some(page_dict) = walker.dict(page_value) else {
+            if walker.failed || walker.limited {
+                return None;
+            }
+            continue;
+        };
+        let Ok(annots_value) = page_dict.get(b"Annots") else {
+            continue;
+        };
+        let Some(annots) = walker.annotation_array_bounded(annots_value, page_annotation_budget)
+        else {
+            if walker.failed || walker.limited {
+                return None;
+            }
+            continue;
+        };
+        page_annotation_budget -= annots.len();
+        admitted_annotations.push((*page, annots));
+    }
     let page_by_id = pages
         .iter()
         .map(|(page, id)| (*id, *page))
         .collect::<HashMap<_, _>>();
     let mut annotation_pages = HashMap::new();
-    for (page, page_id) in pages {
-        let Ok(page_dict) = walker
-            .document
-            .get_object(*page_id)
-            .and_then(Object::as_dict)
-        else {
-            continue;
-        };
-        if let Ok(annots) = page_dict.get(b"Annots").and_then(Object::as_array) {
-            for annot in annots {
-                if let Ok(id) = annot.as_reference() {
-                    annotation_pages.insert(id, *page);
-                }
+    for (page, annots) in admitted_annotations {
+        for annot in annots {
+            if let Ok(id) = annot.as_reference() {
+                annotation_pages.insert(id, page);
             }
         }
     }
@@ -446,19 +489,42 @@ fn first_choice_value(value: Option<Value>) -> Value {
 }
 
 fn form_value<'a>(walker: &mut Walker<'a>, value: &'a Object) -> Option<Value> {
+    form_value_at_depth(walker, value, 0)
+}
+
+fn form_value_at_depth<'a>(
+    walker: &mut Walker<'a>,
+    value: &'a Object,
+    depth: usize,
+) -> Option<Value> {
+    if depth >= MAX_DEPTH || walker.form_value_nodes_remaining == 0 {
+        walker.limited = true;
+        return None;
+    }
+    walker.form_value_nodes_remaining -= 1;
     let value = walker.resolve(value)?;
     match value {
         Object::String(_, _) | Object::Name(_) => walker.text(value).map(Value::String),
-        Object::Array(values) if values.len() <= 256 => {
-            let values = values
-                .iter()
-                .filter_map(|value| form_value(walker, value))
-                .filter(|value| !value.is_null())
-                .collect::<Vec<_>>();
-            Some(if values.is_empty() {
+        Object::Array(values) => {
+            if values.len() > 256 || values.len() > walker.form_value_nodes_remaining {
+                walker.limited = true;
+                return None;
+            }
+            let mut decoded = Vec::new();
+            for value in values {
+                if let Some(value) = form_value_at_depth(walker, value, depth + 1) {
+                    if !value.is_null() {
+                        decoded.push(value);
+                    }
+                }
+                if walker.limited {
+                    return None;
+                }
+            }
+            Some(if decoded.is_empty() {
                 Value::Null
             } else {
-                Value::Array(values)
+                Value::Array(decoded)
             })
         }
         _ => Some(Value::Null),
@@ -930,6 +996,90 @@ mod tests {
                 output.attachment_materialized_array_items, 0,
                 "an oversized NameTree collection must fail before item materialization"
             );
+        }
+    }
+
+    #[test]
+    fn page_and_annotation_admission_is_bounded_before_form_maps() {
+        for indirect_annots in [false, true] {
+            let (mut document, pages_root) = base_document();
+            let form = valid_form(&mut document);
+            let attachment_tree = valid_attachment_tree(&mut document);
+            let annots = vec![Object::Null; MAX_ENTRIES + 1];
+            let page = if indirect_annots {
+                let annots = document.add_object(annots);
+                document.add_object(dictionary! {"Type"=>"Page","Annots"=>annots})
+            } else {
+                document.add_object(dictionary! {"Type"=>"Page","Annots"=>annots})
+            };
+            finish_catalog(
+                &mut document,
+                pages_root,
+                dictionary! {
+                    "AcroForm"=>dictionary!{"Fields"=>vec![form.into()]},
+                    "Names"=>dictionary!{"EmbeddedFiles"=>attachment_tree}
+                },
+            );
+            let output = extract_form_attachment_signals(&document, &[(1, page)], true, true);
+            assert!(output.form_fields.is_none());
+            assert!(output.attachments.is_some());
+            assert!(output
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("include_form_fields")));
+            assert_eq!(output.form_annotation_materialized_array_items, 0);
+        }
+
+        let (mut document, pages_root) = base_document();
+        let form = valid_form(&mut document);
+        let attachment_tree = valid_attachment_tree(&mut document);
+        let page = document.add_object(dictionary! {"Type"=>"Page"});
+        finish_catalog(
+            &mut document,
+            pages_root,
+            dictionary! {
+                "AcroForm"=>dictionary!{"Fields"=>vec![form.into()]},
+                "Names"=>dictionary!{"EmbeddedFiles"=>attachment_tree}
+            },
+        );
+        let pages = vec![(1, page); MAX_ENTRIES + 1];
+        let output = extract_form_attachment_signals(&document, &pages, true, true);
+        assert!(output.form_fields.is_none());
+        assert!(output.attachments.is_some());
+        assert_eq!(output.form_annotation_materialized_array_items, 0);
+    }
+
+    #[test]
+    fn form_value_depth_and_aggregate_nodes_are_bounded() {
+        let mut deep = Object::Name(b"leaf".to_vec());
+        for _ in 0..=MAX_DEPTH {
+            deep = Object::Array(vec![deep]);
+        }
+        let child = Object::Array(vec![Object::Null; 256]);
+        let aggregate = Object::Array(vec![child; (MAX_ENTRIES / 256) + 2]);
+        let oversized = Object::Array(vec![Object::Null; 257]);
+        for value in [deep, aggregate, oversized] {
+            let (mut document, pages) = base_document();
+            let field = document.add_object(dictionary! {
+                "Subtype"=>"Widget","FT"=>"Ch","T"=>Object::string_literal("hostile"),
+                "V"=>value
+            });
+            let attachment_tree = valid_attachment_tree(&mut document);
+            finish_catalog(
+                &mut document,
+                pages,
+                dictionary! {
+                    "AcroForm"=>dictionary!{"Fields"=>vec![field.into()]},
+                    "Names"=>dictionary!{"EmbeddedFiles"=>attachment_tree}
+                },
+            );
+            let output = extract_form_attachment_signals(&document, &[], true, true);
+            assert!(output.form_fields.is_none());
+            assert!(output.attachments.is_some());
+            assert!(output
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("include_form_fields")));
         }
     }
 

--- a/crates/pdf-reader-core/src/form_attachment_signals.rs
+++ b/crates/pdf-reader-core/src/form_attachment_signals.rs
@@ -199,6 +199,9 @@ fn extract_forms(
     let mut output = Vec::new();
     let mut visited = HashSet::new();
     for field in fields {
+        if field.as_reference().is_err() {
+            continue;
+        }
         walk_field(
             walker,
             &field,
@@ -233,11 +236,11 @@ fn walk_field(
         walker.limited = true;
         return;
     }
-    let id = value.as_reference().ok();
-    if let Some(id) = id {
-        if !visited.insert(id) {
-            return;
-        }
+    let Ok(id) = value.as_reference() else {
+        return;
+    };
+    if !visited.insert(id) {
+        return;
     }
     let Some(dict) = walker.dict(value) else {
         walker.failed = false;
@@ -251,11 +254,11 @@ fn walk_field(
         .ok()
         .and_then(|v| walker.text(v))
         .unwrap_or_default();
-    let name = match (parent_name.is_empty(), partial.trim().is_empty()) {
+    let name = match (parent_name.is_empty(), partial.is_empty()) {
         (true, true) => String::new(),
-        (true, false) => partial.trim().to_string(),
+        (true, false) => partial,
         (false, true) => parent_name.to_string(),
-        (false, false) => format!("{parent_name}.{}", partial.trim()),
+        (false, false) => format!("{parent_name}.{partial}"),
     };
     let next = Inherited {
         field_type: dict
@@ -284,23 +287,24 @@ fn walk_field(
         .ok()
         .and_then(|value| walker.resolve(value))
         .and_then(|value| value.as_array().ok().cloned());
-    if !name.is_empty() {
+    let public_name = name.trim().to_string();
+    if !public_name.is_empty() {
         if kids.is_some() {
             output.push(FormField {
-                name: name.clone(),
+                name: public_name.clone(),
                 r#type: None,
                 value: None,
                 default_value: None,
                 page: None,
-                id: id.map(format_id),
+                id: Some(format_id(id)),
                 editable: None,
                 bounding_box: None,
             });
         } else if let Some(field) = normalize_leaf(
             walker,
             &dict,
-            id,
-            name.clone(),
+            Some(id),
+            public_name,
             &next,
             page_by_id,
             annotation_pages,
@@ -361,6 +365,9 @@ fn normalize_leaf(
         .default_value
         .as_ref()
         .and_then(|v| form_value(walker, v));
+    if value.is_none() && matches!(field_type.as_deref(), Some("text" | "listbox" | "combobox")) {
+        value = default_value.clone();
+    }
     match field_type.as_deref() {
         Some("text") => {
             default_value.get_or_insert_with(|| Value::String(String::new()));
@@ -477,15 +484,13 @@ fn extract_attachments(walker: &mut Walker<'_>, catalog: &Dictionary) -> Option<
             }
         }
         let dict = walker.dict(&node)?;
-        let kids = dict
-            .get(b"Kids")
-            .ok()
-            .and_then(|value| walker.resolve(value))
-            .and_then(|value| value.as_array().ok().cloned());
-        if let Some(kids) = kids {
-            for kid in kids {
-                queue.push_back((kid, depth + 1));
+        if let Ok(kids_value) = dict.get(b"Kids") {
+            if let Some(Object::Array(kids)) = walker.resolve(kids_value) {
+                for kid in kids {
+                    queue.push_back((kid, depth + 1));
+                }
             }
+            continue;
         }
         let names = dict
             .get(b"Names")
@@ -539,9 +544,13 @@ fn extract_attachments(walker: &mut Walker<'_>, catalog: &Dictionary) -> Option<
 }
 
 fn filename(walker: &mut Walker<'_>, spec: &Dictionary) -> Option<String> {
-    let raw = [b"UF".as_slice(), b"F", b"Unix", b"Mac", b"DOS"]
-        .into_iter()
-        .find_map(|key| spec.get(key).ok().and_then(|v| walker.text(v)));
+    let mut raw = None;
+    for key in [b"UF".as_slice(), b"F", b"Unix", b"Mac", b"DOS"] {
+        if let Ok(value) = spec.get(key) {
+            raw = walker.text(value);
+            break;
+        }
+    }
     let normalized = raw.unwrap_or_default().replace('\\', "/");
     Some(
         normalized
@@ -570,6 +579,20 @@ fn embedded_size(walker: &mut Walker<'_>, spec: &Dictionary) -> Option<usize> {
 mod tests {
     use super::*;
     use lopdf::{dictionary, Stream};
+
+    fn base_document() -> (Document, ObjectId) {
+        let mut document = Document::with_version("1.7");
+        let pages = document
+            .add_object(dictionary! {"Type"=>"Pages","Kids"=>Vec::<Object>::new(),"Count"=>0});
+        (document, pages)
+    }
+
+    fn finish_catalog(document: &mut Document, pages: ObjectId, extra: Dictionary) {
+        let mut catalog = dictionary! {"Type"=>"Catalog","Pages"=>pages};
+        catalog.extend(&extra);
+        let root = document.add_object(catalog);
+        document.trailer.set("Root", root);
+    }
     #[test]
     fn path_filename_is_stripped_and_unfiltered_size_is_actual() {
         let mut doc = Document::with_version("1.7");
@@ -613,5 +636,105 @@ mod tests {
                 {"name":"evidence","filename":"report.txt","size_bytes":5}
             ])
         );
+    }
+
+    #[test]
+    fn forms_skip_direct_top_level_and_direct_kids_and_use_dv_as_current_value() {
+        let (mut document, pages) = base_document();
+        let child = document.add_object(dictionary! {
+            "Subtype"=>"Widget","FT"=>"Tx","T"=>Object::string_literal("  child  "),
+            "DV"=>Object::string_literal("fallback")
+        });
+        let parent = document.add_object(dictionary! {
+            "T"=>Object::string_literal("  parent  "),
+            "Kids"=>vec![Object::Dictionary(dictionary!{"Subtype"=>"Widget","FT"=>"Tx","T"=>Object::string_literal("direct")}),child.into()]
+        });
+        let direct = Object::Dictionary(dictionary! {
+            "Subtype"=>"Widget","FT"=>"Tx","T"=>Object::string_literal("top-direct")
+        });
+        finish_catalog(
+            &mut document,
+            pages,
+            dictionary! {"AcroForm"=>dictionary!{"Fields"=>vec![direct,parent.into()]}},
+        );
+        let output = extract_form_attachment_signals(&document, &[], true, false);
+        assert_eq!(
+            serde_json::to_value(output.form_fields).unwrap(),
+            serde_json::json!([
+                {"name":"parent","id":format_id(parent)},
+                {"name":"parent  .  child","type":"text","value":"fallback","default_value":"fallback","id":format_id(child),"editable":true}
+            ])
+        );
+    }
+
+    #[test]
+    fn name_tree_kids_win_over_names_and_wrong_type_kids_skip_the_node() {
+        let (mut document, pages) = base_document();
+        let stream = document.add_object(Stream::new(dictionary! {}, b"x".to_vec()));
+        let spec = document.add_object(
+            dictionary! {"F"=>Object::string_literal("a.txt"),"EF"=>dictionary!{"F"=>stream}},
+        );
+        let child = document
+            .add_object(dictionary! {"Names"=>vec![Object::string_literal("child"),spec.into()]});
+        let tree = document.add_object(dictionary! {
+            "Kids"=>vec![child.into()],
+            "Names"=>vec![Object::string_literal("must-skip"),spec.into()]
+        });
+        finish_catalog(
+            &mut document,
+            pages,
+            dictionary! {"Names"=>dictionary!{"EmbeddedFiles"=>tree}},
+        );
+        let output = extract_form_attachment_signals(&document, &[], false, true);
+        assert_eq!(
+            serde_json::to_value(output.attachments).unwrap(),
+            serde_json::json!([{"name":"child","filename":"a.txt","size_bytes":1}])
+        );
+
+        let (mut document, pages) = base_document();
+        let tree = document.add_object(
+            dictionary! {"Kids"=>7,"Names"=>vec![Object::string_literal("ignored"),Object::Null]},
+        );
+        finish_catalog(
+            &mut document,
+            pages,
+            dictionary! {"Names"=>dictionary!{"EmbeddedFiles"=>tree}},
+        );
+        assert!(extract_form_attachment_signals(&document, &[], false, true)
+            .attachments
+            .is_none());
+    }
+
+    #[test]
+    fn indirect_name_tree_arrays_work_duplicate_kids_fail_and_invalid_uf_does_not_fallback() {
+        let (mut document, pages) = base_document();
+        let stream = document.add_object(Stream::new(dictionary! {}, b"xy".to_vec()));
+        let spec=document.add_object(dictionary!{"UF"=>7,"F"=>Object::string_literal("fallback.txt"),"EF"=>dictionary!{"F"=>stream}});
+        let names_array = document.add_object(vec![Object::string_literal("key"), spec.into()]);
+        let child = document.add_object(dictionary! {"Names"=>names_array});
+        let kids_array = document.add_object(vec![child.into()]);
+        let tree = document.add_object(dictionary! {"Kids"=>kids_array});
+        finish_catalog(
+            &mut document,
+            pages,
+            dictionary! {"Names"=>dictionary!{"EmbeddedFiles"=>tree}},
+        );
+        let output = extract_form_attachment_signals(&document, &[], false, true);
+        assert_eq!(
+            serde_json::to_value(output.attachments).unwrap(),
+            serde_json::json!([{"name":"key","filename":"unnamed","size_bytes":2}])
+        );
+
+        let (mut document, pages) = base_document();
+        let child = document.add_object(dictionary! {});
+        let tree = document.add_object(dictionary! {"Kids"=>vec![child.into(),child.into()]});
+        finish_catalog(
+            &mut document,
+            pages,
+            dictionary! {"Names"=>dictionary!{"EmbeddedFiles"=>tree}},
+        );
+        assert!(extract_form_attachment_signals(&document, &[], false, true)
+            .attachments
+            .is_none());
     }
 }

--- a/crates/pdf-reader-core/src/form_attachment_signals.rs
+++ b/crates/pdf-reader-core/src/form_attachment_signals.rs
@@ -242,8 +242,10 @@ fn walk_field(
     if !visited.insert(id) {
         return;
     }
-    let Some(dict) = walker.dict(value) else {
-        walker.failed = false;
+    let Some(resolved) = walker.resolve(value) else {
+        return;
+    };
+    let Ok(dict) = resolved.as_dict().cloned() else {
         return;
     };
     if dict.get(b"Subtype").ok().and_then(|v| v.as_name().ok()) == Some(b"Link") {
@@ -360,23 +362,34 @@ fn normalize_leaf(
         _ => None,
     }
     .map(str::to_string);
-    let mut value = inherited.value.as_ref().and_then(|v| form_value(walker, v));
+    let raw_value = inherited.value.as_ref().map(|v| form_value(walker, v));
     let mut default_value = inherited
         .default_value
         .as_ref()
         .and_then(|v| form_value(walker, v));
-    if value.is_none() && matches!(field_type.as_deref(), Some("text" | "listbox" | "combobox")) {
-        value = default_value.clone();
-    }
+    let fallback = default_value.clone().filter(|value| !value.is_null());
+    let mut value = raw_value.unwrap_or(fallback);
     match field_type.as_deref() {
         Some("text") => {
-            default_value.get_or_insert_with(|| Value::String(String::new()));
+            value = Some(match value {
+                Some(Value::String(value)) => Value::String(value),
+                _ => Value::String(String::new()),
+            });
+            if default_value.as_ref().is_none_or(Value::is_null) {
+                default_value = Some(Value::String(String::new()));
+            }
         }
         Some("checkbox" | "radiobutton" | "button") => {
-            value.get_or_insert_with(|| Value::String("Off".into()));
+            value = Some(match value {
+                Some(Value::String(value)) if !value.is_empty() => Value::String(value),
+                _ => Value::String("Off".into()),
+            });
             default_value.get_or_insert(Value::Null);
         }
-        Some("listbox" | "combobox") => value = Some(first_choice_value(value)),
+        Some("listbox" | "combobox") => {
+            value = Some(first_choice_value(value));
+            default_value.get_or_insert(Value::Null);
+        }
         Some("signature") => {
             value = Some(Value::Null);
             default_value = None;
@@ -418,17 +431,20 @@ fn first_choice_value(value: Option<Value>) -> Value {
 fn form_value(walker: &mut Walker<'_>, value: &Object) -> Option<Value> {
     let value = walker.resolve(value)?;
     match &value {
-        Object::Null => Some(Value::Null),
-        Object::Boolean(v) => Some(Value::Bool(*v)),
-        Object::Integer(v) => Some((*v).into()),
-        Object::Real(v) => serde_json::Number::from_f64(f64::from(*v)).map(Value::Number),
         Object::String(_, _) | Object::Name(_) => walker.text(&value).map(Value::String),
-        Object::Array(values) if values.len() <= 256 => values
-            .iter()
-            .map(|v| form_value(walker, v))
-            .collect::<Option<Vec<_>>>()
-            .map(Value::Array),
-        _ => None,
+        Object::Array(values) if values.len() <= 256 => {
+            let values = values
+                .iter()
+                .filter_map(|value| form_value(walker, value))
+                .filter(|value| !value.is_null())
+                .collect::<Vec<_>>();
+            Some(if values.is_empty() {
+                Value::Null
+            } else {
+                Value::Array(values)
+            })
+        }
+        _ => Some(Value::Null),
     }
 }
 
@@ -555,7 +571,8 @@ fn filename(walker: &mut Walker<'_>, spec: &Dictionary) -> Option<String> {
     Some(
         normalized
             .rsplit('/')
-            .find(|part| !part.is_empty())
+            .next()
+            .filter(|part| !part.is_empty())
             .unwrap_or("unnamed")
             .to_string(),
     )
@@ -736,5 +753,67 @@ mod tests {
         assert!(extract_form_attachment_signals(&document, &[], false, true)
             .attachments
             .is_none());
+    }
+
+    #[test]
+    fn broken_top_level_reference_fails_the_whole_form_surface() {
+        let (mut document, pages) = base_document();
+        let valid = document.add_object(dictionary! {
+            "Subtype"=>"Widget","FT"=>"Tx","T"=>Object::string_literal("valid")
+        });
+        finish_catalog(
+            &mut document,
+            pages,
+            dictionary! {"AcroForm"=>dictionary!{"Fields"=>vec![valid.into(),Object::Reference((999,0))]}},
+        );
+        assert!(extract_form_attachment_signals(&document, &[], true, false)
+            .form_fields
+            .is_none());
+    }
+
+    #[test]
+    fn form_values_follow_pdfjs_decode_and_widget_coercion() {
+        let (mut document, pages) = base_document();
+        let text_numeric = document.add_object(dictionary! {
+            "Subtype"=>"Widget","FT"=>"Tx","T"=>Object::string_literal("numeric"),"V"=>7,"DV"=>Object::string_literal("default")
+        });
+        let text_missing = document.add_object(dictionary! {
+            "Subtype"=>"Widget","FT"=>"Tx","T"=>Object::string_literal("missing")
+        });
+        let button_bool = document.add_object(dictionary! {
+            "Subtype"=>"Widget","FT"=>"Btn","T"=>Object::string_literal("button"),"V"=>true,"DV"=>Object::Name(b"Default".to_vec())
+        });
+        let choice_filtered = document.add_object(dictionary! {
+            "Subtype"=>"Widget","FT"=>"Ch","T"=>Object::string_literal("choice"),
+            "V"=>vec![7.into(),Object::string_literal("first"),Object::Null,Object::string_literal("second")]
+        });
+        let choice_fallback = document.add_object(dictionary! {
+            "Subtype"=>"Widget","FT"=>"Ch","T"=>Object::string_literal("fallback"),
+            "DV"=>vec![false.into(),Object::string_literal("from-default")]
+        });
+        finish_catalog(
+            &mut document,
+            pages,
+            dictionary! {"AcroForm"=>dictionary!{"Fields"=>vec![text_numeric.into(),text_missing.into(),button_bool.into(),choice_filtered.into(),choice_fallback.into()]}},
+        );
+        let output = extract_form_attachment_signals(&document, &[], true, false);
+        assert_eq!(
+            serde_json::to_value(output.form_fields).unwrap(),
+            serde_json::json!([
+                {"name":"numeric","type":"text","value":"","default_value":"default","id":format_id(text_numeric),"editable":true},
+                {"name":"missing","type":"text","value":"","default_value":"","id":format_id(text_missing),"editable":true},
+                {"name":"button","type":"checkbox","value":"Off","default_value":"Default","id":format_id(button_bool),"editable":true},
+                {"name":"choice","type":"listbox","value":"first","default_value":null,"id":format_id(choice_filtered),"editable":true},
+                {"name":"fallback","type":"listbox","value":"from-default","default_value":["from-default"],"id":format_id(choice_fallback),"editable":true}
+            ])
+        );
+    }
+
+    #[test]
+    fn trailing_slash_filename_becomes_unnamed() {
+        let document = Document::with_version("1.7");
+        let mut walker = Walker::new(&document);
+        let spec = dictionary! {"UF"=>Object::string_literal(r"folder/")};
+        assert_eq!(filename(&mut walker, &spec), Some("unnamed".into()));
     }
 }

--- a/crates/pdf-reader-core/src/lib.rs
+++ b/crates/pdf-reader-core/src/lib.rs
@@ -3,6 +3,7 @@
 mod catalog_signals;
 mod cos_document;
 pub mod document_twin;
+mod form_attachment_signals;
 pub mod legacy;
 pub mod ocr_fusion;
 pub mod ocr_tables;

--- a/crates/pdf-reader-core/src/read_pdf.rs
+++ b/crates/pdf-reader-core/src/read_pdf.rs
@@ -574,6 +574,8 @@ struct BuildSignals {
     permissions: Option<Value>,
     mark_info: Option<Value>,
     outline: Option<Value>,
+    form_fields: Option<Value>,
+    attachments: Option<Value>,
     warnings: Vec<String>,
 }
 
@@ -657,6 +659,8 @@ fn build_data(
         permissions,
         mark_info,
         outline,
+        form_fields,
+        attachments,
         mut warnings,
     } = signals;
     let full_text = join_page_text(pages);
@@ -804,7 +808,7 @@ fn build_data(
         None
     };
 
-    let (_, _, form_fields, attachments, structure_trees) = empty_structure_arrays();
+    let (_, _, _, _, structure_trees) = empty_structure_arrays();
 
     let mut data = ReadPdfData {
         num_pages: want_page_count.then_some(total_pages),
@@ -1026,10 +1030,10 @@ fn build_data(
         data.annotations = annotations;
     }
     if want_forms {
-        data.form_fields = Some(form_fields);
+        data.form_fields = form_fields;
     }
     if want_attachments {
-        data.attachments = Some(attachments);
+        data.attachments = attachments;
     }
     if want_structure {
         data.structure_trees = Some(structure_trees);
@@ -1196,6 +1200,14 @@ fn read_local_pdf_filtered(
             outline: input.include_outline || auto_full,
         },
     );
+    let form_attachment_signals = crate::form_attachment_signals::extract_form_attachment_signals(
+        &parsed.document,
+        &parsed.pages,
+        input.include_form_fields || auto_full,
+        input.include_attachments || auto_full,
+    );
+    let mut signal_warnings = signals.warnings;
+    signal_warnings.extend(form_attachment_signals.warnings);
     let mut data = build_data(
         &selected,
         total_pages,
@@ -1209,7 +1221,13 @@ fn read_local_pdf_filtered(
             permissions: catalog_signals.permissions.map(|value| json!(value)),
             mark_info: catalog_signals.mark_info.map(|value| json!(value)),
             outline: catalog_signals.outline.map(|value| json!(value)),
-            warnings: signals.warnings,
+            form_fields: form_attachment_signals
+                .form_fields
+                .map(|value| json!(value)),
+            attachments: form_attachment_signals
+                .attachments
+                .map(|value| json!(value)),
+            warnings: signal_warnings,
         },
     );
     if !invalid_pages.is_empty() {
@@ -1580,8 +1598,8 @@ mod tests {
         assert!(data.page_geometry.is_some());
         assert!(data.permissions.is_none());
         assert!(data.mark_info.is_none());
-        assert!(data.form_fields.is_some());
-        assert!(data.attachments.is_some());
+        assert!(data.form_fields.is_none());
+        assert!(data.attachments.is_none());
         assert!(data.structure_trees.is_some());
         // Provider-backed fields remain absent until the server fuses a
         // normalized outcome; returning an empty placeholder would diverge

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -81,7 +81,7 @@
     "text/search geometry, geometry-perfect pdf.js boxes outside the frozen page-geometry subset, direct-annotation PDF.js presentation normalization, non-Link annotation/action parity, and general bounding-box parity",
     "render/crop/OCR/analyze/read-fusion/table-projection semantic parity outside the immutable 16-case subset, including exact pdf.js pixels and antialiasing",
     "OCR success paths outside the opt-in command JSON/plain-text subset, including tesseract-tsv; mixed selectable/OCR table continuation and full AST hierarchy parity; analyze_regions HTTP and preset providers",
-    "full COS outline/PageLabels/permissions parity outside the frozen common catalog subset; AcroForm radio/pushbutton/signature and malformed-field breadth, integer-like/duplicate attachment-key ordering, filtered embedded-stream decoded sizes, Associated Files, and structure trees",
+    "full COS outline/PageLabels/permissions parity outside the frozen common catalog subset; AcroForm radio/pushbutton/signature and malformed-field breadth, integer-like/duplicate attachment-key ordering, odd-length Names arrays (PDF.js may materialize a final unnamed entry), filtered embedded-stream decoded sizes, Associated Files, and structure trees",
     "cross-platform npm native binary",
     "npm library exports for pure-Rust",
     "2.0x/3.3x industry benchmark headline"

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -39,8 +39,8 @@
       "include_metadata": "PARTIAL",
       "include_outline": "PARTIAL",
       "include_annotations": "PARTIAL",
-      "include_form_fields": "STUB",
-      "include_attachments": "STUB",
+      "include_form_fields": "PARTIAL",
+      "include_attachments": "PARTIAL",
       "include_structure_tree": "STUB",
       "include_page_labels": "PARTIAL",
       "include_page_geometry": "PARTIAL",
@@ -71,17 +71,17 @@
     }
   },
   "claimedForDifferential": [
-    "exact 12-case immutable TS v3.0.14 behavior subset: full text, page selection/order/duplicates, metadata, literal search, case sensitivity, whole word, Unicode, UTF-16 offsets, missing and malformed inputs, mixed-source partial success, inherited crop/media/rotation geometry with page UserUnit, an indirect Link/URI annotation, and common catalog signals (nested URI/destination outline, PageLabels ranges, MarkInfo, and unencrypted permissions omission)",
+    "exact 14-case immutable TS v3.0.14 behavior subset: full text, page selection/order/duplicates, metadata, literal search, case sensitivity, whole word, Unicode, UTF-16 offsets, missing and malformed inputs, mixed-source partial success, inherited crop/media/rotation geometry with page UserUnit, an indirect Link/URI annotation, common catalog signals, a bounded AcroForm text/parent-widget/checkbox/listbox subset, and EmbeddedFiles metadata with distinct ASCII tree keys, path-normalized filenames, descriptions, fixture ordering, and unfiltered content sizes",
     "exact 16-case immutable TS v3.0.14 render/crop/command-provider semantic subset over stdio: defaults, page selection and warnings, region ordering, padding and fractional bounds, rotated pages, mixed-source and late-provider partial success, all-source failure, MCP image indexing, standalone OCR normalization, read_pdf OCR text-layer/map fusion, boxed OCR table projection into elements/chunks/markdown/html/document_ast/document_map, rich region-analysis normalization, plain-text truncation, and truthful provenance; exact pdf.js pixels and antialiasing are not claimed",
     "DNS-pinned URL fetch: one resolution per redirect hop, reject mixed public/non-public answers, disable ambient proxies, and revalidate every redirect; still PARTIAL because resolver timeout and TLS-SNI fixtures remain open",
     "auto off when include_* keys are present"
   ],
   "explicitlyNotClaimed": [
-    "complete TS 3.0.14 semantic parity outside the immutable 12-case subset",
+    "complete TS 3.0.14 semantic parity outside the immutable 14-case subset",
     "text/search geometry, geometry-perfect pdf.js boxes outside the frozen page-geometry subset, direct-annotation PDF.js presentation normalization, non-Link annotation/action parity, and general bounding-box parity",
     "render/crop/OCR/analyze/read-fusion/table-projection semantic parity outside the immutable 16-case subset, including exact pdf.js pixels and antialiasing",
     "OCR success paths outside the opt-in command JSON/plain-text subset, including tesseract-tsv; mixed selectable/OCR table continuation and full AST hierarchy parity; analyze_regions HTTP and preset providers",
-    "full COS outline/PageLabels/permissions parity outside the frozen common catalog subset; AcroForm fields, attachments, and structure trees",
+    "full COS outline/PageLabels/permissions parity outside the frozen common catalog subset; AcroForm radio/pushbutton/signature and malformed-field breadth, integer-like/duplicate attachment-key ordering, filtered embedded-stream decoded sizes, Associated Files, and structure trees",
     "cross-platform npm native binary",
     "npm library exports for pure-Rust",
     "2.0x/3.3x industry benchmark headline"

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -81,7 +81,7 @@
     "text/search geometry, geometry-perfect pdf.js boxes outside the frozen page-geometry subset, direct-annotation PDF.js presentation normalization, non-Link annotation/action parity, and general bounding-box parity",
     "render/crop/OCR/analyze/read-fusion/table-projection semantic parity outside the immutable 16-case subset, including exact pdf.js pixels and antialiasing",
     "OCR success paths outside the opt-in command JSON/plain-text subset, including tesseract-tsv; mixed selectable/OCR table continuation and full AST hierarchy parity; analyze_regions HTTP and preset providers",
-    "full COS outline/PageLabels/permissions parity outside the frozen common catalog subset; AcroForm radio/pushbutton/signature and malformed-field breadth, integer-like/duplicate attachment-key ordering, odd-length Names arrays (PDF.js may materialize a final unnamed entry), filtered embedded-stream decoded sizes, Associated Files, and structure trees",
+    "full COS outline/PageLabels/permissions parity outside the frozen common catalog subset; AcroForm radio/pushbutton/signature, button-array V coercion, and malformed-field breadth, integer-like/duplicate attachment-key ordering, odd-length Names arrays (PDF.js may materialize a final unnamed entry), filtered embedded-stream decoded sizes, Associated Files, and structure trees",
     "cross-platform npm native binary",
     "npm library exports for pure-Rust",
     "2.0x/3.3x industry benchmark headline"

--- a/scripts/differential/check-v3014-behavior-differential.ts
+++ b/scripts/differential/check-v3014-behavior-differential.ts
@@ -77,8 +77,8 @@ function verifyAuthority(): Record<string, string> {
     }
   }
   const ids = corpus.cases.map((entry) => entry.id);
-  if (ids.length !== 12 || new Set(ids).size !== ids.length) {
-    throw new Error(`behavior corpus must contain 12 unique cases (got ${ids.length})`);
+  if (ids.length !== 14 || new Set(ids).size !== ids.length) {
+    throw new Error(`behavior corpus must contain 14 unique cases (got ${ids.length})`);
   }
   if (JSON.stringify(ids.sort()) !== JSON.stringify(Object.keys(oracle.expectations).sort())) {
     throw new Error('corpus and oracle case IDs differ');
@@ -230,6 +230,14 @@ function canonicalRead(id: string, envelope: Record<string, unknown>): Json {
     canonical.page_labels = (data.page_labels ?? null) as Json;
     canonical.permissions = (data.permissions ?? null) as Json;
     canonical.mark_info = (data.mark_info ?? null) as Json;
+  }
+  if (id === 'read-forms') {
+    canonical.form_fields = (data.form_fields ?? null) as Json;
+    canonical.attachments = (data.attachments ?? null) as Json;
+  }
+  if (id === 'read-attachments') {
+    canonical.attachments = (data.attachments ?? null) as Json;
+    canonical.form_fields = (data.form_fields ?? null) as Json;
   }
   canonical.warnings = warnings(data.warnings);
   return canonical;

--- a/scripts/differential/fixtures/v3014-behavior-corpus.json
+++ b/scripts/differential/fixtures/v3014-behavior-corpus.json
@@ -59,6 +59,26 @@
       }
     },
     {
+      "id": "read-forms",
+      "tool": "read_pdf",
+      "input": {
+        "sources": [{ "fixture": "v3014-behavior-v1.pdf" }],
+        "auto": false,
+        "include_form_fields": true,
+        "include_page_count": true
+      }
+    },
+    {
+      "id": "read-attachments",
+      "tool": "read_pdf",
+      "input": {
+        "sources": [{ "fixture": "v3014-behavior-v1.pdf" }],
+        "auto": false,
+        "include_attachments": true,
+        "include_page_count": true
+      }
+    },
+    {
       "id": "search-ci-all",
       "tool": "search_pdf",
       "input": {

--- a/scripts/differential/fixtures/v3014-behavior-fixtures.json
+++ b/scripts/differential/fixtures/v3014-behavior-fixtures.json
@@ -4,8 +4,8 @@
   "fixtures": [
     {
       "path": "test/fixtures/differential/v3014-behavior-v1.pdf",
-      "bytes": 2539,
-      "sha256": "f5156a648e0cacb690bc5cf762f2be11dc62adfaa7e8d56fa6f4e45bdbef7267"
+      "bytes": 3946,
+      "sha256": "cb83cc5132e09b20cc274cfa8e9b16b7fe71e3e5de40d9340ece333af0129628"
     },
     {
       "path": "test/fixtures/differential/v3014-malformed-v1.pdf",

--- a/scripts/differential/fixtures/v3014-behavior-oracle.json
+++ b/scripts/differential/fixtures/v3014-behavior-oracle.json
@@ -167,6 +167,97 @@
       },
       "warnings": []
     },
+    "read-forms": {
+      "outcome": "success",
+      "num_pages": 3,
+      "form_fields": [
+        {
+          "name": "customer_name",
+          "type": "text",
+          "value": "Ada Lovelace",
+          "default_value": "",
+          "page": 1,
+          "id": "22R",
+          "editable": true,
+          "bounding_box": {
+            "left": 72,
+            "bottom": 635,
+            "right": 260,
+            "top": 660
+          }
+        },
+        {
+          "name": "profile",
+          "id": "24R"
+        },
+        {
+          "name": "profile",
+          "type": "text",
+          "value": "Grace Hopper",
+          "default_value": "Unknown",
+          "page": 2,
+          "id": "25R",
+          "editable": false,
+          "bounding_box": {
+            "left": 72,
+            "bottom": 500,
+            "right": 260,
+            "top": 525
+          }
+        },
+        {
+          "name": "consent",
+          "type": "checkbox",
+          "value": "Yes",
+          "default_value": null,
+          "page": 2,
+          "id": "26R",
+          "editable": true,
+          "bounding_box": {
+            "left": 72,
+            "bottom": 450,
+            "right": 90,
+            "top": 468
+          }
+        },
+        {
+          "name": "tier",
+          "type": "listbox",
+          "value": "gold",
+          "default_value": "silver",
+          "page": 3,
+          "id": "27R",
+          "editable": true,
+          "bounding_box": {
+            "left": 72,
+            "bottom": 400,
+            "right": 200,
+            "top": 425
+          }
+        }
+      ],
+      "attachments": null,
+      "warnings": []
+    },
+    "read-attachments": {
+      "outcome": "success",
+      "num_pages": 3,
+      "attachments": [
+        {
+          "name": "source.csv",
+          "filename": "source.csv",
+          "description": "Source data",
+          "size_bytes": 19
+        },
+        {
+          "name": "evidence",
+          "filename": "report.txt",
+          "size_bytes": 5
+        }
+      ],
+      "form_fields": null,
+      "warnings": []
+    },
     "search-ci-all": {
       "outcome": "success",
       "num_pages": 3,

--- a/scripts/differential/generate-v3014-behavior-fixtures.ts
+++ b/scripts/differential/generate-v3014-behavior-fixtures.ts
@@ -31,7 +31,7 @@ function buildPdf(): Buffer {
   const objects = new Map<number, string>([
     [
       1,
-      '<< /Type /Catalog /Pages 2 0 R /PageLabels 13 0 R /MarkInfo 14 0 R /Outlines 15 0 R >>',
+      '<< /Type /Catalog /Pages 2 0 R /PageLabels 13 0 R /MarkInfo 14 0 R /Outlines 15 0 R /Names 18 0 R /AcroForm 23 0 R >>',
     ],
     [2, '<< /Type /Pages /Kids [3 0 R 5 0 R 7 0 R] /Count 3 /MediaBox [0 0 612 792] /CropBox [20 30 580 760] /Rotate 90 /UserUnit 2 >>'],
     [
@@ -67,6 +67,18 @@ function buildPdf(): Buffer {
       '<< /Title (External docs) /Parent 15 0 R /First 17 0 R /Last 17 0 R /Count 1 /F 3 /C [0.25 0.5 0.75] /A << /S /URI /URI (https://example.com/docs) >> >>',
     ],
     [17, '<< /Title (Page three) /Parent 16 0 R /Dest [7 0 R /Fit] >>'],
+    [18, '<< /EmbeddedFiles 19 0 R >>'],
+    [19, '<< /Names [(source.csv) 20 0 R (evidence) 28 0 R] >>'],
+    [20, '<< /Type /Filespec /F (source.csv) /UF (source.csv) /Desc (Source data) /EF << /F 21 0 R /UF 21 0 R >> >>'],
+    [21, '<< /Type /EmbeddedFile /Length 19 >>\nstream\nname,value\nalpha,1\nendstream'],
+    [22, '<< /Type /Annot /Subtype /Widget /FT /Tx /T (customer_name) /V (Ada Lovelace) /DV () /Rect [72 635 260 660] /P 3 0 R /F 4 >>'],
+    [23, '<< /Fields [22 0 R 24 0 R 26 0 R 27 0 R] >>'],
+    [24, '<< /FT /Tx /T (profile) /V (Grace Hopper) /DV (Unknown) /Ff 3 /Kids [25 0 R] >>'],
+    [25, '<< /Type /Annot /Subtype /Widget /Parent 24 0 R /Rect [72 500 260 525] /P 5 0 R >>'],
+    [26, '<< /Type /Annot /Subtype /Widget /FT /Btn /T (consent) /V /Yes /AS /Yes /Rect [72 450 90 468] /P 5 0 R >>'],
+    [27, '<< /Type /Annot /Subtype /Widget /FT /Ch /T (tier) /V (gold) /DV (silver) /Ff 2 /Rect [72 400 200 425] /P 7 0 R >>'],
+    [28, '<< /Type /Filespec /UF (C:\\\\reports\\\\report.txt) /EF << /UF 29 0 R >> >>'],
+    [29, '<< /Type /EmbeddedFile /Length 5 >>\nstream\nhelloendstream'],
   ]);
 
   const chunks: Buffer[] = [Buffer.from('%PDF-1.4\n%\xe2\xe3\xcf\xd3\n', 'latin1')];

--- a/scripts/differential/v3014-baseline-runner.ts
+++ b/scripts/differential/v3014-baseline-runner.ts
@@ -96,6 +96,14 @@ async function readCase(id: string, input: Record<string, unknown>) {
     output.permissions = first.data?.permissions ?? null;
     output.mark_info = first.data?.mark_info ?? null;
   }
+  if (id === 'read-forms') {
+    output.form_fields = first.data?.form_fields ?? null;
+    output.attachments = first.data?.attachments ?? null;
+  }
+  if (id === 'read-attachments') {
+    output.attachments = first.data?.attachments ?? null;
+    output.form_fields = first.data?.form_fields ?? null;
+  }
   output.warnings = canonicalWarnings(first.data?.warnings);
   return output;
 }

--- a/scripts/run-pdf-reader-differential.sh
+++ b/scripts/run-pdf-reader-differential.sh
@@ -69,7 +69,7 @@ echo "--- deterministic v3.0.14 behavior fixtures + baseline replay ---" | tee -
 bun "$REPO_ROOT/scripts/differential/generate-v3014-behavior-fixtures.ts" 2>&1 | tee -a "$LOG"
 bun "$REPO_ROOT/scripts/differential/capture-v3014-behavior-oracle.ts" 2>&1 | tee -a "$LOG"
 
-echo "--- immutable v3.0.14 behavior differential (12 exact cases) ---" | tee -a "$LOG"
+echo "--- immutable v3.0.14 behavior differential (14 exact cases) ---" | tee -a "$LOG"
 bun "$REPO_ROOT/scripts/differential/check-v3014-behavior-differential.ts" \
   --output "$V3014_BEHAVIOR_JSON" >>"$LOG"
 

--- a/test/fixtures/differential/v3014-behavior-v1.pdf
+++ b/test/fixtures/differential/v3014-behavior-v1.pdf
@@ -1,7 +1,7 @@
 %PDF-1.4
 %‚„œ”
 1 0 obj
-<< /Type /Catalog /Pages 2 0 R /PageLabels 13 0 R /MarkInfo 14 0 R /Outlines 15 0 R >>
+<< /Type /Catalog /Pages 2 0 R /PageLabels 13 0 R /MarkInfo 14 0 R /Outlines 15 0 R /Names 18 0 R /AcroForm 23 0 R >>
 endobj
 2 0 obj
 << /Type /Pages /Kids [3 0 R 5 0 R 7 0 R] /Count 3 /MediaBox [0 0 612 792] /CropBox [20 30 580 760] /Rotate 90 /UserUnit 2 >>
@@ -80,28 +80,82 @@ endobj
 17 0 obj
 << /Title (Page three) /Parent 16 0 R /Dest [7 0 R /Fit] >>
 endobj
+18 0 obj
+<< /EmbeddedFiles 19 0 R >>
+endobj
+19 0 obj
+<< /Names [(source.csv) 20 0 R (evidence) 28 0 R] >>
+endobj
+20 0 obj
+<< /Type /Filespec /F (source.csv) /UF (source.csv) /Desc (Source data) /EF << /F 21 0 R /UF 21 0 R >> >>
+endobj
+21 0 obj
+<< /Type /EmbeddedFile /Length 19 >>
+stream
+name,value
+alpha,1
+endstream
+endobj
+22 0 obj
+<< /Type /Annot /Subtype /Widget /FT /Tx /T (customer_name) /V (Ada Lovelace) /DV () /Rect [72 635 260 660] /P 3 0 R /F 4 >>
+endobj
+23 0 obj
+<< /Fields [22 0 R 24 0 R 26 0 R 27 0 R] >>
+endobj
+24 0 obj
+<< /FT /Tx /T (profile) /V (Grace Hopper) /DV (Unknown) /Ff 3 /Kids [25 0 R] >>
+endobj
+25 0 obj
+<< /Type /Annot /Subtype /Widget /Parent 24 0 R /Rect [72 500 260 525] /P 5 0 R >>
+endobj
+26 0 obj
+<< /Type /Annot /Subtype /Widget /FT /Btn /T (consent) /V /Yes /AS /Yes /Rect [72 450 90 468] /P 5 0 R >>
+endobj
+27 0 obj
+<< /Type /Annot /Subtype /Widget /FT /Ch /T (tier) /V (gold) /DV (silver) /Ff 2 /Rect [72 400 200 425] /P 7 0 R >>
+endobj
+28 0 obj
+<< /Type /Filespec /UF (C:\\reports\\report.txt) /EF << /UF 29 0 R >> >>
+endobj
+29 0 obj
+<< /Type /EmbeddedFile /Length 5 >>
+stream
+helloendstream
+endobj
 xref
-0 18
+0 30
 0000000000 65535 f 
 0000000015 00000 n 
-0000000117 00000 n 
-0000000258 00000 n 
-0000000389 00000 n 
-0000000532 00000 n 
-0000000658 00000 n 
-0000000823 00000 n 
-0000000949 00000 n 
-0000001079 00000 n 
-0000001176 00000 n 
-0000001390 00000 n 
-0000001537 00000 n 
-0000001616 00000 n 
-0000001709 00000 n 
-0000001781 00000 n 
-0000001855 00000 n 
-0000002024 00000 n 
+0000000148 00000 n 
+0000000289 00000 n 
+0000000420 00000 n 
+0000000563 00000 n 
+0000000689 00000 n 
+0000000854 00000 n 
+0000000980 00000 n 
+0000001110 00000 n 
+0000001207 00000 n 
+0000001421 00000 n 
+0000001568 00000 n 
+0000001647 00000 n 
+0000001740 00000 n 
+0000001812 00000 n 
+0000001886 00000 n 
+0000002055 00000 n 
+0000002131 00000 n 
+0000002175 00000 n 
+0000002244 00000 n 
+0000002366 00000 n 
+0000002455 00000 n 
+0000002596 00000 n 
+0000002656 00000 n 
+0000002752 00000 n 
+0000002851 00000 n 
+0000002973 00000 n 
+0000003104 00000 n 
+0000003193 00000 n 
 trailer
-<< /Size 18 /Root 1 0 R /Info 10 0 R >>
+<< /Size 30 /Root 1 0 R /Info 10 0 R >>
 startxref
-2100
+3267
 %%EOF

--- a/test/production/capabilityParity.contract.test.ts
+++ b/test/production/capabilityParity.contract.test.ts
@@ -36,8 +36,6 @@ const READ_PDF_REQUIRED_FIELDS: Record<string, string[]> = {
   trust: ['trust_report'],
   a11y: ['accessibility_report'],
   'page-geometry': ['page_geometry'],
-  forms: ['form_fields'],
-  attachments: ['attachments'],
   structure: ['structure_trees'],
   images: ['images'],
   visual: ['visual_enrichments'],
@@ -197,6 +195,103 @@ describe.skipIf(!pureRustEnabled)('experimental pure-Rust capability contract', 
       results?: Array<{ data?: { annotations?: unknown } }>;
     };
     expect(omitted.results?.[0]?.data?.annotations).toBeUndefined();
+  }, 180_000);
+
+  test('forms and attachments match separate immutable fixtures and omit placeholders', async () => {
+    const formsResponse = await callTool(
+      proc,
+      nextId(),
+      'read_pdf',
+      { sources: [{ path: signalPdf }], auto: false, include_form_fields: true },
+      90_000
+    );
+    const formsData = (
+      JSON.parse(parseToolPayload(formsResponse).text) as {
+        results?: Array<{ data?: Record<string, unknown> }>;
+      }
+    ).results?.[0]?.data;
+    expect(formsData?.form_fields).toEqual([
+      {
+        name: 'customer_name',
+        type: 'text',
+        value: 'Ada Lovelace',
+        default_value: '',
+        page: 1,
+        id: '22R',
+        editable: true,
+        bounding_box: { left: 72, bottom: 635, right: 260, top: 660 },
+      },
+      { name: 'profile', id: '24R' },
+      {
+        name: 'profile',
+        type: 'text',
+        value: 'Grace Hopper',
+        default_value: 'Unknown',
+        page: 2,
+        id: '25R',
+        editable: false,
+        bounding_box: { left: 72, bottom: 500, right: 260, top: 525 },
+      },
+      {
+        name: 'consent',
+        type: 'checkbox',
+        value: 'Yes',
+        default_value: null,
+        page: 2,
+        id: '26R',
+        editable: true,
+        bounding_box: { left: 72, bottom: 450, right: 90, top: 468 },
+      },
+      {
+        name: 'tier',
+        type: 'listbox',
+        value: 'gold',
+        default_value: 'silver',
+        page: 3,
+        id: '27R',
+        editable: true,
+        bounding_box: { left: 72, bottom: 400, right: 200, top: 425 },
+      },
+    ]);
+    expect(formsData?.attachments).toBeUndefined();
+
+    const attachmentsResponse = await callTool(
+      proc,
+      nextId(),
+      'read_pdf',
+      { sources: [{ path: signalPdf }], auto: false, include_attachments: true },
+      90_000
+    );
+    const attachmentsData = (
+      JSON.parse(parseToolPayload(attachmentsResponse).text) as {
+        results?: Array<{ data?: Record<string, unknown> }>;
+      }
+    ).results?.[0]?.data;
+    expect(attachmentsData?.attachments).toEqual([
+      { name: 'source.csv', filename: 'source.csv', description: 'Source data', size_bytes: 19 },
+      { name: 'evidence', filename: 'report.txt', size_bytes: 5 },
+    ]);
+    expect(attachmentsData?.form_fields).toBeUndefined();
+
+    const emptyResponse = await callTool(
+      proc,
+      nextId(),
+      'read_pdf',
+      {
+        sources: [{ path: samplePdf }],
+        auto: false,
+        include_form_fields: true,
+        include_attachments: true,
+      },
+      90_000
+    );
+    const emptyData = (
+      JSON.parse(parseToolPayload(emptyResponse).text) as {
+        results?: Array<{ data?: Record<string, unknown> }>;
+      }
+    ).results?.[0]?.data;
+    expect(emptyData?.form_fields).toBeUndefined();
+    expect(emptyData?.attachments).toBeUndefined();
   }, 180_000);
 
   test('catalog signals match the immutable v3.0.14 subset and omit unavailable values', async () => {


### PR DESCRIPTION
## Outcome

Adds bounded pure-Rust AcroForm and EmbeddedFiles projections for the explicitly claimed TS 3.0.14 subset. Public `form_fields` and `attachments` remain opt-in/omitted when empty or failed, with independent failure isolation.

## Safety and parity

- borrowed exact-generation COS traversal; collections are admitted before handle/materialization allocation
- bounded Pages and cumulative direct/indirect Annots; maps build only after complete admission
- bounded field/name-tree traversal, recursion, values, decoded strings, and attachment content
- PDF.js-aligned inheritance, coercion, filename precedence, NameTree Kids precedence, and failure/omission behavior for the frozen subset
- oversized/malformed forms fail closed without suppressing valid attachments
- capability matrix remains `PARTIAL`; `dropInFor3014=false` and publish freeze stay unchanged

## Evidence

- exact candidate: `c360755fb796e90155a9d35e255186e854d4806c`
- independent review: R1-R5 found material defects; R6 PASS (confidence 0.98; no P0-P2)
- parent `cargo test --workspace`: 137/137 green
- parent `cargo clippy --workspace --all-targets -- -D warnings`
- parent release build green
- immutable TS v3.0.14 differential: 14/14, 0 skipped
- focused form/attachment tests: 13/13
- production TS contract, capability contract, and honest matrix checks green

This is a bounded subset admission, not full drop-in parity or release approval.

Agent-Author: Codex