### PR TITLE
fix(release): run changesets version via shell wrapper script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,13 @@ jobs:
       - name: Enforce verified-candidate admission (replaces hard publish freeze)
         run: bun scripts/check-verified-candidate-admission.ts
 
+      - name: Normalize tracked dist permissions before version PR
+        run: |
+          if [ -d dist ]; then
+            find dist -type f \( -name '*.js' -o -name '*.mjs' \) -exec chmod a-x {} +
+            ls -la dist || true
+          fi
+
       - name: Create release PR
         id: changesets
         uses: changesets/action@v1
@@ -108,13 +115,7 @@ jobs:
           # Use node entrypoint (bun package-bin arg parsing is brittle here).
           # Sync native optional package manifests + server.json after version bump.
           # Clear executable bits on tracked dist/*.js so github-api commitMode accepts them.
-          version: |
-            node node_modules/@changesets/cli/bin.js version
-            bun run native:sync-manifests
-            bun run sync:server-json
-            if [ -d dist ]; then
-              find dist -type f \( -name '*.js' -o -name '*.mjs' \) -exec chmod a-x {} +
-            fi
+          version: bash scripts/release-version.sh
           title: 'chore(release): version packages'
           commit: 'chore(release): version packages'
           createGithubReleases: true

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Changesets version wrapper for Release workflow.
+# Must be a single executable command for changesets/action `version` input.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+echo "[release-version] bump package versions from changesets"
+node node_modules/@changesets/cli/bin.js version
+
+echo "[release-version] sync native optional package manifests to root version"
+bun run native:sync-manifests
+
+echo "[release-version] sync server.json + Rust SERVER_VERSION"
+bun run sync:server-json
+
+# Tracked dist/*.js are rebuilt earlier in Release and may gain +x from bun build.
+# changesets/action commitMode=github-api rejects executable files.
+if [[ -d dist ]]; then
+  echo "[release-version] clear executable bits on tracked dist artifacts"
+  find dist -type f \( -name '*.js' -o -name '*.mjs' \) -exec chmod a-x {} +
+fi
+
+echo "[release-version] PASS"


### PR DESCRIPTION
## Summary
Main Release after #555 still failed:

- multiline `version: |` is not run as a shell script by `changesets/action`
- first line effectively became a broken changesets invocation
- tracked `dist/*.js` stayed executable and github-api commitMode rejected them

### Fix
- `scripts/release-version.sh` single command: changeset version → native sync → server.json sync → chmod dist
- pre-step to clear dist executable bits before version PR

## Test plan
- [x] `bash -n scripts/release-version.sh`
- [x] `bun test test/releaseGate.test.ts`
- [ ] Merge → main Release opens `chore(release): version packages`