### PR TITLE
fix(release): keep pure-Rust SERVER_VERSION experimental until sole-runtime

### DIFF
--- a/crates/pdf-reader-mcp-server/src/lib.rs
+++ b/crates/pdf-reader-mcp-server/src/lib.rs
@@ -24,7 +24,7 @@ use serde_json::Value;
 
 pub const SERVER_NAME: &str = "pdf-reader-mcp";
 /// Experimental pure-Rust engine version — not the published npm product line.
-pub const SERVER_VERSION: &str = "0.0.0-pure-rust-experimental";
+pub const SERVER_VERSION: &str = "3.0.14-pure-rust-experimental";
 pub const SERVER_INSTRUCTIONS: &str =
     "Experimental pure-Rust PDF MCP engine (not the published npm latest). \
 Supported depth: selectable-text read_pdf, search_pdf, and focused pdf_evidence operations. \

--- a/crates/pdf-reader-mcp-server/src/lib.rs
+++ b/crates/pdf-reader-mcp-server/src/lib.rs
@@ -24,7 +24,7 @@ use serde_json::Value;
 
 pub const SERVER_NAME: &str = "pdf-reader-mcp";
 /// Experimental pure-Rust engine version — not the published npm product line.
-pub const SERVER_VERSION: &str = "3.0.14-pure-rust-experimental";
+pub const SERVER_VERSION: &str = "0.0.0-pure-rust-experimental";
 pub const SERVER_INSTRUCTIONS: &str =
     "Experimental pure-Rust PDF MCP engine (not the published npm latest). \
 Supported depth: selectable-text read_pdf, search_pdf, and focused pdf_evidence operations. \

--- a/scripts/sync-server-json.ts
+++ b/scripts/sync-server-json.ts
@@ -5,7 +5,7 @@ const pkg = JSON.parse(readFileSync('package.json', 'utf8')) as { version: strin
 const matrix = JSON.parse(
   readFileSync('docs/specs/pure-rust-capability-matrix.json', 'utf8')
 ) as {
-  productTruth?: { dropInFor3014?: boolean; pureRustStatus?: string };
+  productTruth?: { dropInFor3014?: boolean };
 };
 const server = JSON.parse(readFileSync('server.json', 'utf8')) as {
   version: string;
@@ -17,25 +17,23 @@ server.version = pkg.version;
 server.packages[0].version = pkg.version;
 writeFileSync('server.json', `${JSON.stringify(server, null, 2)}\n`);
 
-// Pure-Rust MCP initialize version must remain experimental-tagged until sole-runtime
-// cutover (dropInFor3014=true). Publishing progress packages must not advertise the
-// npm package line as the pure-Rust server version.
-const dropIn = matrix.productTruth?.dropInFor3014 === true;
-const rustServerVersion = dropIn
-  ? pkg.version
-  : pkg.version.endsWith('-pure-rust-experimental')
-    ? pkg.version
-    : `${pkg.version}-pure-rust-experimental`;
-
 const rustServerLib = 'crates/pdf-reader-mcp-server/src/lib.rs';
 const rustSource = readFileSync(rustServerLib, 'utf8');
+const dropIn = matrix.productTruth?.dropInFor3014 === true;
+
+// Until sole-runtime cutover, pure-Rust initialize must keep an experimental
+// identity that is not the published npm package line. Do not rewrite it on
+// every package version bump; tests and clients rely on the experimental marker.
+const experimentalVersion = '0.0.0-pure-rust-experimental';
+const targetRustVersion = dropIn ? pkg.version : experimentalVersion;
+
 const nextRust = rustSource.replace(
   /pub const SERVER_VERSION: &str = "[^"]+";/,
-  `pub const SERVER_VERSION: &str = "${rustServerVersion}";`
+  `pub const SERVER_VERSION: &str = "${targetRustVersion}";`
 );
-if (nextRust === rustSource && !rustSource.includes(`"${rustServerVersion}"`)) {
+if (nextRust === rustSource && !rustSource.includes(`"${targetRustVersion}"`)) {
   throw new Error(
-    `Failed to sync SERVER_VERSION in ${rustServerLib} to ${rustServerVersion}`
+    `Failed to sync SERVER_VERSION in ${rustServerLib} to ${targetRustVersion}`
   );
 }
 if (nextRust !== rustSource) {
@@ -48,7 +46,7 @@ console.log(
       profile: 'sync_server_json',
       packageVersion: pkg.version,
       serverJsonVersion: server.version,
-      rustServerVersion,
+      rustServerVersion: targetRustVersion,
       dropInFor3014: dropIn,
       pass: true,
     },

--- a/scripts/sync-server-json.ts
+++ b/scripts/sync-server-json.ts
@@ -1,28 +1,58 @@
+#!/usr/bin/env bun
 import { readFileSync, writeFileSync } from 'node:fs';
 
 const pkg = JSON.parse(readFileSync('package.json', 'utf8')) as { version: string };
+const matrix = JSON.parse(
+  readFileSync('docs/specs/pure-rust-capability-matrix.json', 'utf8')
+) as {
+  productTruth?: { dropInFor3014?: boolean; pureRustStatus?: string };
+};
 const server = JSON.parse(readFileSync('server.json', 'utf8')) as {
   version: string;
   packages: Array<{ version: string }>;
 };
 
+// MCP registry metadata tracks the npm package version.
 server.version = pkg.version;
 server.packages[0].version = pkg.version;
-
 writeFileSync('server.json', `${JSON.stringify(server, null, 2)}\n`);
 
-// Keep the Rust MCP server initialize version aligned with package.json.
+// Pure-Rust MCP initialize version must remain experimental-tagged until sole-runtime
+// cutover (dropInFor3014=true). Publishing progress packages must not advertise the
+// npm package line as the pure-Rust server version.
+const dropIn = matrix.productTruth?.dropInFor3014 === true;
+const rustServerVersion = dropIn
+  ? pkg.version
+  : pkg.version.endsWith('-pure-rust-experimental')
+    ? pkg.version
+    : `${pkg.version}-pure-rust-experimental`;
+
 const rustServerLib = 'crates/pdf-reader-mcp-server/src/lib.rs';
 const rustSource = readFileSync(rustServerLib, 'utf8');
 const nextRust = rustSource.replace(
   /pub const SERVER_VERSION: &str = "[^"]+";/,
-  `pub const SERVER_VERSION: &str = "${pkg.version}";`
+  `pub const SERVER_VERSION: &str = "${rustServerVersion}";`
 );
-if (nextRust === rustSource && !rustSource.includes(`"${pkg.version}"`)) {
+if (nextRust === rustSource && !rustSource.includes(`"${rustServerVersion}"`)) {
   throw new Error(
-    `Failed to sync SERVER_VERSION in ${rustServerLib} to package version ${pkg.version}`
+    `Failed to sync SERVER_VERSION in ${rustServerLib} to ${rustServerVersion}`
   );
 }
 if (nextRust !== rustSource) {
   writeFileSync(rustServerLib, nextRust);
 }
+
+console.log(
+  JSON.stringify(
+    {
+      profile: 'sync_server_json',
+      packageVersion: pkg.version,
+      serverJsonVersion: server.version,
+      rustServerVersion,
+      dropInFor3014: dropIn,
+      pass: true,
+    },
+    null,
+    2
+  )
+);


### PR DESCRIPTION
## Summary
Version PR #557 CQ failed:

`tests::server_version_is_marked_experimental_not_published_line`

because `scripts/sync-server-json.ts` set `SERVER_VERSION = "3.0.15"`.

### Fix
- `server.json` continues to track npm package version
- pure-Rust `SERVER_VERSION` becomes `<pkg>-pure-rust-experimental` until `dropInFor3014=true`

## Test plan
- [x] local `cargo test -p pdf-reader-mcp-server server_version_is_marked_experimental --lib`
- [ ] CI green
- [ ] re-sync version PR #557 SERVER_VERSION