### PR TITLE
fix(manifest): strip platform identity from public sylphx.toml

### DIFF
--- a/sylphx.toml
+++ b/sylphx.toml
@@ -2,8 +2,6 @@ version = "1"
 
 [project]
 name = "@sylphx/pdf-reader-mcp"
-slug = "pdf-reader-mcp"
-org = "sylphx"
 
 [build]
 strategy = "auto"


### PR DESCRIPTION
## Outcome

Strip platform-derived identity from public `sylphx.toml` (ADR-3927 identity cut):

- Remove `project.slug` / TypeIDs / org binding / region echoes
- Keep optional user-authored `name` / `description` / `default_env`
- Project targeting remains Platform binding + path identity

## Dependency / merge gate

**Merge only after** [SylphxAI/platform#4337](https://github.com/SylphxAI/platform/pull/4337) is merged **and** live Platform deploy projection accepts blueprints without platform identity (legacy parser optional identity).

Until then this PR should stay open (or draft) so dogfood deploys are not parsed by pre-cut Platform code.

## Why

Platform-generated immutable identity is not developer intent. Public D1 is an application blueprint only (zero-knowledge / zero-config product semantics).

AI-REVIEW: GO on fleet identity strip (depends on platform parser cut)