### PR TITLE
docs(rust): adopt capability-first semantic admission (ADR-0005)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The most-starred PDF MCP server on GitHub.
 > **Published stable: `@sylphx/pdf-reader-mcp@3.0.14` (TypeScript path).**  
 > Pure-Rust cutover is **in progress and not published**. Versions `3.0.15`–`3.1.1`
 > are **WITHDRAWN** (deprecated on npm). Do not install them.  
-> **Publish freeze** until capability parity is real — no more premature releases.
+> **Publish freeze** until capability-first semantic compatibility is proven (ADR-0005) — not exact PDF.js JSON equality, and no premature releases.
 
 [![GitHub stars](https://img.shields.io/github/stars/SylphxAI/pdf-reader-mcp?style=for-the-badge&logo=github)](https://github.com/SylphxAI/pdf-reader-mcp/stargazers)
 [![npm version](https://img.shields.io/npm/v/@sylphx/pdf-reader-mcp?style=flat-square)](https://www.npmjs.com/package/@sylphx/pdf-reader-mcp)

--- a/docs/adr/0005-capability-first-semantic-compatibility.md
+++ b/docs/adr/0005-capability-first-semantic-compatibility.md
@@ -1,0 +1,162 @@
+# ADR-0005 — Capability-first semantic compatibility replaces exact PDF.js output parity
+
+- **Status:** Accepted
+- **Date:** 2026-07-22
+- **Relates to:** ADR-PROPOSED fleet Rust north star, `docs/specs/pure-rust-capability-matrix.json`, `docs/specs/temporary-rust-migration-fences.md`, `docs/specs/capability-first-admission-contract.md`
+- **Change class:** `required-now` for Rust admission and release bar
+
+## Context
+
+The pure-Rust cutover program admitted many bounded TS v3.0.14 public-stdio
+differential residuals. That program proved useful for:
+
+- locking interface/schema contracts;
+- discovering coverage gaps;
+- preserving security/resource fail-closed behavior;
+- preventing accidental publish while Rust is incomplete.
+
+It also produced a long tail of exact-output residual PRs that mostly re-encode
+PDF.js implementation quirks:
+
+- annotation appearance precedence edge cases;
+- malformed object fallbacks;
+- checkbox/radio `/AP` `/AS` micro-details;
+- UTF-16 surrogate and locale lowercase quirks;
+- bounding-box rounding and null/missing/empty representation differences.
+
+Exact JSON equality with PDF.js is no longer a sustainable whole-product
+admission bar. It binds Rust architecture to PDF.js object-model accidents,
+creates near-infinite residual PR volume, and does not necessarily improve agent
+document intelligence.
+
+## Decision
+
+### 1. Admission bar is capability-first semantic compatibility
+
+Rust may replace TypeScript when it provides **equivalent or better PDF
+intelligence capability** for agent tasks, not when it reproduces PDF.js output
+byte-for-byte.
+
+Three compatibility layers are mandatory and distinct:
+
+1. **Interface compatibility** — strict/exact
+   - MCP tool names
+   - input required/optional rules
+   - JSON Schema field types
+   - transport and JSON-RPC envelope
+   - error classification
+   - page numbering convention
+   - deterministic/stable system IDs where claimed
+   - capability availability and fail-closed behavior
+
+2. **Semantic capability equivalence** — primary release standard
+   - same user tasks must be supportable
+   - table/search/AST/map/OCR/visual/form/annotation results must preserve task-relevant meaning
+   - provenance/page/location evidence must be usable
+   - representation differences (whitespace, IDs, reasonable bbox deltas, ordering within equivalence class) may be accepted when classified
+
+3. **Quality parity** — task-eval gated
+   - same corpus, same agent tasks, Rust evidence quality not below calibrated TS baseline
+   - thresholds come from corpus measurement, not invented percentages
+
+### 2. TS 3.0.14 exact differentials are demoted, not deleted
+
+TS 3.0.14 remains valuable as:
+
+- regression baseline;
+- coverage discovery tool;
+- compatibility reference;
+- mismatch classification source.
+
+It is **not** the sole whole-product oracle.
+
+Existing exact residual families remain frozen evidence. New work must not
+expand exact residual volume unless the mismatch is classified as:
+
+- contract break;
+- semantic regression;
+- security/resource fail-closed gap.
+
+### 3. Mismatch taxonomy is mandatory
+
+Every TS-vs-Rust mismatch must be classified as one of:
+
+1. `contract_break` — must fix
+2. `semantic_regression` — must fix
+3. `equivalent_representation` — accept and document
+4. `rust_improvement` — accept and document
+5. `pdfjs_implementation_non_goal` — stop chasing
+6. `unknown` — send to task-eval, do not hand-wave
+
+### 4. Non-claims require reclassification before unfreeze
+
+The historical `explicitlyNotClaimed` list mixes true capability gaps with
+PDF.js non-goals. Before `publishFreeze=false` or `dropInFor3014=true`:
+
+1. complete reclassification of open non-claims into the taxonomy in
+   `docs/specs/nonclaim-reclassification-ledger.json`;
+2. prove only remaining `blocking_capability_gap` and unresolved `quality_risk`
+   items are closed or explicitly accepted with task-eval evidence;
+3. keep security/resource bounds executable and fail-closed.
+
+### 5. Publish freeze remains until the new bar is met
+
+This ADR does **not** unfreeze publish and does **not** claim drop-in.
+
+`productTruth.dropInFor3014=false` and `productTruth.publishFreeze=true` remain
+until:
+
+- interface contracts are green;
+- core capabilities have executable semantic contracts;
+- agent-task corpus acceptance is green against calibrated thresholds;
+- five-platform clean native install/runtime is proven;
+- whole-product independent review of one exact candidate passes;
+- TS retirement/rollback plan is complete;
+- registry/install readback is complete.
+
+### 6. Architecture ownership
+
+Canonical document model and capability modules are owned by Rust
+(`pdf-reader-core` + MCP server boundary), not reverse-engineered from PDF.js
+response shapes.
+
+```text
+PDF parse/render adapters
+        ↓
+Canonical Rust Document Model
+        ↓
+Capability modules
+  text / table / search / OCR / image /
+  structure / forms / annotations / evidence
+        ↓
+Stable MCP semantic projection
+```
+
+External engines remain optional adapters. Do not replace the pure-Rust default
+runtime without measured corpus failure of the current stack.
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+| --- | --- |
+| Continue exact PDF.js output parity as sole bar | Infinite residual tail; architecture capture by PDF.js quirks |
+| Immediately treat all PARTIAL as PASS / unfreeze | Dishonest; mixes representation non-goals with real gaps |
+| Replace stack with commercial PDF SDK / PDFium / MuPDF now | Licensing, native packaging, and pure-Rust posture costs without measured necessity |
+| Word/DOCX library as PDF path | Wrong format boundary |
+
+## Consequences
+
+- New residual PRs that only re-encode PDF.js representation quirks are out of
+  scope unless they prove a contract/semantic/security break.
+- Matrix legend and admission docs describe capability/semantic status, not
+  “identical to PDF.js JSON”.
+- Exact differential suites remain as frozen regression assets.
+- A nonclaim reclassification ledger becomes part of release evidence.
+- Agent-task corpus and semantic contracts become the path to unfreeze.
+
+## Validation
+
+- `bun run check:pure-rust-matrix`
+- matrix keeps `dropInFor3014=false`, `publishFreeze=true`
+- admission contract + reclassification ledger present and checker-enforced
+- no publish-path change in this ADR candidate

--- a/docs/adr/ADR-PROPOSED-fleet-pdf-reader-mcp-rust-north-star.md
+++ b/docs/adr/ADR-PROPOSED-fleet-pdf-reader-mcp-rust-north-star.md
@@ -1,5 +1,7 @@
 # ADR-PROPOSED — Fleet PDF Reader MCP Rust North Star architecture
 
+> **Admission update (2026-07-22):** whole-product exact PDF.js/TS output parity is no longer the Rust release bar. See [ADR-0005](0005-capability-first-semantic-compatibility.md) for capability-first semantic compatibility. Frozen exact residual families remain regression assets.
+
 - **Status:** Proposed
 - **Date:** 2026-07-10
 - **Relates to:** ADR-167 (SylphxAI/doctrine), ADR-0004 (reader portfolio architecture), SylphxAI/mcp-server-sdk

--- a/docs/performance/why-rust.md
+++ b/docs/performance/why-rust.md
@@ -5,6 +5,26 @@ title: Why pure Rust + open gaps
 
 # Why pure Rust + open gaps
 
+
+## Capability-first admission (ADR-0005)
+
+As of 2026-07-22, pure-Rust admission is **capability-first semantic
+compatibility**, not whole-product exact PDF.js output parity.
+
+- Interface/schema/transport/error contracts remain exact.
+- Semantic capability equivalence and calibrated agent-task quality are the
+  release standards.
+- Frozen TS v3.0.14 differential families below remain valuable regression and
+  coverage evidence.
+- Do **not** expand exact residual families for representation-only PDF.js
+  quirks unless classified as contract break, semantic regression, or
+  security/resource fail-closed gap.
+- `dropInFor3014=false` and publish freeze remain until the ADR-0005 bar is met.
+
+See `docs/adr/0005-capability-first-semantic-compatibility.md` and
+`docs/specs/capability-first-admission-contract.md`.
+
+
 > **Status:** experimental. **Not** a full drop-in for TypeScript 3.0.14.
 > Published stable remains `@sylphx/pdf-reader-mcp@3.0.14`.
 

--- a/docs/specs/capability-first-admission-contract.md
+++ b/docs/specs/capability-first-admission-contract.md
@@ -1,0 +1,119 @@
+# Capability-first admission contract
+
+Status: active  
+Date: 2026-07-22  
+Authority: ADR-0005  
+Product truth SSOT: `docs/specs/pure-rust-capability-matrix.json`
+
+## Purpose
+
+Define how Rust is admitted as the TypeScript 3.0.14 replacement without
+requiring exact PDF.js output equality.
+
+## Layers
+
+### A. Interface compatibility (exact)
+
+Must remain stable or explicitly versioned:
+
+- tool names: `read_pdf`, `search_pdf`, `pdf_evidence` (and any published aliases)
+- input schema required/optional rules
+- output field types for claimed public surfaces
+- MCP transport/JSON-RPC envelopes
+- error classes (`isError`, source-local vs request-fatal)
+- 1-based page numbering
+- system-owned IDs/provenance non-overwrite rules
+- fail-closed capability absence
+
+Breaks here block release.
+
+### B. Semantic capability equivalence (primary)
+
+For each claimed capability family, Rust must support the same agent task class
+as the TS LKG, with correct page/location/provenance usefulness.
+
+Examples of accepted representation differences when classified:
+
+- whitespace normalization
+- ID formatting within stable system ownership
+- bbox sub-pixel / rounding deltas inside documented tolerance
+- ordering differences inside an equivalence class
+- richer provenance than TS
+
+Examples of semantic failures:
+
+- missing primary table or wrong cell relations
+- citation to wrong page
+- search misses all relevant matches for a query class
+- OCR path silently drops scanned-page evidence
+- form/annotation capability disappears or mislabels critical values
+
+### C. Quality parity (task-eval)
+
+Release requires a calibrated agent-task corpus. Thresholds are measured against
+TS baseline on the same corpus, not invented.
+
+Minimum task classes:
+
+1. extract specified passage
+2. answer table numeric questions
+3. recover headings/sections
+4. cite answers with correct page
+5. surface annotations/forms/attachments
+6. OCR scanned pages
+7. image/caption linkage
+8. malformed/huge PDF safety and bounds
+9. latency/memory resource bounds
+
+## Mismatch taxonomy
+
+| Class | Action |
+| --- | --- |
+| `contract_break` | must fix before merge/release |
+| `semantic_regression` | must fix before merge/release |
+| `equivalent_representation` | accept + document |
+| `rust_improvement` | accept + document |
+| `pdfjs_implementation_non_goal` | stop chasing |
+| `unknown` | route to task-eval |
+
+## TS 3.0.14 differential role
+
+Keep:
+
+- frozen exact families already admitted
+- interface/schema checks
+- security/resource hostile cases
+- high-value semantic oracles
+
+Stop expanding:
+
+- residual PRs whose only goal is PDF.js representation micro-parity
+
+## Nonclaim reclassification
+
+All open matrix non-claims must eventually land in
+`docs/specs/nonclaim-reclassification-ledger.json` as one of:
+
+- `blocking_capability_gap`
+- `quality_risk`
+- `compatibility_only`
+- `pdfjs_implementation_non_goal`
+- `equivalent_representation`
+- `security_or_resource_bound`
+- `unclassified` (temporary only)
+
+Unfreeze requires zero `unclassified` and zero unresolved
+`blocking_capability_gap`.
+
+## Current freeze
+
+Until the new bar is met:
+
+- `productTruth.dropInFor3014 = false`
+- `productTruth.publishFreeze = true`
+- published stable remains `@sylphx/pdf-reader-mcp@3.0.14` TypeScript path
+
+## Architecture note
+
+Canonical model ownership stays in Rust. PDF.js is a reference implementation
+for compatibility discovery, not the product’s semantic SSOT.

--- a/docs/specs/nonclaim-reclassification-ledger.json
+++ b/docs/specs/nonclaim-reclassification-ledger.json
@@ -1,0 +1,795 @@
+{
+  "schemaVersion": 1,
+  "title": "Nonclaim reclassification ledger for capability-first admission",
+  "updated": "2026-07-22",
+  "authority": "ADR-0005",
+  "matrixPath": "docs/specs/pure-rust-capability-matrix.json",
+  "matrixUpdated": "2026-07-22",
+  "status": "provisional-heuristic-seed",
+  "notes": [
+    "This ledger seeds classification for the historical explicitlyNotClaimed list.",
+    "Classes marked provisional_heuristic require review before unfreeze.",
+    "Unfreeze requires zero unclassified and zero unresolved blocking_capability_gap.",
+    "Exact residual expansion is not the default closure path for pdfjs_implementation_non_goal items."
+  ],
+  "taxonomy": {
+    "blocking_capability_gap": "Real missing/weak capability that can fail agent tasks or block sole-runtime publish.",
+    "quality_risk": "May affect answer quality; needs task-eval corpus evidence rather than exact JSON equality.",
+    "compatibility_only": "Compatibility/packaging/docs/marketing concern not itself a document-intelligence semantic contract.",
+    "pdfjs_implementation_non_goal": "PDF.js implementation quirk or residual-outside representation breadth; stop exact chasing.",
+    "equivalent_representation": "Different representation that can still support the same task when documented.",
+    "security_or_resource_bound": "Security, hostile-input, or resource-bound fail-closed requirement; keep executable.",
+    "unclassified": "Temporary; must be reclassified before unfreeze."
+  },
+  "stats": {
+    "total": 108,
+    "byClass": {
+      "pdfjs_implementation_non_goal": 15,
+      "quality_risk": 66,
+      "security_or_resource_bound": 16,
+      "equivalent_representation": 1,
+      "unclassified": 3,
+      "blocking_capability_gap": 6,
+      "compatibility_only": 1
+    },
+    "blockingForUnfreezeCount": 9
+  },
+  "entries": [
+    {
+      "nonclaim": "exact PDF.js/TS 3.0.14 whole-product output equality outside frozen regression families; residual expansion for representation-only PDF.js quirks is a non-goal under ADR-0005",
+      "class": "pdfjs_implementation_non_goal",
+      "confidence": "reviewed",
+      "rationale": "ADR-0005 explicitly retires whole-product exact PDF.js output equality as the admission bar.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "complete TS 3.0.14 semantic parity outside the immutable 14-case subset",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Legacy exact-semantic-parity umbrella; replaced by capability-first bar in ADR-0005.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "selectable-text segmentation outside the frozen 4-case LTR corpus, including RTL or vertical writing, negative-Y JavaScript rounding, arbitrary font kerning or TJ spacing, glyph-perfect geometry, OCR or provider fusion, cross-runtime hostile-input resource parity, and whole-product parity",
+      "class": "security_or_resource_bound",
+      "confidence": "provisional_heuristic",
+      "rationale": "Mentions security, hostile input, or resource/fail-closed bounds.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "UTF-16 split-surrogate wire parity is explicitly excluded and fail-closed because Rust String and Serde cannot represent lone surrogate values; the admitted astral search case consumes the complete two-unit scalar only, and full search parity is not claimed",
+      "class": "security_or_resource_bound",
+      "confidence": "provisional_heuristic",
+      "rationale": "Mentions security, hostile input, or resource/fail-closed bounds.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "the frozen lowercase-index subset captures en-US default-locale behavior only; arbitrary host locales, split-surrogate wire parity, OCR/provider paths, search geometry, query-size admission, and broader Unicode case mapping remain explicitly unclaimed",
+      "class": "pdfjs_implementation_non_goal",
+      "confidence": "provisional_heuristic",
+      "rationale": "Looks like PDF.js representation/implementation micro-behavior rather than agent task capability.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "OCR search outside the frozen 15-case command-provider word subset, including text-only provider output, first-five-of-six page behavior, selectable/OCR interleaving, URL single-fetch, page numbers beyond u32, arbitrary providers/languages, cross-runtime hostile-resource parity, and whole-product parity",
+      "class": "security_or_resource_bound",
+      "confidence": "provisional_heuristic",
+      "rationale": "Mentions security, hostile input, or resource/fail-closed bounds.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "OCR-search residual outside the frozen 4-case public-stdio subset, including selectable/OCR interleaving, URL single-fetch, tesseract-tsv search, arbitrary providers/languages, and whole-product parity",
+      "class": "security_or_resource_bound",
+      "confidence": "provisional_heuristic",
+      "rationale": "Mentions security, hostile input, or resource/fail-closed bounds.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "selectable/OCR search interleaving outside the frozen 4-case public-stdio subset, including URL single-fetch, tesseract-tsv search, arbitrary providers/languages, and whole-product parity",
+      "class": "security_or_resource_bound",
+      "confidence": "provisional_heuristic",
+      "rationale": "Mentions security, hostile input, or resource/fail-closed bounds.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "URL single-fetch outside the frozen 2-case read_pdf public-stdio subset, including search_pdf URL+OCR single-fetch (TS double-fetch), resolver timeout, TLS-SNI fixtures, public-internet fetch, and whole-product parity",
+      "class": "security_or_resource_bound",
+      "confidence": "provisional_heuristic",
+      "rationale": "Mentions security, hostile input, or resource/fail-closed bounds.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "search_pdf tesseract-tsv outside the frozen 2-case public-stdio subset, including real tesseract binary health checks, selectable/OCR interleaving, URL single-fetch, arbitrary providers/languages, and whole-product parity",
+      "class": "security_or_resource_bound",
+      "confidence": "provisional_heuristic",
+      "rationale": "Mentions security, hostile input, or resource/fail-closed bounds.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "search_pdf multiword selectable geometry outside the frozen 3-case public-stdio residual, including glyph-perfect boxes, RTL/vertical writing, OCR fusion, prefer_speed, and whole-product parity",
+      "class": "pdfjs_implementation_non_goal",
+      "confidence": "provisional_heuristic",
+      "rationale": "Looks like PDF.js representation/implementation micro-behavior rather than agent task capability.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_form_fields outside the frozen 2-case form residual public-stdio subset, including radio group kids, broader button-array V coercion, malformed-field breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_form_fields radio-group outside the frozen 2-case public-stdio residual, including broader button-array V coercion, malformed-field breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_attachments outside the frozen 2-case public-stdio residual, including malformed name-tree breadth, duplicate-kids fail-closed, and whole-product parity",
+      "class": "security_or_resource_bound",
+      "confidence": "provisional_heuristic",
+      "rationale": "Mentions security, hostile input, or resource/fail-closed bounds.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf catalog mark_info outside the frozen 3-case public-stdio residual, including permissions encryption, outline beyond behavior, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_form_fields parent/child outside the frozen 2-case public-stdio residual, including malformed-field breadth, broader button-array V coercion, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations outside the frozen public-stdio residual families, including URI action beyond url, glyph-perfect boxes, and whole-product parity",
+      "class": "pdfjs_implementation_non_goal",
+      "confidence": "provisional_heuristic",
+      "rationale": "Looks like PDF.js representation/implementation micro-behavior rather than agent task capability.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations dest residual outside the frozen 2-case public-stdio residual, including named dest resolution to array, glyph-perfect boxes, and whole-product parity",
+      "class": "pdfjs_implementation_non_goal",
+      "confidence": "provisional_heuristic",
+      "rationale": "Looks like PDF.js representation/implementation micro-behavior rather than agent task capability.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations action/named dest residual outside the frozen 2-case public-stdio residual, including named dest resolution to array, URI action beyond url, glyph-perfect boxes, and whole-product parity",
+      "class": "pdfjs_implementation_non_goal",
+      "confidence": "provisional_heuristic",
+      "rationale": "Looks like PDF.js representation/implementation micro-behavior rather than agent task capability.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations action-precedence residual outside the frozen 3-case public-stdio residual, including named dest resolution to array, glyph-perfect boxes, and whole-product parity",
+      "class": "pdfjs_implementation_non_goal",
+      "confidence": "provisional_heuristic",
+      "rationale": "Looks like PDF.js representation/implementation micro-behavior rather than agent task capability.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_ocr_text_layer outside the frozen 6-case command-provider public-stdio subset, including tesseract-tsv, text-only provider fallback, selectable/OCR table continuation, URL single-fetch, first-five-of-six page boundary, and whole-product parity",
+      "class": "security_or_resource_bound",
+      "confidence": "provisional_heuristic",
+      "rationale": "Mentions security, hostile input, or resource/fail-closed bounds.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf OCR residual outside the frozen 3-case public-stdio subset, including tesseract-tsv, selectable/OCR table continuation, URL single-fetch, mixed selectable/OCR interleaving, and whole-product parity",
+      "class": "security_or_resource_bound",
+      "confidence": "provisional_heuristic",
+      "rationale": "Mentions security, hostile input, or resource/fail-closed bounds.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "tesseract-tsv outside the frozen 2-case public-stdio command-provider subset, including real tesseract binary health checks, selectable/OCR table continuation, URL single-fetch, and whole-product parity",
+      "class": "security_or_resource_bound",
+      "confidence": "provisional_heuristic",
+      "rationale": "Mentions security, hostile input, or resource/fail-closed bounds.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "selectable/OCR table merge outside the frozen 3-case public-stdio subset, including tesseract-tsv-derived tables, URL single-fetch, mixed selectable/OCR search interleaving, and whole-product parity",
+      "class": "security_or_resource_bound",
+      "confidence": "provisional_heuristic",
+      "rationale": "Mentions security, hostile input, or resource/fail-closed bounds.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf text-layer/element/chunk geometry outside the frozen selectable-text subset, glyph-perfect pdf.js boxes, text-layer font/direction/transform/EOL metadata, citation-chunk semantics outside the frozen 6-case schema/boundary/dependency subset, semantic-hint classification outside the frozen 3-case classifier/chunk-propagation subset including unrepresented layout variants, raw page_contents payload/presence parity, document-AST semantics outside the frozen text-only, selectable-table, and exact selectable-table-caption-linkage subsets including image captions, visual enrichment payloads, OCR fusion, and broader semantic/layout variants, document-map semantics outside the frozen text-first/trust/table/visual-candidate linkage subsets including OCR, accessibility, arbitrary images, visual enrichment payloads, provider fusion, and arbitrary hostile internal chunk spans, trust-report semantics outside the frozen redaction/link/table-quality linkage subsets including overlapping/hidden/tiny/off-page variants, annotation normalization beyond Link URIs, arbitrary action dictionaries, visual/OCR/provider fusion, malware scanning, phishing classification, remote-link safety, and general evidence geometry, selectable-table detection outside the exact 6-case corpus including OCR/visual/ML/general-table variants, visual-candidate selection outside the exact 11-case provider-independent corpus, search geometry outside the frozen selectable-text subset, direct-annotation PDF.js presentation normalization, non-Link annotation/action parity, and general bounding-box parity",
+      "class": "security_or_resource_bound",
+      "confidence": "provisional_heuristic",
+      "rationale": "Mentions security, hostile input, or resource/fail-closed bounds.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "within the frozen document-map subset, exact cross-runtime provenance label values are not claimed because Rust truthfully reports pdf-reader-core/selectable-text instead of pdfjs/text-content; PDF.js-only empty text runs and run/font/direction/transform/EOL-dependent text-layer counts are schema-validated but excluded from semantic value comparison",
+      "class": "equivalent_representation",
+      "confidence": "provisional_heuristic",
+      "rationale": "Truthful engine provenance labels may differ while task evidence remains usable.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "render/crop/OCR/analyze/read-fusion/table-projection semantic parity outside the immutable 16-case subset, including exact pdf.js pixels and antialiasing",
+      "class": "unclassified",
+      "confidence": "provisional_heuristic",
+      "rationale": "No confident heuristic; requires human/task-eval classification.",
+      "blockingForUnfreeze": true
+    },
+    {
+      "nonclaim": "OCR success paths outside the opt-in command JSON/plain-text subset, including tesseract-tsv; mixed selectable/OCR table continuation; analyze_regions HTTP and preset providers",
+      "class": "unclassified",
+      "confidence": "provisional_heuristic",
+      "rationale": "No confident heuristic; requires human/task-eval classification.",
+      "blockingForUnfreeze": true
+    },
+    {
+      "nonclaim": "full COS outline/PageLabels/permissions parity outside the frozen common catalog subset; AcroForm radio/pushbutton/signature, button-array V coercion, and malformed-field breadth, integer-like/duplicate attachment-key ordering, odd-length Names arrays (PDF.js may materialize a final unnamed entry), filtered embedded-stream decoded sizes, and Associated Files",
+      "class": "pdfjs_implementation_non_goal",
+      "confidence": "provisional_heuristic",
+      "rationale": "Residual-outside breadth without a concrete agent capability keyword.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "structure-tree, accessibility, and inspect parity outside the immutable 11-case subset, including broader malformed/deep-number-tree corpus coverage, image-paint inspection, provider recommendations, and non-reference top-level StructElem forms",
+      "class": "unclassified",
+      "confidence": "provisional_heuristic",
+      "rationale": "No confident heuristic; requires human/task-eval classification.",
+      "blockingForUnfreeze": true
+    },
+    {
+      "nonclaim": "cross-platform npm native binary",
+      "class": "blocking_capability_gap",
+      "confidence": "provisional_heuristic",
+      "rationale": "Packaging/install/distribution gap that blocks Rust sole-runtime publish.",
+      "blockingForUnfreeze": true
+    },
+    {
+      "nonclaim": "npm library exports for pure-Rust",
+      "class": "blocking_capability_gap",
+      "confidence": "provisional_heuristic",
+      "rationale": "Packaging/install/distribution gap that blocks Rust sole-runtime publish.",
+      "blockingForUnfreeze": true
+    },
+    {
+      "nonclaim": "2.0x/3.3x industry benchmark headline",
+      "class": "compatibility_only",
+      "confidence": "provisional_heuristic",
+      "rationale": "Marketing/benchmark headline, not a user-task capability contract.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_metadata info residual outside the frozen 2-case public-stdio residual, including and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_page_geometry residual outside the frozen 3-case public-stdio residual, including Bleed/Trim/Art boxes, non-right-angle rotation, inherited MediaBox breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_page_geometry inheritance residual outside the frozen 3-case public-stdio residual, including Bleed/Trim/Art boxes, non-right-angle rotation beyond clamp, deeper Pages inheritance breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_page_geometry depth-clamp residual outside the frozen 3-case public-stdio residual, including Bleed/Trim/Art boxes, UserUnit Pages inheritance, multi-page geometry breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_page_geometry userunit-multipage residual outside the frozen 3-case public-stdio residual, including Bleed/Trim/Art as alternate view source, page-level UserUnit override breadth beyond the frozen fixtures, large multi-page breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_page_labels residual outside the frozen 3-case public-stdio residual, including number-tree Kids breadth, hostile label overflow, and whole-product parity",
+      "class": "security_or_resource_bound",
+      "confidence": "provisional_heuristic",
+      "rationale": "Mentions security, hostile input, or resource/fail-closed bounds.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_outline residual outside the frozen 3-case public-stdio residual, including outline cycle suppression beyond behavior, named dest string lookup, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_permissions residual outside the frozen 4-case public-stdio residual, including non-empty user password, owner-only unlock, unknown permission bits, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_metadata presence residual outside the frozen 2-case public-stdio residual, including XMP key/value parsing, rich getAll payloads, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_metadata info-extras residual outside the frozen 2-case public-stdio residual, including XMP key/value parsing, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_metadata info trapped-custom residual outside the frozen 3-case public-stdio residual, including XMP key/value parsing, keywords array coercion, info beyond Trapped/Custom breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_metadata encrypt-filter residual outside the frozen 2-case public-stdio residual, including non-Standard security handlers, non-empty user password, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_metadata linearized residual outside the frozen 3-case public-stdio residual, including four-entry hint arrays, pageFirst optional variants, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_metadata form-flags residual outside the frozen 4-case public-stdio residual, including nested Kids signature-only breadth, empty XFA stream edge cases, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations text-annotation residual outside the frozen 2-case public-stdio residual, including Text with appearance stream, Name field, glyph-perfect boxes, and whole-product parity",
+      "class": "pdfjs_implementation_non_goal",
+      "confidence": "provisional_heuristic",
+      "rationale": "Looks like PDF.js representation/implementation micro-behavior rather than agent task capability.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations remote-action residual outside the frozen 3-case public-stdio residual, including GoToE attachments, newWindow field, named remote dest string variants, and whole-product parity",
+      "class": "blocking_capability_gap",
+      "confidence": "provisional_heuristic",
+      "rationale": "Outside frozen subset and names a real capability family still open.",
+      "blockingForUnfreeze": true
+    },
+    {
+      "nonclaim": "read_pdf include_annotations popup-annotation residual outside the frozen 2-case public-stdio residual, including Popup Group/IRT chain, zero-size rect nulling, richText RC, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations popup-zero-size residual outside the frozen 2-case public-stdio residual, including Popup Group/IRT chain, richText RC, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations popup-group-irt residual outside the frozen 2-case public-stdio residual, including richText RC, group color/flags, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations text-appearance residual outside the frozen 2-case public-stdio residual, including Name field, glyph-perfect boxes, named appearance-state selection, and whole-product parity",
+      "class": "pdfjs_implementation_non_goal",
+      "confidence": "provisional_heuristic",
+      "rationale": "Looks like PDF.js representation/implementation micro-behavior rather than agent task capability.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations text-named-appearance residual outside the frozen 2-case public-stdio residual, including Name field, glyph-perfect boxes, invalid-AS fallback variants, and whole-product parity",
+      "class": "pdfjs_implementation_non_goal",
+      "confidence": "provisional_heuristic",
+      "rationale": "Looks like PDF.js representation/implementation micro-behavior rather than agent task capability.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations text-inverted-rect residual outside the frozen 2-case public-stdio residual, including Name field, glyph-perfect boxes, appearance-stream geometry, and whole-product parity",
+      "class": "pdfjs_implementation_non_goal",
+      "confidence": "provisional_heuristic",
+      "rationale": "Looks like PDF.js representation/implementation micro-behavior rather than agent task capability.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations remote-named-dest residual outside the frozen 3-case public-stdio residual, including GoToE attachments, newWindow field, and whole-product parity",
+      "class": "blocking_capability_gap",
+      "confidence": "provisional_heuristic",
+      "rationale": "Outside frozen subset and names a real capability family still open.",
+      "blockingForUnfreeze": true
+    },
+    {
+      "nonclaim": "read_pdf include_page_labels kids residual outside the frozen 3-case public-stdio residual, including hostile label overflow and whole-product parity",
+      "class": "security_or_resource_bound",
+      "confidence": "provisional_heuristic",
+      "rationale": "Mentions security, hostile input, or resource/fail-closed bounds.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_form_fields form button-array residual outside the frozen 2-case public-stdio residual, including malformed-field breadth, nested Kids beyond parent/child residual, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_attachments attachment odd-names residual outside the frozen 2-case public-stdio residual, including broader malformed name-tree breadth, duplicate-kids fail-closed, and whole-product parity",
+      "class": "security_or_resource_bound",
+      "confidence": "provisional_heuristic",
+      "rationale": "Mentions security, hostile input, or resource/fail-closed bounds.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_attachments attachment dupkids residual outside the frozen 3-case public-stdio residual, including broader malformed name-tree breadth, invalid UF fallback breadth, and whole-product parity",
+      "class": "blocking_capability_gap",
+      "confidence": "provisional_heuristic",
+      "rationale": "Outside frozen subset and names a real capability family still open.",
+      "blockingForUnfreeze": true
+    },
+    {
+      "nonclaim": "read_pdf include_form_fields form utf16-text residual outside the frozen 2-case public-stdio residual, including split-surrogate wire parity, metadata/annotation UTF-16 breadth, and whole-product parity",
+      "class": "pdfjs_implementation_non_goal",
+      "confidence": "provisional_heuristic",
+      "rationale": "Looks like PDF.js representation/implementation micro-behavior rather than agent task capability.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_form_fields form text-multiline residual outside the frozen 3-case public-stdio residual, including password/fileSelect flags, richText/DA, annotation/metadata multiline breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations contents-multiline residual outside the frozen 3-case public-stdio residual, including richText RC fallback, default appearance DA, appearance-stream content bbox, form-field multiline breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_outline cycle residual outside the frozen 3-case public-stdio residual, including named dest string lookup, remote GoToR, outline beyond cycle breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_outline named-dest residual outside the frozen 3-case public-stdio residual, including named dest resolution to array, remote GoToR, outline beyond named-dest breadth, and whole-product parity",
+      "class": "blocking_capability_gap",
+      "confidence": "provisional_heuristic",
+      "rationale": "Outside frozen subset and names a real capability family still open.",
+      "blockingForUnfreeze": true
+    },
+    {
+      "nonclaim": "read_pdf include_outline GoToR residual outside the frozen 3-case public-stdio residual, including relative GoToR file urls, named dest array resolution, outline beyond GoToR breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_outline Launch residual outside the frozen 3-case public-stdio residual, including relative Launch file urls, newWindow field, outline beyond Launch breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_outline relative-remote residual outside the frozen 3-case public-stdio residual, including absolute remote breadth, newWindow field, named dest array resolution, outline beyond relative-remote breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "utf16-text residual outside the frozen 3-case public-stdio residual, including split-surrogate wire parity, XMP key/value, and whole-product parity",
+      "class": "pdfjs_implementation_non_goal",
+      "confidence": "provisional_heuristic",
+      "rationale": "Looks like PDF.js representation/implementation micro-behavior rather than agent task capability.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations text invalid-as residual outside the frozen 2-case public-stdio residual, including Name field, glyph-perfect boxes, and whole-product parity",
+      "class": "pdfjs_implementation_non_goal",
+      "confidence": "provisional_heuristic",
+      "rationale": "Looks like PDF.js representation/implementation micro-behavior rather than agent task capability.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations line annotation residual outside the frozen 3-case public-stdio residual, including line endings LE, appearance-stream geometry, PolyLine/Polygon, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations polyline/polygon residual outside the frozen 3-case public-stdio residual, including line endings LE, appearance-stream geometry, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations ink annotation residual outside the frozen 3-case public-stdio residual, including appearance-stream geometry, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations border-width clamp residual outside the frozen 3-case public-stdio residual, including zero-size Rect clamp-bypass breadth, appearance-stream geometry, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations border-array width residual outside the frozen 3-case public-stdio residual, including Border array length < 3, BS preference over Border, zero-size Rect clamp-bypass breadth, appearance-stream geometry, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations border BS preference residual outside the frozen 3-case public-stdio residual, including Border array length < 3, zero-size Rect clamp-bypass breadth, appearance-stream geometry, non-dict BS fallthrough breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations border BS nondict residual outside the frozen 3-case public-stdio residual, including wrong-Type BS breadth, Border array length < 3, zero-size Rect clamp-bypass breadth, appearance-stream geometry, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations border array short residual outside the frozen 3-case public-stdio residual, including BS-present short Border combinations, zero-size Rect clamp-bypass breadth, appearance-stream geometry, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations border BS wrong-type residual outside the frozen 3-case public-stdio residual, including missing-Type BS (uses W), zero-size Rect clamp-bypass breadth, appearance-stream geometry, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations border zero-size clamp-bypass residual outside the frozen 3-case public-stdio residual, including positive-dimension clamp cases, appearance-stream geometry, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations appearance bbox residual outside the frozen 3-case public-stdio residual, including appearance-stream content bbox derivation, line endings LE, named appearance states, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations AP non-stream residual outside the frozen 3-case public-stdio residual, including named appearance-state selection, appearance-stream content bbox derivation, line endings LE, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations AP named-state residual outside the frozen 3-case public-stdio residual, including appearance-stream content bbox derivation, line endings LE, PolyLine/Ink named-state breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations AP named-state polyline/ink residual outside the frozen 3-case public-stdio residual, including appearance-stream content bbox derivation, line endings LE, Square/Circle named-state breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations AP named-state square/circle residual outside the frozen 3-case public-stdio residual, including appearance-stream content bbox derivation, line endings LE, Widget named-state breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations highlight quadpoints residual outside the frozen 3-case public-stdio residual, including Underline/Squiggly/StrikeOut quadpoints breadth, appearance-stream content bbox derivation, line endings LE, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations text-markup quadpoints residual outside the frozen 3-case public-stdio residual, including text-markup with appearance breadth, appearance-stream content bbox derivation, line endings LE, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations text-markup with-appearance residual outside the frozen 3-case public-stdio residual, including appearance-stream content bbox derivation, line endings LE, Widget named-state breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations stamp/caret/fileattachment residual outside the frozen 3-case public-stdio residual, including appearance-stream content bbox derivation, FileAttachment payload surface, stamp icon-name breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations square/circle/widget residual outside the frozen 3-case public-stdio residual, including appearance-stream content bbox derivation, widget form-field parity, FreeText inverted breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations link-uri-normalize residual outside the frozen 3-case public-stdio residual, including relative URL docBaseUrl breadth, javascript: URI, Launch file breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations freetext-rect residual outside the frozen 3-case public-stdio residual, including appearance-stream content bbox derivation, richText RC, default appearance DA, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations link-uri-name residual outside the frozen 3-case public-stdio residual, including relative URL docBaseUrl breadth, Launch file breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations link-aa-action residual outside the frozen 3-case public-stdio residual, including AA other triggers, relative URL docBaseUrl breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_annotations link-aa-precedence residual outside the frozen 3-case public-stdio residual, including AA other triggers breadth, relative URL docBaseUrl breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_form_fields form button-default-off residual outside the frozen 3-case public-stdio residual, including pushbutton AP default-off breadth, malformed-field breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_form_fields form pushbutton-default-null residual outside the frozen 3-case public-stdio residual, including pushbutton action/export breadth, malformed-field breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_form_fields form checkbox-as-value residual outside the frozen 3-case public-stdio residual, including radio AS override breadth, export-value normalization breadth, malformed-field breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_form_fields form checkbox-export-normalize residual outside the frozen 3-case public-stdio residual, including radio export-normalize breadth, multi-export option breadth, malformed-field breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_form_fields form radio-as-no-override residual outside the frozen 3-case public-stdio residual, including radio parent/kids AS breadth, radio exportValues materialization, malformed-field breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_form_fields form checkbox-multi-export residual outside the frozen 3-case public-stdio residual, including more-than-three export options breadth, radio multi-export breadth, malformed-field breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_form_fields form checkbox-multi-export-many residual outside the frozen 3-case public-stdio residual, including empty/single export-option breadth, radio multi-export breadth, malformed-field breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_form_fields form checkbox-export-empty-single residual outside the frozen 3-case public-stdio residual, including radio empty/single export breadth, malformed AP breadth, malformed-field breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_form_fields form checkbox-malformed-ap residual outside the frozen 3-case public-stdio residual, including radio malformed AP breadth, malformed-field breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_form_fields form radio-malformed-ap residual outside the frozen 3-case public-stdio residual, including radio parent/kids malformed AP breadth, malformed-field breadth, and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_form_fields form radio-parent-kids-ap residual outside the frozen 3-case public-stdio residual, including malformed-field breadth and whole-product parity beyond the admitted deeper-kids residual",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_form_fields form radio-deeper-kids-ap residual outside the frozen 3-case public-stdio residual, including malformed-field breadth and whole-product parity beyond the admitted broken-parent-chain residual",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    },
+    {
+      "nonclaim": "read_pdf include_form_fields form radio-broken-parent-chain residual outside the frozen 3-case public-stdio residual, including malformed-field breadth and whole-product parity",
+      "class": "quality_risk",
+      "confidence": "provisional_heuristic",
+      "rationale": "Broad whole-product/residual-outside claim; needs task-eval rather than exact residual expansion.",
+      "blockingForUnfreeze": false
+    }
+  ]
+}

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -1,18 +1,21 @@
 {
   "schemaVersion": 1,
-  "title": "Pure-Rust experimental capability matrix (honest SSOT)",
-  "updated": "2026-07-21",
+  "title": "Pure-Rust capability matrix (capability-first semantic admission SSOT)",
+  "updated": "2026-07-22",
   "productTruth": {
     "publishedStable": "@sylphx/pdf-reader-mcp@3.0.14",
     "publishedImplementation": "TypeScript dist/index.js",
     "pureRustStatus": "experimental-opt-in",
     "optIn": "PDF_READER_ENGINE_MODE=pure-rust",
     "dropInFor3014": false,
-    "publishFreeze": true
+    "publishFreeze": true,
+    "admissionBar": "capability-first-semantic-compatibility",
+    "exactPdfJsOutputParityRequired": false,
+    "ts3014Role": "regression-baseline-coverage-discovery-compatibility-reference"
   },
   "legend": {
-    "FULL": "Production-usable semantic parity with TS 3.0.14 intent for this slice",
-    "PARTIAL": "Present with reduced depth / heuristic",
+    "FULL": "Production-usable capability for agent tasks in this slice under the capability-first semantic contract (not exact PDF.js JSON equality)",
+    "PARTIAL": "Capability present with reduced depth, breadth, or proven subset only",
     "STUB": "Key exists but empty/placeholder",
     "FAIL_CLOSED": "Explicit error (not silent success)",
     "MISSING": "Not implemented"
@@ -71,6 +74,7 @@
     }
   },
   "claimedForDifferential": [
+    "capability-first semantic admission program accepted (ADR-0005): exact PDF.js output parity is no longer the whole-product bar; interface compatibility remains exact; semantic capability equivalence and calibrated agent-task quality are the release standards; TS 3.0.14 exact differentials remain frozen regression/coverage assets; dropInFor3014=false and publishFreeze=true until the new bar is met",
     "exact 14-case immutable TS v3.0.14 behavior subset: full text, page selection/order/duplicates, metadata, literal search, case sensitivity, whole word, Unicode, UTF-16 offsets, uniformly estimated selectable-text match bounding boxes and levels, missing and malformed inputs, mixed-source partial success, inherited crop/media/rotation geometry with page UserUnit, an indirect Link/URI annotation, common catalog signals, a bounded AcroForm text/parent-widget/checkbox/listbox subset, and EmbeddedFiles metadata with distinct ASCII tree keys, path-normalized filenames, descriptions, fixture ordering, and unfiltered content sizes",
     "exact 16-case immutable TS v3.0.14 render/crop/command-provider semantic subset over stdio: defaults, page selection and warnings, region ordering, padding and fractional bounds, rotated pages, mixed-source and late-provider partial success, all-source failure, MCP image indexing, standalone OCR normalization, read_pdf OCR text-layer/map fusion, boxed OCR table projection into elements/chunks/markdown/html/document_ast/document_map, rich region-analysis normalization, plain-text truncation, and truthful provenance; exact pdf.js pixels and antialiasing are not claimed",
     "exact 11-case immutable TS v3.0.14 tagged-structure and inspect subset: RoleMap, ParentTree, StructParents, inherited page association, scalar-reference, scalar-direct, combined-scalar, and array StructTreeRoot/StructElem /K plus ParentTree values, MCID/MCR and OBJR identifiers, sorted/deduplicated selected pages, empty Root pages, untagged omission, accessibility-private consumption, document-map accessibility routing, auto-full explicit-false override, and tagged-fixture inspect profile/page/document/recommendation signals; fixture, runner, projection, normalizer, generator, TS source, and pdf.js 6.0.227 digests are bound with mutation-sensitivity checks",
@@ -188,6 +192,7 @@
     "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_form_fields form radio-broken-parent-chain residual: pdf.js radio broken parent-chain intermediate omits widgets without inheritable FT and names the intermediate via Parent-chain only (Opt, not Plan.Opt); root Plan stub remains; AP stream / AP/N stream / named AP/N variants all drop leaves when intermediate has no Parent to the radio root; Rust form extraction uses Parent-chain name construction and Parent-chain FT/V/Ff/DV inheritance; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation, relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; malformed-field breadth and whole-product parity remain unclaimed; include_form_fields remains PARTIAL"
   ],
   "explicitlyNotClaimed": [
+    "exact PDF.js/TS 3.0.14 whole-product output equality outside frozen regression families; residual expansion for representation-only PDF.js quirks is a non-goal under ADR-0005",
     "complete TS 3.0.14 semantic parity outside the immutable 14-case subset",
     "selectable-text segmentation outside the frozen 4-case LTR corpus, including RTL or vertical writing, negative-Y JavaScript rounding, arbitrary font kerning or TJ spacing, glyph-perfect geometry, OCR or provider fusion, cross-runtime hostile-input resource parity, and whole-product parity",
     "UTF-16 split-surrogate wire parity is explicitly excluded and fail-closed because Rust String and Serde cannot represent lone surrogate values; the admitted astral search case consumes the complete two-unit scalar only, and full search parity is not claimed",
@@ -295,5 +300,31 @@
     "read_pdf include_form_fields form radio-parent-kids-ap residual outside the frozen 3-case public-stdio residual, including malformed-field breadth and whole-product parity beyond the admitted deeper-kids residual",
     "read_pdf include_form_fields form radio-deeper-kids-ap residual outside the frozen 3-case public-stdio residual, including malformed-field breadth and whole-product parity beyond the admitted broken-parent-chain residual",
     "read_pdf include_form_fields form radio-broken-parent-chain residual outside the frozen 3-case public-stdio residual, including malformed-field breadth and whole-product parity"
-  ]
+  ],
+  "admissionProgram": {
+    "mode": "capability-first-semantic-compatibility",
+    "authority": "docs/adr/0005-capability-first-semantic-compatibility.md",
+    "contract": "docs/specs/capability-first-admission-contract.md",
+    "nonclaimLedger": "docs/specs/nonclaim-reclassification-ledger.json",
+    "exactPdfJsOutputParity": false,
+    "expandExactResidualsOnlyFor": [
+      "contract_break",
+      "semantic_regression",
+      "security_or_resource_bound"
+    ],
+    "layers": {
+      "interfaceCompatibility": "exact",
+      "semanticCapabilityEquivalence": "primary-release-standard",
+      "qualityParity": "task-eval-gated"
+    },
+    "publishFreeze": true,
+    "dropInFor3014": false,
+    "nextActions": [
+      "Review provisional nonclaim ledger classifications",
+      "Author executable semantic contracts for core capabilities",
+      "Build calibrated agent-task corpus and thresholds against TS baseline",
+      "Close remaining blocking_capability_gap items with capability evidence, not PDF.js micro-parity",
+      "Keep five-platform native install/runtime proof on the critical path"
+    ]
+  }
 }

--- a/docs/specs/temporary-rust-migration-fences.md
+++ b/docs/specs/temporary-rust-migration-fences.md
@@ -1,8 +1,11 @@
 # Temporary Rust migration fences
 
 The published `3.0.14`-compatible TypeScript runtime remains authoritative after
-the `3.0.15` rollback. Rust is experimental and opt-in. The remaining
-source-shape checks in `scripts/check-no-ts-{stdio,http}-backend.sh`,
+the `3.0.15` rollback. Rust is experimental and opt-in under a
+**capability-first semantic compatibility** admission bar (ADR-0005). Exact
+PDF.js output equality is not the whole-product release standard.
+
+The remaining source-shape checks in `scripts/check-no-ts-{stdio,http}-backend.sh`,
 `scripts/check-ts-adapter-deletion-ready.sh`, their focused test matrices, and
 the corresponding release-gate assertions are temporary migration fences, not
 durable architecture tests.
@@ -10,14 +13,25 @@ durable architecture tests.
 Retire all of them in the same candidate when every condition below is true:
 
 1. `docs/specs/pure-rust-capability-matrix.json` records
-   `productTruth.dropInFor3014: true` from complete capability evidence;
-2. `bun run validate:pure-rust-claimed` passes on the exact candidate, including
-   all v3.0.14 behavior, structure, text, citation, semantic, AST, document-map,
-   visual, and TS-versus-Rust differential suites;
+   `productTruth.dropInFor3014: true` from complete **capability-first**
+   evidence (interface + semantic contracts + calibrated task-eval), not from
+   exhaustive PDF.js JSON equality;
+2. `bun run validate:pure-rust-claimed` passes on the exact candidate for the
+   claimed interface/security/semantic suites that remain in force;
 3. package smoke proves the installed default MCP entrypoint and public schemas
    are drop-in compatible; and
 4. the published artifact readback identifies that exact candidate.
 
+Until then:
+
+- `productTruth.dropInFor3014` remains `false`
+- `productTruth.publishFreeze` remains `true`
+- TS 3.0.14 exact differential families remain frozen regression assets
+- new exact residual expansion is limited to contract breaks, semantic
+  regressions, and security/resource fail-closed gaps
+- open non-claims are tracked in
+  `docs/specs/nonclaim-reclassification-ledger.json`
+
 The replacement proof is the executable package smoke, integration, contract,
-and differential suites. Do not replace these fences with new source-token
-checks after cutover.
+semantic, task-eval, and differential suites. Do not replace these fences with
+new source-token checks after cutover.

--- a/scripts/check-pure-rust-matrix.ts
+++ b/scripts/check-pure-rust-matrix.ts
@@ -2630,6 +2630,113 @@ if (matrix.productTruth.dropInFor3014 !== false) {
 if (matrix.productTruth.publishFreeze !== true) {
   failures.push('bounded Rust parity slices must keep publishFreeze=true');
 }
+
+// ADR-0005 capability-first admission invariants
+const admissionProgram = (matrix as {
+  admissionProgram?: {
+    mode?: string;
+    authority?: string;
+    contract?: string;
+    nonclaimLedger?: string;
+    exactPdfJsOutputParity?: boolean;
+    publishFreeze?: boolean;
+    dropInFor3014?: boolean;
+  };
+  productTruth: {
+    admissionBar?: string;
+    exactPdfJsOutputParityRequired?: boolean;
+    ts3014Role?: string;
+  };
+}).admissionProgram;
+if (!admissionProgram || admissionProgram.mode !== 'capability-first-semantic-compatibility') {
+  failures.push('matrix admissionProgram.mode must be capability-first-semantic-compatibility');
+}
+if (admissionProgram?.exactPdfJsOutputParity !== false) {
+  failures.push('admissionProgram.exactPdfJsOutputParity must be false under ADR-0005');
+}
+if (admissionProgram?.publishFreeze !== true || admissionProgram?.dropInFor3014 !== false) {
+  failures.push('admissionProgram must keep publishFreeze=true and dropInFor3014=false until the new bar is met');
+}
+if ((matrix.productTruth as { admissionBar?: string }).admissionBar !== 'capability-first-semantic-compatibility') {
+  failures.push('productTruth.admissionBar must record capability-first-semantic-compatibility');
+}
+if ((matrix.productTruth as { exactPdfJsOutputParityRequired?: boolean }).exactPdfJsOutputParityRequired !== false) {
+  failures.push('productTruth.exactPdfJsOutputParityRequired must be false');
+}
+for (const requiredDoc of [
+  'docs/adr/0005-capability-first-semantic-compatibility.md',
+  'docs/specs/capability-first-admission-contract.md',
+  'docs/specs/nonclaim-reclassification-ledger.json',
+]) {
+  if (!existsSync(join(root, requiredDoc))) {
+    failures.push(`capability-first admission document missing: ${requiredDoc}`);
+  }
+}
+const nonclaimLedger = JSON.parse(
+  readFileSync(join(root, 'docs/specs/nonclaim-reclassification-ledger.json'), 'utf8')
+) as {
+  authority?: string;
+  entries?: Array<{ nonclaim: string; class: string; blockingForUnfreeze?: boolean }>;
+  stats?: { total?: number };
+  taxonomy?: Record<string, string>;
+};
+if (nonclaimLedger.authority !== 'ADR-0005') {
+  failures.push('nonclaim reclassification ledger must cite ADR-0005 authority');
+}
+const allowedNonclaimClasses = new Set([
+  'blocking_capability_gap',
+  'quality_risk',
+  'compatibility_only',
+  'pdfjs_implementation_non_goal',
+  'equivalent_representation',
+  'security_or_resource_bound',
+  'unclassified',
+]);
+if (!nonclaimLedger.taxonomy || Object.keys(nonclaimLedger.taxonomy).length < 7) {
+  failures.push('nonclaim ledger must define the full ADR-0005 taxonomy');
+}
+const ledgerNonclaims = new Set((nonclaimLedger.entries ?? []).map((entry) => entry.nonclaim));
+for (const nonclaim of matrix.explicitlyNotClaimed) {
+  if (!ledgerNonclaims.has(nonclaim)) {
+    failures.push(`nonclaim ledger missing matrix nonclaim: ${nonclaim.slice(0, 120)}`);
+  }
+}
+if ((nonclaimLedger.stats?.total ?? -1) !== matrix.explicitlyNotClaimed.length) {
+  failures.push('nonclaim ledger stats.total must equal matrix.explicitlyNotClaimed length');
+}
+for (const entry of nonclaimLedger.entries ?? []) {
+  if (!allowedNonclaimClasses.has(entry.class)) {
+    failures.push(`nonclaim ledger entry has invalid class: ${entry.class}`);
+  }
+}
+if (
+  !matrix.claimedForDifferential.some((claim) =>
+    claim.includes('capability-first semantic admission program accepted (ADR-0005)')
+  )
+) {
+  failures.push('matrix must claim the ADR-0005 capability-first admission program');
+}
+if (
+  !matrix.explicitlyNotClaimed.some((claim) =>
+    claim.includes('exact PDF.js/TS 3.0.14 whole-product output equality')
+  )
+) {
+  failures.push('matrix must explicitly nonclaim whole-product exact PDF.js output equality');
+}
+const whyRustAdmission = readFileSync(join(root, 'docs/performance/why-rust.md'), 'utf8');
+if (
+  !whyRustAdmission.includes('Capability-first admission (ADR-0005)') ||
+  !whyRustAdmission.includes('exact PDF.js output parity')
+) {
+  failures.push('why-rust must document the ADR-0005 capability-first admission pivot');
+}
+const fences = readFileSync(join(root, 'docs/specs/temporary-rust-migration-fences.md'), 'utf8');
+if (
+  !fences.includes('capability-first semantic compatibility') ||
+  !fences.includes('nonclaim-reclassification-ledger.json')
+) {
+  failures.push('temporary Rust migration fences must cite capability-first admission and nonclaim ledger');
+}
 if (matrix.tools.read_pdf.include_semantic_hints !== 'PARTIAL') {
   failures.push('bounded semantic-hint claim must remain PARTIAL');
 }


### PR DESCRIPTION
## Summary
- Accept **ADR-0005**: capability-first semantic compatibility replaces whole-product exact PDF.js output parity as the Rust admission/release bar.
- Keep three layers explicit:
  1. **Interface compatibility** (exact)
  2. **Semantic capability equivalence** (primary release standard)
  3. **Quality parity** via calibrated agent-task eval
- Demote TS 3.0.14 exact differentials to frozen regression/coverage assets; expand exact residuals only for contract breaks, semantic regressions, or security/resource fail-closed gaps.
- Seed `docs/specs/nonclaim-reclassification-ledger.json` for all matrix non-claims (provisional heuristic classes).
- Update matrix, temporary fences, why-rust, README, and matrix checker invariants.
- **Does not unfreeze publish** and does **not** set `dropInFor3014=true`.

## Exact candidate
- SHA: `4d99c2df3d01355db4ce7b2ca75260e6448f0fb7`
- Reviewed base: `d8b1c658bff7ff656abdc7736d6ac4b278733470`
- Independent review: **PASS** (confidence 0.95)
  - P0/P1: none
  - Checked: freeze remains true; drop-in remains false; ledger covers every nonclaim; checker enforces ADR/contract/ledger presence; no residual-family deletion; no publish-path change.

## Test plan
- [x] `bun run check:pure-rust-matrix` PASS
- [x] productTruth freeze unchanged (`dropInFor3014=false`, `publishFreeze=true`)
- [x] ADR-0005 + admission contract + nonclaim ledger present
- [ ] CI docs/matrix checks

Agent-Author: codex