### PR TITLE
fix(test): stop hardcoding package.json version 3.0.14

### DIFF
--- a/test/architectureContract.test.ts
+++ b/test/architectureContract.test.ts
@@ -13,7 +13,7 @@ describe('architecture contract (published TS + experimental pure-Rust)', () => 
     };
     expect(pkg.bin?.['pdf-reader-mcp']).toBe('./dist/index.js');
     expect(pkg.exports?.['.']).toBe('./dist/index.js');
-    expect(pkg.version).toBe('3.0.14');
+    expect(pkg.version).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
   });
 
   it('pure-Rust tool modules exist without parity bridge', () => {

--- a/test/production/productionPath.contract.test.ts
+++ b/test/production/productionPath.contract.test.ts
@@ -50,7 +50,7 @@ const buildReadPdfArgs = (entry: { id: string; args: Record<string, unknown> }) 
   return args as Record<string, unknown>;
 };
 
-describe('production-path public contract (published TypeScript 3.0.14 path)', () => {
+describe('production-path public contract (TypeScript default entry path)', () => {
   let proc: ChildProcess;
   let reqId = 10;
 
@@ -74,7 +74,7 @@ describe('production-path public contract (published TypeScript 3.0.14 path)', (
     expect(packageJson.bin?.['pdf-reader-mcp']).toBe('./dist/index.js');
     expect(packageJson.exports?.['.']).toBe('./dist/index.js');
     expect(packageJson.files).toContain('dist/');
-    expect(packageJson.version).toBe('3.0.14');
+    expect(packageJson.version).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
     expect(fs.existsSync(path.join(repoRoot, 'dist/index.js'))).toBe(true);
   });
 

--- a/test/tsAdapterDeletion.matrix.test.ts
+++ b/test/tsAdapterDeletion.matrix.test.ts
@@ -19,7 +19,7 @@ describe('published TypeScript production default', () => {
     };
     expect(pkg.bin?.['pdf-reader-mcp']).toBe('./dist/index.js');
     expect(pkg.exports?.['.']).toBe('./dist/index.js');
-    expect(pkg.version).toBe('3.0.14');
+    expect(pkg.version).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
   });
 
   it('parity bridge is deleted', () => {


### PR DESCRIPTION
## Summary
Version PR #557 CQ fails because several contract tests hardcode:

`expect(pkg.version).toBe('3.0.14')`

while the version PR correctly bumps to `3.0.15`.

### Fix
- Assert package.json version is semver-shaped
- Keep `productTruth.publishedStable` checks pointing at registry truth (`3.0.14`) until publish updates the matrix

## Test plan
- [x] bun test architecture/tsAdapter/productionPath contracts
- [ ] CI green
- [ ] Re-run/merge version PR #557