### PR TITLE
fix(release): make changesets version step reliable for Stage B

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,16 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: bun changeset version && bun run sync:server-json
+          # Use node entrypoint (bun package-bin arg parsing is brittle here).
+          # Sync native optional package manifests + server.json after version bump.
+          # Clear executable bits on tracked dist/*.js so github-api commitMode accepts them.
+          version: |
+            node node_modules/@changesets/cli/bin.js version
+            bun run native:sync-manifests
+            bun run sync:server-json
+            if [ -d dist ]; then
+              find dist -type f \( -name '*.js' -o -name '*.mjs' \) -exec chmod a-x {} +
+            fi
           title: 'chore(release): version packages'
           commit: 'chore(release): version packages'
           createGithubReleases: true

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sylphx/pdf-reader-mcp",
   "version": "3.0.14",
   "mcpName": "io.github.SylphxAI/pdf-reader-mcp",
-  "description": "Evidence-first PDF MCP. Published stable is 3.0.14 (TypeScript). Pure-Rust cutover is experimental/unpublished; 3.0.15–3.1.1 are withdrawn.",
+  "description": "Evidence-first PDF MCP. Published stable is 3.0.14 (TypeScript). Pure-Rust cutover is experimental/unpublished; 3.0.15\u20133.1.1 are withdrawn.",
   "type": "module",
   "bin": {
     "pdf-reader-mcp": "./dist/index.js"
@@ -232,7 +232,8 @@
     "native:sync-manifests": "bun scripts/native/sync-native-package-manifests.ts",
     "native:assert-ready": "bun scripts/native/assert-native-packages-ready.ts",
     "native:stage-from-artifacts": "bun scripts/native/stage-native-artifacts.ts",
-    "release:publish-with-natives": "bun scripts/release-publish-with-natives.ts"
+    "release:publish-with-natives": "bun scripts/release-publish-with-natives.ts",
+    "sync:server-json": "bun scripts/sync-server-json.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary
Post-#554 main Release failed while creating the version PR:

1. `bun changeset version` → `Too many arguments passed to changesets`
2. `commitMode: github-api` rejected executable tracked `dist/*.js` files from the build step

### Fix
- Run `node node_modules/@changesets/cli/bin.js version`
- After version: `bun run native:sync-manifests` + `bun run sync:server-json`
- `chmod a-x` on tracked `dist/*.{js,mjs}` before the github-api commit

## Test plan
- [x] Inspect failed Release log for #554 merge
- [ ] Main Release after merge creates `chore(release): version packages` PR