### PR TITLE
feat(rust): honor search_pdf prefer_speed speed-route semantics

### DIFF
--- a/crates/pdf-reader-core/src/search_pdf.rs
+++ b/crates/pdf-reader-core/src/search_pdf.rs
@@ -325,11 +325,30 @@ pub fn search_pdf(input: &SearchPdfInput) -> Result<SearchPdfResponse, SearchPdf
                     }));
                     continue;
                 }
+                let prefer_speed = input.prefer_speed.unwrap_or(false);
+                let include_ocr = input.include_ocr_text_layer.unwrap_or(false);
+                // current TS prefer_speed uses the rust-text-index route only when OCR is off:
+                // matches omit geometry and emit the speed-route warning.
+                let speed_route = prefer_speed && !include_ocr;
                 let matches: Vec<Value> = search
                     .matches
                     .iter()
                     .enumerate()
                     .map(|(index, item)| {
+                        if speed_route {
+                            return json!({
+                                "id": format!("p{}-match-{}", item.page, index + 1),
+                                "page": item.page,
+                                "text": item.text,
+                                "snippet": item.snippet,
+                                "match_start": item.match_start,
+                                "match_end": item.match_end,
+                                "provenance": {
+                                    "engine": "rust-text-index",
+                                    "source": "text-content",
+                                }
+                            });
+                        }
                         let mut value = json!({
                             "id": format!("p{}-match-{}", item.page, index + 1),
                             "page": item.page,
@@ -354,6 +373,12 @@ pub fn search_pdf(input: &SearchPdfInput) -> Result<SearchPdfResponse, SearchPdf
                     .collect();
 
                 let mut warnings = Vec::new();
+                if speed_route {
+                    warnings.push(
+                        "Search route: rust-text-index via literal PDF text extraction. Bounding boxes are unavailable on this route; use read_pdf or pdf_evidence for geometry-backed evidence."
+                            .to_string(),
+                    );
+                }
                 if !invalid_pages.is_empty() {
                     warnings.push(format!(
                         "Requested page numbers {} exceed total pages ({}).",
@@ -990,6 +1015,47 @@ mod tests {
         assert!(item.get("ocr_word_index").is_none());
         assert!(item.get("bounding_box").is_none());
         assert!(item.get("bounding_box_level").is_none());
+    }
+
+    #[test]
+    fn prefer_speed_strips_geometry_and_emits_route_warning() {
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../test/fixtures/differential/v3014-behavior-v1.pdf");
+        let response = search_pdf(&SearchPdfInput {
+            sources: vec![SearchPdfSource {
+                path: Some(fixture.to_string_lossy().into_owned()),
+                url: None,
+                pages: None,
+            }],
+            query: "Needle".into(),
+            case_sensitive: None,
+            whole_word: None,
+            include_ocr_text_layer: None,
+            max_pages: Some(10),
+            max_matches_per_source: Some(20),
+            context_chars: Some(4),
+            prefer_speed: Some(true),
+        })
+        .expect("prefer_speed search");
+        assert_eq!(response.search_options["prefer_speed"], json!(true));
+        let result = &response.results[0];
+        assert_eq!(result["success"], json!(true));
+        let warnings = result["warnings"].as_array().expect("warnings");
+        assert!(
+            warnings.iter().any(|w| w
+                .as_str()
+                .is_some_and(|s| { s.contains("Bounding boxes are unavailable on this route") })),
+            "missing speed-route warning: {warnings:?}"
+        );
+        let matches = result["matches"].as_array().expect("matches");
+        assert!(!matches.is_empty());
+        for item in matches {
+            assert!(item.get("bounding_box").is_none(), "{item}");
+            assert!(item.get("bounding_box_level").is_none(), "{item}");
+            assert!(item.get("text_item_index").is_none(), "{item}");
+            assert_eq!(item["provenance"]["engine"], json!("rust-text-index"));
+            assert_eq!(item["provenance"]["source"], json!("text-content"));
+        }
     }
 
     #[test]

--- a/crates/pdf-reader-mcp-server/src/schema.rs
+++ b/crates/pdf-reader-mcp-server/src/schema.rs
@@ -160,6 +160,9 @@ pub struct SearchPdfArgs {
     pub max_matches_per_source: Option<u32>,
     #[schemars(range(min = 0, max = 1000))]
     pub context_chars: Option<u32>,
+    /// When true, match the current TS prefer_speed route: omit match geometry and
+    /// emit the rust-text-index speed-route warning (ignored when OCR is enabled).
+    pub prefer_speed: Option<bool>,
 }
 
 impl SearchPdfArgs {

--- a/docs/performance/why-rust.md
+++ b/docs/performance/why-rust.md
@@ -178,6 +178,11 @@ A frozen four-case public-stdio selectable/OCR search interleaving subset is adm
 A frozen two-case public-stdio URL source single-fetch subset is admitted for `read_pdf` over a local fixture HTTP server with `MCP_PDF_ALLOW_PRIVATE_IPS=true`: no-OCR single fetch and OCR-with-document-map single fetch that reuses materialized bytes. Leaf-mutation count is frozen at 16 with relocated fixture-root replay. `url_ssrf` remains `PARTIAL`; `search_pdf` URL+OCR single-fetch (TS double-fetch residual), resolver timeout, TLS-SNI fixtures, public-internet fetch, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
 
 
+
+### search_pdf prefer_speed route (post-3.0.14 surface)
+
+Pure-Rust `search_pdf` now accepts `prefer_speed` and, when OCR is off, matches the current TypeScript speed route: match geometry is omitted, provenance uses `rust-text-index`/`text-content`, and the speed-route warning is emitted. This is a current-surface parity fix, not a frozen detached TS v3.0.14 differential claim. `prefer_speed` remains `PARTIAL` in the capability matrix; `dropInFor3014` stays false and publish freeze remains enabled.
+
 ### search_pdf tesseract-tsv public-stdio subset (bounded)
 
 A frozen two-case public-stdio `search_pdf` tesseract-tsv OCR subset is admitted over `v3014-visual-v1.pdf`: valid TSV level-5 words produce image-to-PDF `ocr_word` geometry on the search match, and malformed TSV soft-falls back to raw text without geometry. Leaf-mutation count is frozen at 34 with relocated fixture-root replay. `include_ocr_text_layer` remains `PARTIAL`; real tesseract binary health checks, selectable/OCR interleaving, URL single-fetch, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.


### PR DESCRIPTION
## Summary
- Pure-Rust MCP previously dropped `prefer_speed` when re-encoding `SearchPdfArgs`.
- When `prefer_speed=true` and OCR is off, match the current TypeScript speed route:
  - no match geometry / `text_item_index`
  - provenance `{ engine: rust-text-index, source: text-content }`
  - speed-route warning about unavailable bounding boxes
- Control path (`prefer_speed=false`) keeps `char_estimated` geometry.

## Scope note
- `prefer_speed` is **not** part of detached TS **v3.0.14** (LKG schema lacks it).
- This is current-surface pure-Rust ↔ current TS parity, not a v3.0.14 frozen differential claim.
- `dropInFor3014=false`, `publishFreeze=true` unchanged.

## Test plan
- [x] `cargo test -p pdf-reader-core --lib prefer_speed`
- [x] `cargo clippy -p pdf-reader-core -p pdf-reader-mcp-server -- -D warnings`
- [x] Manual stdio probe: prefer_speed true/false vs current TS
- [ ] CI green
- [ ] post-merge Release freeze-only