### PR TITLE
docs: retire GroundAtlas dogfood; Skills instruction SSOT

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -10,7 +10,7 @@ evidence without becoming a hosted Sylphx Platform BaaS service.
 
 - Lifecycle: `production`
 - Layer: `tooling`
-- Doctrine source of truth: [SylphxAI/doctrine](https://github.com/SylphxAI/doctrine)
+- Static instruction SSOT: [SylphxAI/skills](https://github.com/SylphxAI/skills) (Doctrine residual is historical only)
 - Machine manifest: `.doctrine/project.json`
 - Vendor-neutral GroundAtlas manifest: `project.manifest.json`
 - Generated GroundAtlas reports: `.groundatlas*`, JSON reports, and Markdown

--- a/docs/adr/0003-groundatlas-013-scorecard-gate.md
+++ b/docs/adr/0003-groundatlas-013-scorecard-gate.md
@@ -1,5 +1,7 @@
 # ADR 0003: Dogfood GroundAtlas 0.1.3 Scorecard Gate
 
+> **Status: Retired.** GroundAtlas package/action dogfood is no longer an active CI gate (Control Plane ADR-0014). Skills/static standards SSOT is SylphxAI/skills; this ADR is historical only.
+
 ## Status
 
 Superseded by Control Plane ADR-0014.


### PR DESCRIPTION
## Summary
- Collision-safe docs-only PR (does not touch open PR #438 / #396 file sets)
- Retire GroundAtlas scorecard dogfood ADR as historical
- Point PROJECT.md static instruction SSOT to **SylphxAI/skills**
- SSRF policy already fail-closed on main (`cargo test -p pdf-reader-core ssrf` → 3 passed)

## Verification
- Local: `cargo test -p pdf-reader-core ssrf` → **3 passed**
- No product code changes

## Not done
- Merge/deploy/publish proof for other PDF product work remains with owners of #438/#396
- CI workflow is currently disabled_manually on this repo