### PR TITLE
docs(release): record 3.1.2 native optional publish and harden readback

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -135,7 +135,16 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="$(jq -r .version package.json)"
-          npm view "@sylphx/pdf-reader-mcp@$VERSION" version
-          npm view "@sylphx/pdf-reader-mcp-linux-x64-gnu@$VERSION" version
-          bun run check:registry-install-proof -- --registry --version="$VERSION" || true
-          # Host-only registry proof in this job; full five-platform proof remains a dedicated matrix.
+          # npm registry can lag briefly after publish; retry views before failing the job.
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if npm view "@sylphx/pdf-reader-mcp@$VERSION" version               && npm view "@sylphx/pdf-reader-mcp-linux-x64-gnu@$VERSION" version; then
+              break
+            fi
+            if [ "$i" -eq 10 ]; then
+              echo "registry readback failed after retries for $VERSION" >&2
+              exit 1
+            fi
+            sleep 6
+          done
+          bun run check:registry-install-proof -- --registry --version="$VERSION"
+          # Host-only registry proof in this job; full five-platform pure-Rust initialize remains a dedicated matrix.

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -3,8 +3,8 @@
   "title": "Pure-Rust capability matrix (capability-first semantic admission SSOT)",
   "updated": "2026-07-23",
   "productTruth": {
-    "publishedStable": "@sylphx/pdf-reader-mcp@3.0.14",
-    "publishedImplementation": "TypeScript dist/index.js",
+    "publishedStable": "@sylphx/pdf-reader-mcp@3.1.2",
+    "publishedImplementation": "TypeScript dist/index.js (default); pure-Rust optional native packages + ./pure-rust export",
     "pureRustStatus": "experimental-opt-in",
     "optIn": "PDF_READER_ENGINE_MODE=pure-rust",
     "dropInFor3014": false,
@@ -330,8 +330,7 @@
     "publishFreeze": false,
     "dropInFor3014": false,
     "nextActions": [
-      "Publish versioned main + five native optional packages via publish-npm / release:publish-with-natives",
-      "Run registry install/readback on all five platforms (check:registry-install-proof --registry)",
+      "Run five-platform registry install + pure-Rust MCP initialize readback for 3.1.2",
       "Only then set dropInFor3014=true / sole-runtime default and retire TypeScript entry"
     ],
     "semanticContracts": "docs/specs/semantic-contracts/",
@@ -353,29 +352,33 @@
       ]
     },
     "nativePackageProof": {
-      "status": "publishable-optional-packages-and-multiplatform-publish-pipeline",
-      "registryInstall": false,
+      "status": "registry-published-optional-packages-host-install-proven",
+      "registryInstall": "host-proven-five-platform-runtime-pending",
       "packagesPublishable": true,
       "optionalDependenciesWired": true,
+      "publishedVersion": "3.1.2",
+      "publishedNatives": [
+        "@sylphx/pdf-reader-mcp-darwin-arm64@3.1.2",
+        "@sylphx/pdf-reader-mcp-darwin-x64@3.1.2",
+        "@sylphx/pdf-reader-mcp-linux-arm64-gnu@3.1.2",
+        "@sylphx/pdf-reader-mcp-linux-x64-gnu@3.1.2",
+        "@sylphx/pdf-reader-mcp-win32-x64-msvc@3.1.2"
+      ],
       "publishFreeze": false,
       "commands": [
-        "bun run native:sync-manifests",
-        "bun run native:assert-ready -- --manifests-only --all",
+        "bun run check:registry-install-proof -- --registry --version=3.1.2",
         "bun run smoke:native-launcher",
-        "bun run smoke:native-package-resolve",
-        "bun run check:registry-install-proof",
-        "bun run release:publish-with-natives -- --dry-run"
+        "bun run smoke:native-package-resolve"
       ],
       "workflow": ".github/workflows/native-package-scaffold.yml",
       "publishWorkflow": ".github/workflows/publish-npm.yml",
       "notes": [
-        "Native packages are no longer private scaffolds; prepublishOnly refuses empty binaries.",
-        "Main package declares optionalDependencies for all five platform packages.",
-        "Registry install/readback on all five platforms remains required before dropInFor3014=true."
+        "Main package and five native optional packages are published at 3.1.2.",
+        "Host registry install proof is green; full five-platform pure-Rust MCP initialize readback remains required before dropInFor3014=true."
       ]
     },
     "libraryExports": {
-      "status": "experimental-opt-in-contract",
+      "status": "published-experimental-opt-in",
       "exportPath": "./pure-rust",
       "artifact": "dist/pure-rust.js",
       "defaultStillTypescript": true,

--- a/docs/specs/temporary-rust-migration-fences.md
+++ b/docs/specs/temporary-rust-migration-fences.md
@@ -72,3 +72,11 @@ Until registry install/readback is green on all five platforms:
 - TypeScript remains the default package entry
 - pure-Rust remains opt-in
 
+## Published progress package (3.1.2)
+
+`@sylphx/pdf-reader-mcp@3.1.2` and the five native optional packages are
+published under verified-candidate admission. Default entry remains TypeScript.
+Withdrawn range `3.0.15`–`3.1.1` must not be used. Sole-runtime cutover still
+requires five-platform registry pure-Rust initialize proof before
+`dropInFor3014=true`.
+

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sylphx/pdf-reader-mcp",
   "version": "3.1.2",
   "mcpName": "io.github.SylphxAI/pdf-reader-mcp",
-  "description": "Evidence-first PDF MCP. Published stable is 3.0.14 (TypeScript). Pure-Rust cutover is experimental/unpublished; 3.0.15–3.1.1 are withdrawn.",
+  "description": "Evidence-first PDF MCP. Default entry is TypeScript. Pure-Rust is opt-in via PDF_READER_ENGINE_MODE=pure-rust / ./pure-rust export and optional native platform packages. dropInFor3014 remains false; withdrawn 3.0.15\u20133.1.1 must not be used.",
   "type": "module",
   "bin": {
     "pdf-reader-mcp": "./dist/index.js"

--- a/scripts/check-pure-rust-matrix.ts
+++ b/scripts/check-pure-rust-matrix.ts
@@ -2590,11 +2590,25 @@ const annotationTextMarkupWithApResidualWorkflow =
     : '';
 
 const failures: string[] = [];
-if (
-  !matrix.productTruth.dropInFor3014 &&
-  !String(matrix.productTruth.publishedStable).includes('3.0.14')
-) {
-  failures.push('publishedStable must reference 3.0.14 while Rust is not drop-in');
+if (!matrix.productTruth.dropInFor3014) {
+  const publishedStable = String(matrix.productTruth.publishedStable ?? '');
+  const publishedImplementation = String(matrix.productTruth.publishedImplementation ?? '');
+  // While not sole-runtime, published stable may remain TS 3.0.14 LKG or a later
+  // progress package that still defaults to TypeScript (e.g. 3.1.2 Stage B).
+  const okStable =
+    publishedStable.includes('3.0.14') ||
+    publishedStable.includes('@sylphx/pdf-reader-mcp@3.1.') ||
+    /@sylphx\/pdf-reader-mcp@\d+\.\d+\.\d+/.test(publishedStable);
+  if (!okStable) {
+    failures.push(
+      'publishedStable must identify a published @sylphx/pdf-reader-mcp version while Rust is not drop-in'
+    );
+  }
+  if (!publishedImplementation.toLowerCase().includes('typescript')) {
+    failures.push(
+      'publishedImplementation must still identify TypeScript default while dropInFor3014=false'
+    );
+  }
 }
 const capabilityStatuses = Object.entries(matrix.tools).flatMap(([tool, capabilities]) =>
   Object.entries(capabilities).map(([capability, status]) => ({


### PR DESCRIPTION
## Summary
Registry proof (live):

- `@sylphx/pdf-reader-mcp@3.1.2` is `latest`
- five native optional packages published at 3.1.2 with real binaries
- host `check:registry-install-proof --registry --version=3.1.2` PASS
- `dropInFor3014` still false

Also hardens publish-npm registry readback with retries (previous run failed only on immediate post-publish `npm view` lag).

## Test plan
- [x] npm view main + 5 natives @3.1.2
- [x] host registry install proof
- [x] check:pure-rust-matrix / admission
- [ ] CI green