### PR TITLE
fix(ci): restore release lint admission

### DIFF
--- a/test/production/mcpContract.helpers.ts
+++ b/test/production/mcpContract.helpers.ts
@@ -52,7 +52,7 @@ export const productionEnv = (overrides: NodeJS.ProcessEnv = {}): NodeJS.Process
   const env = { ...process.env, ...overrides };
   // Default published path: do not force pure-rust
   if (!overrides.PDF_READER_ENGINE_MODE) {
-    delete env.PDF_READER_ENGINE_MODE;
+    env.PDF_READER_ENGINE_MODE = undefined;
   }
   env.NODE_ENV = env.NODE_ENV ?? 'test';
   env.MCP_TRANSPORT = env.MCP_TRANSPORT ?? 'stdio';

--- a/test/rustMcp.boundary.test.ts
+++ b/test/rustMcp.boundary.test.ts
@@ -8,7 +8,6 @@ const repoRoot = path.resolve(import.meta.dirname, '..');
 const rustServerBin = path.join(repoRoot, 'target/release/pdf-reader-mcp-server');
 const rustCliBin = path.join(repoRoot, 'target/release/pdf-reader-cli');
 const stagedRustBin = path.join(repoRoot, 'bin/native/pdf-reader-mcp-server');
-const binWrapper = path.join(repoRoot, 'bin/pdf-reader-mcp');
 const samplePdf = path.join(repoRoot, 'test/fixtures/sample.pdf');
 
 describe('MCP transport boundary (pure-Rust)', () => {


### PR DESCRIPTION
Repairs the post-merge Release admission failure from run 29671175264.\n\n- replace Biome-prohibited delete in the production test environment helper while preserving an actually absent child-process environment key\n- remove one unused Rust boundary-test constant\n- no runtime, semantic parity, packaging, or publish-state changes\n\nExact candidate: c54234481f20ca1b16c9a19cfc0fd4169c1e771e\nBase: 1c4e5ca92c514541644a14722cc9eb2add771058\nTree: 3cc1e60f4d3279bf8f062e8183b4d289b7528b37\n\nIndependent review: PASS, confidence 0.99, no material findings.\nReviewer verified Node 26 and Bun 1.3.12 both omit PDF_READER_ENGINE_MODE when the env map value is undefined.\n\nLocal evidence:\n- Biome: 151 files, PASS\n- typecheck: PASS\n- production contract: 7/7\n- Rust MCP boundary: 5/5\n- Bun suite: 496 pass, 11 expected capability skips, 0 fail\n- opt-in capability contract: 9/9, 55 assertions\n- exact-candidate claimed-subset differential audit: PASS, zero skipped\n- Rust core: 160 pass\n- Rust MCP server: 38 pass\n- package smoke: 14/14\n- docs build: PASS\n\nProduct truth remains:\n- dropInFor3014=false\n- publishFreeze=true\n- include_tables=PARTIAL\n- TypeScript 3.0.14 remains the published path\n\nAfter merge, Release must pass every preceding gate and fail only at Enforce Rust replacement publish freeze.\n\nAgent-Author: Codex <codex@openai.com>