### PR TITLE
chore(release): bump to 3.1.2 skipping withdrawn 3.0.15-3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.1.2
+
+### Patch Changes
+
+- Stage B progress release after withdrawn 3.0.15–3.1.1 range: five-platform pure-Rust optional native packages with binary-gated publish, optionalDependencies wiring, and admission-gated multi-platform publish pipeline. TypeScript remains the default entry (`dropInFor3014=false`). Do not use withdrawn 3.0.15–3.1.1.
+
+
 ## 3.0.15
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp",
-  "version": "3.0.15",
+  "version": "3.1.2",
   "mcpName": "io.github.SylphxAI/pdf-reader-mcp",
   "description": "Evidence-first PDF MCP. Published stable is 3.0.14 (TypeScript). Pure-Rust cutover is experimental/unpublished; 3.0.15–3.1.1 are withdrawn.",
   "type": "module",
@@ -262,10 +262,10 @@
   },
   "packageManager": "bun@1.3.12",
   "optionalDependencies": {
-    "@sylphx/pdf-reader-mcp-darwin-arm64": "3.0.15",
-    "@sylphx/pdf-reader-mcp-darwin-x64": "3.0.15",
-    "@sylphx/pdf-reader-mcp-linux-arm64-gnu": "3.0.15",
-    "@sylphx/pdf-reader-mcp-linux-x64-gnu": "3.0.15",
-    "@sylphx/pdf-reader-mcp-win32-x64-msvc": "3.0.15"
+    "@sylphx/pdf-reader-mcp-darwin-arm64": "3.1.2",
+    "@sylphx/pdf-reader-mcp-darwin-x64": "3.1.2",
+    "@sylphx/pdf-reader-mcp-linux-arm64-gnu": "3.1.2",
+    "@sylphx/pdf-reader-mcp-linux-x64-gnu": "3.1.2",
+    "@sylphx/pdf-reader-mcp-win32-x64-msvc": "3.1.2"
   }
 }

--- a/packages/pdf-reader-mcp-darwin-arm64/package.json
+++ b/packages/pdf-reader-mcp-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-darwin-arm64",
-  "version": "3.0.15",
+  "version": "3.1.2",
   "description": "Optional pure-Rust MCP server binary for darwin-arm64. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/packages/pdf-reader-mcp-darwin-x64/package.json
+++ b/packages/pdf-reader-mcp-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-darwin-x64",
-  "version": "3.0.15",
+  "version": "3.1.2",
   "description": "Optional pure-Rust MCP server binary for darwin-x64. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/packages/pdf-reader-mcp-linux-arm64-gnu/package.json
+++ b/packages/pdf-reader-mcp-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-linux-arm64-gnu",
-  "version": "3.0.15",
+  "version": "3.1.2",
   "description": "Optional pure-Rust MCP server binary for linux-arm64-gnu. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/packages/pdf-reader-mcp-linux-x64-gnu/package.json
+++ b/packages/pdf-reader-mcp-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-linux-x64-gnu",
-  "version": "3.0.15",
+  "version": "3.1.2",
   "description": "Optional pure-Rust MCP server binary for linux-x64-gnu. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/packages/pdf-reader-mcp-win32-x64-msvc/package.json
+++ b/packages/pdf-reader-mcp-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-win32-x64-msvc",
-  "version": "3.0.15",
+  "version": "3.1.2",
   "description": "Optional pure-Rust MCP server binary for win32-x64-msvc. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/SylphxAI/pdf-reader-mcp",
     "source": "github"
   },
-  "version": "3.0.15",
+  "version": "3.1.2",
   "websiteUrl": "https://sylphxai.github.io/pdf-reader-mcp/",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@sylphx/pdf-reader-mcp",
-      "version": "3.0.15",
+      "version": "3.1.2",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
Five native optional packages already published at `3.0.15`, but main package publish failed because **npm already has withdrawn `@sylphx/pdf-reader-mcp@3.0.15`** (and through 3.1.1).

### Fix
- Bump main + five native packages to **3.1.2**
- Keep TypeScript default / `dropInFor3014=false`
- Keep pure-Rust `SERVER_VERSION=0.0.0-pure-rust-experimental`

### Next
After merge, re-run admission-gated `publish-npm` to publish `@sylphx/pdf-reader-mcp@3.1.2` and matching native packages.

## Test plan
- [x] version sync across package.json + natives + server.json
- [ ] CI green
- [ ] publish-npm succeeds
- [ ] `npm view @sylphx/pdf-reader-mcp version` → 3.1.2 (or latest still 3.0.14 if we don't retag — will publish as latest)