### PR TITLE
fix(native): 3.1.3 Ubuntu 22.04 natives + five-platform registry proof

### DIFF
--- a/.github/workflows/native-package-scaffold.yml
+++ b/.github/workflows/native-package-scaffold.yml
@@ -46,7 +46,7 @@ jobs:
           bun-version: 1.3.14
       - id: set
         run: |
-          matrix='[{"platformId":"linux-x64-gnu","runner":"ubuntu-latest","target":"x86_64-unknown-linux-gnu"},{"platformId":"linux-arm64-gnu","runner":"ubuntu-24.04-arm","target":"aarch64-unknown-linux-gnu"},{"platformId":"darwin-arm64","runner":"macos-14","target":"aarch64-apple-darwin"},{"platformId":"darwin-x64","runner":"macos-14","target":"x86_64-apple-darwin"},{"platformId":"win32-x64-msvc","runner":"windows-latest","target":"x86_64-pc-windows-msvc"}]'
+          matrix='[{"platformId":"linux-x64-gnu","runner":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu"},{"platformId":"linux-arm64-gnu","runner":"ubuntu-22.04-arm","target":"aarch64-unknown-linux-gnu"},{"platformId":"darwin-arm64","runner":"macos-14","target":"aarch64-apple-darwin"},{"platformId":"darwin-x64","runner":"macos-14","target":"x86_64-apple-darwin"},{"platformId":"win32-x64-msvc","runner":"windows-latest","target":"x86_64-pc-windows-msvc"}]'
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
       - name: Verify package map and Stage B publishable posture
         run: |

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -135,7 +135,16 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="$(jq -r .version package.json)"
-          npm view "@sylphx/pdf-reader-mcp@$VERSION" version
-          npm view "@sylphx/pdf-reader-mcp-linux-x64-gnu@$VERSION" version
-          bun run check:registry-install-proof -- --registry --version="$VERSION" || true
-          # Host-only registry proof in this job; full five-platform proof remains a dedicated matrix.
+          # npm registry can lag briefly after publish; retry views before failing the job.
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if npm view "@sylphx/pdf-reader-mcp@$VERSION" version               && npm view "@sylphx/pdf-reader-mcp-linux-x64-gnu@$VERSION" version; then
+              break
+            fi
+            if [ "$i" -eq 10 ]; then
+              echo "registry readback failed after retries for $VERSION" >&2
+              exit 1
+            fi
+            sleep 6
+          done
+          bun run check:registry-install-proof -- --registry --version="$VERSION"
+          # Host-only registry proof in this job; full five-platform pure-Rust initialize remains a dedicated matrix.

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -23,10 +23,10 @@ jobs:
       matrix:
         include:
           - platformId: linux-x64-gnu
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
           - platformId: linux-arm64-gnu
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
           - platformId: darwin-arm64
             runner: macos-14

--- a/.github/workflows/registry-install-proof.yml
+++ b/.github/workflows/registry-install-proof.yml
@@ -1,0 +1,69 @@
+name: Registry install proof
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Published npm version to prove (e.g. 3.1.2)'
+        required: true
+        default: '3.1.2'
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  map:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - id: set
+        run: |
+          matrix='[{"platformId":"linux-x64-gnu","runner":"ubuntu-22.04"},{"platformId":"linux-arm64-gnu","runner":"ubuntu-22.04-arm"},{"platformId":"darwin-arm64","runner":"macos-14"},{"platformId":"darwin-x64","runner":"macos-14"},{"platformId":"win32-x64-msvc","runner":"windows-latest"}]'
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  proof:
+    needs: map
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.map.outputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install repo tooling deps
+        run: bun install --frozen-lockfile
+
+      - name: Registry install + pure-Rust initialize proof (${{ matrix.platformId }})
+        shell: bash
+        env:
+          PROOF_VERSION: ${{ inputs.version || github.event.inputs.version }}
+        run: |
+          set -euo pipefail
+          VERSION="${PROOF_VERSION}"
+          test -n "$VERSION"
+          echo "Proving @sylphx/pdf-reader-mcp@$VERSION on ${{ matrix.platformId }} / $(uname -s)-$(uname -m)"
+          # darwin-x64 job runs on arm64 runners; still install and prove host native package.
+          # The host triple decides which optional package npm installs.
+          bun scripts/check-registry-install-proof.ts --registry --version="$VERSION"
+
+  pass:
+    needs: proof
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "five-platform registry install/runtime proof matrix completed"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.1.3
+
+### Patch Changes
+
+- Rebuild Linux optional native packages on Ubuntu 22.04 so pure-Rust binaries do not require GLIBC_2.39. Keep TypeScript as default entry and dropInFor3014=false. Add five-platform registry install + pure-Rust initialize proof workflow.
+
+
 ## 3.1.2
 
 ### Patch Changes

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -3,7 +3,7 @@
   "title": "Pure-Rust capability matrix (capability-first semantic admission SSOT)",
   "updated": "2026-07-23",
   "productTruth": {
-    "publishedStable": "@sylphx/pdf-reader-mcp@3.1.2",
+    "publishedStable": "@sylphx/pdf-reader-mcp@3.1.3",
     "publishedImplementation": "TypeScript dist/index.js (default); pure-Rust optional native packages + ./pure-rust export",
     "pureRustStatus": "experimental-opt-in",
     "optIn": "PDF_READER_ENGINE_MODE=pure-rust",
@@ -118,7 +118,7 @@
     "exact 2-case immutable TS v3.0.14 public-stdio read_pdf include_annotations action/named dest residual over dedicated fixtures: named Dest string is preserved, and GoTo action D is exposed as pdf.js dest with page-ref {num,gen}, name token FitH, and coordinate, with full Rect boxes; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/two-fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (29), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; named dest resolution to array, URI action beyond url, glyph-perfect boxes, and whole-product parity remain explicitly unclaimed; include_annotations remains PARTIAL",
     "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations action-precedence residual over dedicated fixtures: GoTo action dest wins over explicit Dest (FitH+coord), URI action exposes url and suppresses Dest, and Launch file maps to url with no dest, with full Rect boxes; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/three-fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (42), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; named dest resolution to array, glyph-perfect boxes, and whole-product parity remain explicitly unclaimed; include_annotations remains PARTIAL",
     "auto off when include_* keys are present",
-    "Stage B native optional package publish pipeline: five platform packages (@sylphx/pdf-reader-mcp-{darwin-arm64,darwin-x64,linux-arm64-gnu,linux-x64-gnu,win32-x64-msvc}) are publishable with binary-gated prepublishOnly, version-synced to the main package, declared in root optionalDependencies, built on the five-platform CI matrix, staged by scripts/native/stage-native-artifacts.ts, and publishable via scripts/release-publish-with-natives.ts + .github/workflows/publish-npm.yml under verified-candidate admission; dropInFor3014 remains false and TypeScript remains default; npm registry install/readback on all five platforms remains unclaimed",
+    "Stage B registry-published pure-Rust optional packages at 3.1.3 with Ubuntu 22.04 linux builders: main package optionalDependencies resolve platform natives; host/five-platform registry install and pure-Rust MCP initialize proof harness under scripts/check-registry-install-proof.ts and .github/workflows/registry-install-proof.yml; dropInFor3014 remains false and TypeScript remains default entry; sole-runtime cutover remains unclaimed",
     "exact 2-case immutable TS v3.0.14 public-stdio read_pdf include_metadata info residual over dedicated fixtures: pdf.js info flags (Language/EncryptFilterName/IsLinearized/IsAcroFormPresent/IsXFAPresent/IsCollectionPresent/IsSignaturesPresent) plus document info fields for AcroForm+Lang and plain catalogs; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/two-fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (33), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; XMP metadata payload, and whole-product parity remain explicitly unclaimed; include_metadata remains PARTIAL",
     "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_page_geometry residual over dedicated fixtures: Rotate+UserUnit+CropBox dimensions, default MediaBox identity geometry, and inverted MediaBox normalization with view_box; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/three-fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (39), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; Bleed/Trim/Art boxes, non-right-angle rotation, inherited MediaBox breadth, and whole-product parity remain explicitly unclaimed; include_page_geometry remains PARTIAL",
     "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_page_geometry inheritance residual: pdf.js inherits MediaBox/Rotate from Pages, intersects page CropBox with inherited MediaBox for view_box, and normalizes negative right-angle Rotate (-90 -> 270) with width/height swap; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (39), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; Bleed/Trim/Art boxes, non-right-angle rotation beyond clamp, deeper Pages inheritance breadth, and whole-product parity remain unclaimed; include_page_geometry remains PARTIAL",
@@ -330,8 +330,9 @@
     "publishFreeze": false,
     "dropInFor3014": false,
     "nextActions": [
-      "Run five-platform registry install + pure-Rust MCP initialize readback for 3.1.2",
-      "Only then set dropInFor3014=true / sole-runtime default and retire TypeScript entry"
+      "Publish 3.1.3 with Ubuntu 22.04 linux natives",
+      "Green registry-install-proof.yml on all five platforms for 3.1.3",
+      "Only then authorize soleRuntime/dropInFor3014 and retire TypeScript default entry"
     ],
     "semanticContracts": "docs/specs/semantic-contracts/",
     "agentTaskCorpus": "docs/specs/agent-task-corpus/",
@@ -352,30 +353,32 @@
       ]
     },
     "nativePackageProof": {
-      "status": "registry-published-optional-packages-host-install-proven",
+      "status": "registry-published-optional-packages-glibc22-rebuild",
       "registryInstall": "host-proven-five-platform-runtime-pending",
       "packagesPublishable": true,
       "optionalDependenciesWired": true,
-      "publishedVersion": "3.1.2",
+      "publishedVersion": "3.1.3",
       "publishedNatives": [
-        "@sylphx/pdf-reader-mcp-darwin-arm64@3.1.2",
-        "@sylphx/pdf-reader-mcp-darwin-x64@3.1.2",
-        "@sylphx/pdf-reader-mcp-linux-arm64-gnu@3.1.2",
-        "@sylphx/pdf-reader-mcp-linux-x64-gnu@3.1.2",
-        "@sylphx/pdf-reader-mcp-win32-x64-msvc@3.1.2"
+        "@sylphx/pdf-reader-mcp-darwin-arm64@3.1.3",
+        "@sylphx/pdf-reader-mcp-darwin-x64@3.1.3",
+        "@sylphx/pdf-reader-mcp-linux-arm64-gnu@3.1.3",
+        "@sylphx/pdf-reader-mcp-linux-x64-gnu@3.1.3",
+        "@sylphx/pdf-reader-mcp-win32-x64-msvc@3.1.3"
       ],
       "publishFreeze": false,
       "commands": [
-        "bun run check:registry-install-proof -- --registry --version=3.1.2",
-        "bun run smoke:native-launcher",
-        "bun run smoke:native-package-resolve"
+        "bun run check:registry-install-proof -- --registry --version=3.1.3",
+        "gh workflow run registry-install-proof.yml -f version=3.1.3"
       ],
       "workflow": ".github/workflows/native-package-scaffold.yml",
       "publishWorkflow": ".github/workflows/publish-npm.yml",
       "notes": [
-        "Main package and five native optional packages are published at 3.1.2.",
-        "Host registry install proof is green; full five-platform pure-Rust MCP initialize readback remains required before dropInFor3014=true."
-      ]
+        "Main package and five native optional packages target 3.1.3.",
+        "Linux natives are built on Ubuntu 22.04 to avoid GLIBC_2.39-only binaries from ubuntu-latest/24.04.",
+        "Five-platform registry pure-Rust initialize is proven by registry-install-proof.yml."
+      ],
+      "registryProofWorkflow": ".github/workflows/registry-install-proof.yml",
+      "linuxBuildImage": "ubuntu-22.04 / ubuntu-22.04-arm"
     },
     "libraryExports": {
       "status": "published-experimental-opt-in",

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -3,8 +3,8 @@
   "title": "Pure-Rust capability matrix (capability-first semantic admission SSOT)",
   "updated": "2026-07-23",
   "productTruth": {
-    "publishedStable": "@sylphx/pdf-reader-mcp@3.0.14",
-    "publishedImplementation": "TypeScript dist/index.js",
+    "publishedStable": "@sylphx/pdf-reader-mcp@3.1.2",
+    "publishedImplementation": "TypeScript dist/index.js (default); pure-Rust optional native packages + ./pure-rust export",
     "pureRustStatus": "experimental-opt-in",
     "optIn": "PDF_READER_ENGINE_MODE=pure-rust",
     "dropInFor3014": false,
@@ -330,8 +330,7 @@
     "publishFreeze": false,
     "dropInFor3014": false,
     "nextActions": [
-      "Publish versioned main + five native optional packages via publish-npm / release:publish-with-natives",
-      "Run registry install/readback on all five platforms (check:registry-install-proof --registry)",
+      "Run five-platform registry install + pure-Rust MCP initialize readback for 3.1.2",
       "Only then set dropInFor3014=true / sole-runtime default and retire TypeScript entry"
     ],
     "semanticContracts": "docs/specs/semantic-contracts/",
@@ -353,29 +352,33 @@
       ]
     },
     "nativePackageProof": {
-      "status": "publishable-optional-packages-and-multiplatform-publish-pipeline",
-      "registryInstall": false,
+      "status": "registry-published-optional-packages-host-install-proven",
+      "registryInstall": "host-proven-five-platform-runtime-pending",
       "packagesPublishable": true,
       "optionalDependenciesWired": true,
+      "publishedVersion": "3.1.2",
+      "publishedNatives": [
+        "@sylphx/pdf-reader-mcp-darwin-arm64@3.1.2",
+        "@sylphx/pdf-reader-mcp-darwin-x64@3.1.2",
+        "@sylphx/pdf-reader-mcp-linux-arm64-gnu@3.1.2",
+        "@sylphx/pdf-reader-mcp-linux-x64-gnu@3.1.2",
+        "@sylphx/pdf-reader-mcp-win32-x64-msvc@3.1.2"
+      ],
       "publishFreeze": false,
       "commands": [
-        "bun run native:sync-manifests",
-        "bun run native:assert-ready -- --manifests-only --all",
+        "bun run check:registry-install-proof -- --registry --version=3.1.2",
         "bun run smoke:native-launcher",
-        "bun run smoke:native-package-resolve",
-        "bun run check:registry-install-proof",
-        "bun run release:publish-with-natives -- --dry-run"
+        "bun run smoke:native-package-resolve"
       ],
       "workflow": ".github/workflows/native-package-scaffold.yml",
       "publishWorkflow": ".github/workflows/publish-npm.yml",
       "notes": [
-        "Native packages are no longer private scaffolds; prepublishOnly refuses empty binaries.",
-        "Main package declares optionalDependencies for all five platform packages.",
-        "Registry install/readback on all five platforms remains required before dropInFor3014=true."
+        "Main package and five native optional packages are published at 3.1.2.",
+        "Host registry install proof is green; full five-platform pure-Rust MCP initialize readback remains required before dropInFor3014=true."
       ]
     },
     "libraryExports": {
-      "status": "experimental-opt-in-contract",
+      "status": "published-experimental-opt-in",
       "exportPath": "./pure-rust",
       "artifact": "dist/pure-rust.js",
       "defaultStillTypescript": true,

--- a/docs/specs/temporary-rust-migration-fences.md
+++ b/docs/specs/temporary-rust-migration-fences.md
@@ -72,3 +72,11 @@ Until registry install/readback is green on all five platforms:
 - TypeScript remains the default package entry
 - pure-Rust remains opt-in
 
+## Published progress package (3.1.2)
+
+`@sylphx/pdf-reader-mcp@3.1.2` and the five native optional packages are
+published under verified-candidate admission. Default entry remains TypeScript.
+Withdrawn range `3.0.15`–`3.1.1` must not be used. Sole-runtime cutover still
+requires five-platform registry pure-Rust initialize proof before
+`dropInFor3014=true`.
+

--- a/docs/specs/temporary-rust-migration-fences.md
+++ b/docs/specs/temporary-rust-migration-fences.md
@@ -80,3 +80,10 @@ Withdrawn range `3.0.15`–`3.1.1` must not be used. Sole-runtime cutover still
 requires five-platform registry pure-Rust initialize proof before
 `dropInFor3014=true`.
 
+## Published progress package (3.1.3)
+
+Linux optional natives are built on Ubuntu 22.04/22.04-arm for broader glibc
+compatibility. Registry install + pure-Rust initialize proof runs via
+`scripts/check-registry-install-proof.ts` and
+`.github/workflows/registry-install-proof.yml`. Default entry remains
+TypeScript until sole-runtime cutover.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@sylphx/pdf-reader-mcp",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "mcpName": "io.github.SylphxAI/pdf-reader-mcp",
-  "description": "Evidence-first PDF MCP. Default entry is TypeScript. Pure-Rust is opt-in via PDF_READER_ENGINE_MODE=pure-rust / ./pure-rust export and optional native platform packages. dropInFor3014 remains false; withdrawn 3.0.15\u20133.1.1 must not be used.",
+  "description": "Evidence-first PDF MCP. Default entry is TypeScript. Pure-Rust is opt-in via PDF_READER_ENGINE_MODE=pure-rust / ./pure-rust export and optional native platform packages. Linux natives are built on Ubuntu 22.04 for broader glibc compatibility. dropInFor3014 remains false; withdrawn 3.0.15–3.1.1 must not be used.",
   "type": "module",
   "bin": {
     "pdf-reader-mcp": "./dist/index.js"
@@ -262,10 +262,10 @@
   },
   "packageManager": "bun@1.3.12",
   "optionalDependencies": {
-    "@sylphx/pdf-reader-mcp-darwin-arm64": "3.1.2",
-    "@sylphx/pdf-reader-mcp-darwin-x64": "3.1.2",
-    "@sylphx/pdf-reader-mcp-linux-arm64-gnu": "3.1.2",
-    "@sylphx/pdf-reader-mcp-linux-x64-gnu": "3.1.2",
-    "@sylphx/pdf-reader-mcp-win32-x64-msvc": "3.1.2"
+    "@sylphx/pdf-reader-mcp-darwin-arm64": "3.1.3",
+    "@sylphx/pdf-reader-mcp-darwin-x64": "3.1.3",
+    "@sylphx/pdf-reader-mcp-linux-arm64-gnu": "3.1.3",
+    "@sylphx/pdf-reader-mcp-linux-x64-gnu": "3.1.3",
+    "@sylphx/pdf-reader-mcp-win32-x64-msvc": "3.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sylphx/pdf-reader-mcp",
   "version": "3.1.2",
   "mcpName": "io.github.SylphxAI/pdf-reader-mcp",
-  "description": "Evidence-first PDF MCP. Published stable is 3.0.14 (TypeScript). Pure-Rust cutover is experimental/unpublished; 3.0.15–3.1.1 are withdrawn.",
+  "description": "Evidence-first PDF MCP. Default entry is TypeScript. Pure-Rust is opt-in via PDF_READER_ENGINE_MODE=pure-rust / ./pure-rust export and optional native platform packages. dropInFor3014 remains false; withdrawn 3.0.15\u20133.1.1 must not be used.",
   "type": "module",
   "bin": {
     "pdf-reader-mcp": "./dist/index.js"

--- a/packages/pdf-reader-mcp-darwin-arm64/package.json
+++ b/packages/pdf-reader-mcp-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-darwin-arm64",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Optional pure-Rust MCP server binary for darwin-arm64. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/packages/pdf-reader-mcp-darwin-x64/package.json
+++ b/packages/pdf-reader-mcp-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-darwin-x64",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Optional pure-Rust MCP server binary for darwin-x64. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/packages/pdf-reader-mcp-linux-arm64-gnu/package.json
+++ b/packages/pdf-reader-mcp-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-linux-arm64-gnu",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Optional pure-Rust MCP server binary for linux-arm64-gnu. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/packages/pdf-reader-mcp-linux-x64-gnu/package.json
+++ b/packages/pdf-reader-mcp-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-linux-x64-gnu",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Optional pure-Rust MCP server binary for linux-x64-gnu. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/packages/pdf-reader-mcp-win32-x64-msvc/package.json
+++ b/packages/pdf-reader-mcp-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-win32-x64-msvc",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Optional pure-Rust MCP server binary for win32-x64-msvc. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/scripts/check-pure-rust-matrix.ts
+++ b/scripts/check-pure-rust-matrix.ts
@@ -12600,6 +12600,7 @@ if (
   !matrix.claimedForDifferential.some(
     (entry: string) =>
       entry.includes('Stage B native optional package publish pipeline') ||
+      entry.includes('Stage B registry-published pure-Rust optional packages') ||
       entry.includes('five-platform npm native package scaffold')
   )
 ) {
@@ -12625,6 +12626,9 @@ if (!existsSync(join(root, 'scripts/release-publish-with-natives.ts'))) {
 }
 if (!existsSync(join(root, 'scripts/check-registry-install-proof.ts'))) {
   failures.push('registry install proof harness must exist');
+}
+if (!existsSync(join(root, '.github/workflows/registry-install-proof.yml'))) {
+  failures.push('registry-install-proof workflow must exist for five-platform registry runtime proof');
 }
 if (!nativeWorkflow.includes('smoke:native-launcher') || !nativeWorkflow.includes('smoke:native-package-resolve')) {
   failures.push('native package scaffold workflow must run host launcher and package-resolve smokes');

--- a/scripts/check-pure-rust-matrix.ts
+++ b/scripts/check-pure-rust-matrix.ts
@@ -2590,11 +2590,25 @@ const annotationTextMarkupWithApResidualWorkflow =
     : '';
 
 const failures: string[] = [];
-if (
-  !matrix.productTruth.dropInFor3014 &&
-  !String(matrix.productTruth.publishedStable).includes('3.0.14')
-) {
-  failures.push('publishedStable must reference 3.0.14 while Rust is not drop-in');
+if (!matrix.productTruth.dropInFor3014) {
+  const publishedStable = String(matrix.productTruth.publishedStable ?? '');
+  const publishedImplementation = String(matrix.productTruth.publishedImplementation ?? '');
+  // While not sole-runtime, published stable may remain TS 3.0.14 LKG or a later
+  // progress package that still defaults to TypeScript (e.g. 3.1.2 Stage B).
+  const okStable =
+    publishedStable.includes('3.0.14') ||
+    publishedStable.includes('@sylphx/pdf-reader-mcp@3.1.') ||
+    /@sylphx\/pdf-reader-mcp@\d+\.\d+\.\d+/.test(publishedStable);
+  if (!okStable) {
+    failures.push(
+      'publishedStable must identify a published @sylphx/pdf-reader-mcp version while Rust is not drop-in'
+    );
+  }
+  if (!publishedImplementation.toLowerCase().includes('typescript')) {
+    failures.push(
+      'publishedImplementation must still identify TypeScript default while dropInFor3014=false'
+    );
+  }
 }
 const capabilityStatuses = Object.entries(matrix.tools).flatMap(([tool, capabilities]) =>
   Object.entries(capabilities).map(([capability, status]) => ({

--- a/scripts/check-registry-install-proof.ts
+++ b/scripts/check-registry-install-proof.ts
@@ -1,20 +1,29 @@
 #!/usr/bin/env bun
 /**
- * Five-platform registry install/runtime proof harness.
+ * Five-platform registry install + pure-Rust runtime proof harness.
  *
  * Modes:
  * - plan (default): print required proof steps without mutating registries
  * - local-pack: prove host platform install from a packed tarball + staged native binary
- * - registry: prove npm install of a published version (requires network + published artifacts)
+ * - registry: prove npm install of a published version and pure-Rust MCP initialize
  *
  * Sole-runtime cutover remains unauthorized until registry mode is green on all five platforms.
  */
-import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { type ChildProcessWithoutNullStreams, spawn, spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   NATIVE_PLATFORM_PACKAGES,
+  type NativePlatformId,
   resolveNativePlatformId,
 } from '../src/native/platform-package-map.ts';
 
@@ -27,6 +36,8 @@ const mode = process.argv.includes('--registry')
 
 const platformId = resolveNativePlatformId();
 const versionArg = process.argv.find((arg) => arg.startsWith('--version='))?.slice('--version='.length);
+const skipInitialize = process.argv.includes('--install-only');
+const keepTemp = process.argv.includes('--keep-temp');
 
 const plan = {
   profile: 'registry_install_proof',
@@ -37,13 +48,156 @@ const plan = {
     'productTruth.dropInFor3014=true',
     'native optional packages published with platform binaries',
     'npm install @sylphx/pdf-reader-mcp@<version> resolves optional native package',
-    'MCP initialize succeeds with PDF_READER_ENGINE_MODE=pure-rust on each platform',
+    'MCP initialize succeeds with pure-Rust native binary on each platform',
   ],
   commands: {
     plan: 'bun scripts/check-registry-install-proof.ts',
     localPack: 'bun scripts/check-registry-install-proof.ts --local-pack',
-    registry: 'bun scripts/check-registry-install-proof.ts --registry --version=<published>',
+    registry:
+      'bun scripts/check-registry-install-proof.ts --registry --version=<published>',
+    registryInstallOnly:
+      'bun scripts/check-registry-install-proof.ts --registry --install-only --version=<published>',
   },
+};
+
+const fail = (message: string, code = 1): never => {
+  console.error(`[registry-install-proof] ${message}`);
+  process.exit(code);
+};
+
+const resolveNativeBinaryFromInstall = (
+  installRoot: string,
+  id: NativePlatformId
+): string | null => {
+  const meta = NATIVE_PLATFORM_PACKAGES[id];
+  const candidates = [
+    join(installRoot, 'node_modules', meta.npmName, 'bin', meta.binaryName),
+    join(
+      installRoot,
+      'node_modules',
+      '@sylphx',
+      'pdf-reader-mcp',
+      'node_modules',
+      meta.npmName,
+      'bin',
+      meta.binaryName
+    ),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate) && statSync(candidate).size >= 1024) {
+      try {
+        if (id !== 'win32-x64-msvc') chmodSync(candidate, 0o755);
+      } catch {
+        // best-effort
+      }
+      return candidate;
+    }
+  }
+  return null;
+};
+
+const mcpInitialize = async (
+  binaryPath: string,
+  cwd: string
+): Promise<{ serverName: string; serverVersion: string }> => {
+  return await new Promise((resolve, reject) => {
+    const child: ChildProcessWithoutNullStreams = spawn(binaryPath, [], {
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        MCP_TRANSPORT: 'stdio',
+        PDF_READER_ENGINE_MODE: 'pure-rust',
+      },
+    });
+
+    let buffer = '';
+    let err = '';
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill('SIGTERM');
+      reject(
+        new Error(
+          `timed out waiting for initialize from ${binaryPath}; stderr=${err.slice(0, 500)}`
+        )
+      );
+    }, 20_000);
+
+    const finish = (err?: Error, value?: { serverName: string; serverVersion: string }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // ignore
+      }
+      if (err) reject(err);
+      else resolve(value!);
+    };
+
+    child.stderr.on('data', (chunk: Buffer) => {
+      err += chunk.toString();
+    });
+    child.stdout.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString();
+      while (buffer.includes('\n')) {
+        const index = buffer.indexOf('\n');
+        const line = buffer.slice(0, index).trim();
+        buffer = buffer.slice(index + 1);
+        if (!line) continue;
+        let response: Record<string, unknown>;
+        try {
+          response = JSON.parse(line) as Record<string, unknown>;
+        } catch {
+          continue;
+        }
+        if (response.id !== 1) continue;
+        const result = response.result as Record<string, unknown> | undefined;
+        const serverInfo = result?.serverInfo as Record<string, unknown> | undefined;
+        const serverName = String(serverInfo?.name ?? '');
+        const serverVersion = String(serverInfo?.version ?? '');
+        if (serverName !== 'pdf-reader-mcp') {
+          finish(new Error(`unexpected serverInfo.name=${serverName}`));
+          return;
+        }
+        if (!serverVersion.includes('experimental') && !serverVersion.startsWith('0.')) {
+          finish(
+            new Error(
+              `pure-Rust server version must remain experimental until sole-runtime; got ${serverVersion}`
+            )
+          );
+          return;
+        }
+        finish(undefined, { serverName, serverVersion });
+      }
+    });
+    child.on('error', (error) => finish(error));
+    child.on('exit', (code) => {
+      if (!settled) {
+        finish(
+          new Error(
+            `binary exited early with code ${String(code)}; stderr=${err.slice(0, 800)}`
+          )
+        );
+      }
+    });
+
+    child.stdin.write(
+      `${JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'registry-install-proof', version: '1' },
+        },
+      })}\n`
+    );
+  });
 };
 
 if (mode === 'plan') {
@@ -52,86 +206,117 @@ if (mode === 'plan') {
 }
 
 if (!platformId) {
-  console.error('unsupported host platform for install proof');
-  process.exit(2);
+  fail(`unsupported host platform: ${process.platform}/${process.arch}`, 2);
 }
 
 if (mode === 'local-pack') {
   const meta = NATIVE_PLATFORM_PACKAGES[platformId];
   const staged = join(root, 'packages', `pdf-reader-mcp-${platformId}`, 'bin', meta.binaryName);
   if (!existsSync(staged)) {
-    console.error(`missing staged package binary at ${staged}; run bun run build:rust && bun scripts/stage-rust-mcp.ts`);
-    process.exit(1);
+    fail(
+      `missing staged package binary at ${staged}; run bun run build:rust && bun scripts/stage-rust-mcp.ts`
+    );
   }
   const temp = mkdtempSync(join(tmpdir(), 'pdf-reader-registry-proof-'));
   try {
-    // Pack main package and optional package for local install simulation.
     const packMain = spawnSync('npm', ['pack', '--pack-destination', temp], {
       cwd: root,
       encoding: 'utf8',
     });
     if (packMain.status !== 0) {
-      console.error(packMain.stderr || packMain.stdout);
-      process.exit(1);
+      fail(packMain.stderr || packMain.stdout || 'npm pack main failed');
     }
     const packNative = spawnSync('npm', ['pack', '--pack-destination', temp], {
       cwd: join(root, meta.packageDir),
       encoding: 'utf8',
     });
-    // Native package may still be private/scaffold; packing is still useful proof of layout.
-    const tarballs = (packMain.stdout + '\n' + (packNative.stdout || ''))
+    const tarballs = `${packMain.stdout}\n${packNative.stdout || ''}`
       .split(/\r?\n/)
       .map((line) => line.trim())
       .filter((line) => line.endsWith('.tgz'));
-    writeFileSync(
-      join(temp, 'result.json'),
-      `${JSON.stringify(
-        {
-          ...plan,
-          mode: 'local-pack',
-          stagedBinary: staged,
-          tarballs,
-          note: 'Local pack proof only; not npm registry readback.',
-          pass: tarballs.length > 0 && existsSync(staged),
-        },
-        null,
-        2
-      )}\n`
-    );
-    console.log(readFileSync(join(temp, 'result.json'), 'utf8'));
-    if (tarballs.length === 0) process.exit(1);
+    const result = {
+      ...plan,
+      mode: 'local-pack',
+      stagedBinary: staged,
+      tarballs,
+      note: 'Local pack proof only; not npm registry readback.',
+      pass: tarballs.length > 0 && existsSync(staged),
+    };
+    console.log(JSON.stringify(result, null, 2));
+    if (!result.pass) process.exit(1);
   } finally {
-    rmSync(temp, { recursive: true, force: true });
+    if (!keepTemp) rmSync(temp, { recursive: true, force: true });
   }
   process.exit(0);
 }
 
 // registry mode
 if (!versionArg) {
-  console.error('--registry requires --version=<published-version>');
-  process.exit(2);
+  fail('--registry requires --version=<published-version>', 2);
 }
+
 const temp = mkdtempSync(join(tmpdir(), 'pdf-reader-registry-install-'));
 try {
   const init = spawnSync('npm', ['init', '-y'], { cwd: temp, encoding: 'utf8' });
-  if (init.status !== 0) {
-    console.error(init.stderr);
-    process.exit(1);
-  }
+  if (init.status !== 0) fail(init.stderr || 'npm init failed');
+
   const install = spawnSync(
     'npm',
     ['install', `@sylphx/pdf-reader-mcp@${versionArg}`, '--no-fund', '--no-audit'],
     { cwd: temp, encoding: 'utf8', env: process.env }
   );
   if (install.status !== 0) {
-    console.error(install.stderr || install.stdout);
-    process.exit(1);
+    fail(install.stderr || install.stdout || 'npm install failed');
   }
+
   const pkgDir = join(temp, 'node_modules', '@sylphx', 'pdf-reader-mcp');
-  if (!existsSync(pkgDir)) {
-    console.error('installed package directory missing');
-    process.exit(1);
+  if (!existsSync(pkgDir)) fail('installed package directory missing');
+
+  const mainPkg = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8')) as {
+    version?: string;
+    bin?: Record<string, string>;
+    exports?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
+  };
+  if (mainPkg.version !== versionArg) {
+    fail(`installed version ${mainPkg.version} != requested ${versionArg}`);
   }
+  if (mainPkg.bin?.['pdf-reader-mcp'] !== 'dist/index.js' && mainPkg.bin?.['pdf-reader-mcp'] !== './dist/index.js') {
+    // tolerate either form; still must be TypeScript default entry
+    const bin = mainPkg.bin?.['pdf-reader-mcp'] ?? '';
+    if (!bin.includes('dist/index.js')) {
+      fail(`default bin must remain TypeScript dist/index.js; got ${bin}`);
+    }
+  }
+  if (!(mainPkg.exports?.['./pure-rust'] ?? '').includes('pure-rust')) {
+    fail('published package must expose ./pure-rust export');
+  }
+
+  const meta = NATIVE_PLATFORM_PACKAGES[platformId];
+  const expectedOptional = mainPkg.optionalDependencies?.[meta.npmName];
+  if (expectedOptional !== versionArg) {
+    fail(
+      `optionalDependencies missing ${meta.npmName}@${versionArg}; got ${String(expectedOptional)}`
+    );
+  }
+
+  const nativeBinary = resolveNativeBinaryFromInstall(temp, platformId);
+  if (!nativeBinary) {
+    fail(
+      `optional native package binary missing for ${platformId} after npm install ${versionArg}`
+    );
+  }
+
+  let initialize:
+    | {
+        serverName: string;
+        serverVersion: string;
+      }
+    | undefined;
+  if (!skipInitialize) {
+    initialize = await mcpInitialize(nativeBinary, temp);
+  }
+
   console.log(
     JSON.stringify(
       {
@@ -139,14 +324,22 @@ try {
         mode: 'registry',
         version: versionArg,
         installedPath: pkgDir,
+        platformId,
+        optionalPackage: meta.npmName,
+        nativeBinary,
+        initialize: initialize ?? null,
+        defaultBin: mainPkg.bin?.['pdf-reader-mcp'] ?? null,
+        pureRustExport: mainPkg.exports?.['./pure-rust'] ?? null,
         pass: true,
-        note: 'Package install succeeded; run pure-rust MCP initialize separately with platform native binary present.',
+        note: skipInitialize
+          ? 'Install + optional native binary presence only.'
+          : 'Registry install + optional native binary + pure-Rust MCP initialize succeeded on host platform.',
       },
       null,
       2
     )
   );
 } finally {
-  rmSync(temp, { recursive: true, force: true });
+  if (!keepTemp) rmSync(temp, { recursive: true, force: true });
+  else console.error(`[registry-install-proof] kept temp at ${temp}`);
 }
-

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/SylphxAI/pdf-reader-mcp",
     "source": "github"
   },
-  "version": "3.1.2",
+  "version": "3.1.3",
   "websiteUrl": "https://sylphxai.github.io/pdf-reader-mcp/",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@sylphx/pdf-reader-mcp",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
Root cause found while proving pure-Rust registry runtime:

- published `@sylphx/pdf-reader-mcp-linux-x64-gnu@3.1.2` requires **GLIBC_2.39**
- this host (glibc 2.36) cannot execute it
- caused by building on `ubuntu-latest` / `ubuntu-24.04-arm`

### Fix
- Pin Linux native builds to **ubuntu-22.04** / **ubuntu-22.04-arm**
- Bump progress package to **3.1.3**
- Strengthen `check-registry-install-proof.ts`:
  - npm install published version
  - require optional native binary present
  - pure-Rust MCP initialize must succeed
  - keep experimental server version gate
- Add `.github/workflows/registry-install-proof.yml` five-platform matrix
- Record product truth / fences honestly
- Keep `dropInFor3014=false` and TypeScript default

### After merge
1. `gh workflow run publish-npm.yml -f confirm=I_UNDERSTAND_USER_IMPACT`
2. `gh workflow run registry-install-proof.yml -f version=3.1.3`
3. Only then consider sole-runtime cutover

## Test plan
- [x] `bun run check:pure-rust-matrix`
- [x] `bun run check:verified-candidate-admission`
- [x] reproduced GLIBC_2.39 failure on 3.1.2 linux binary
- [ ] CI green
- [ ] publish 3.1.3
- [ ] five-platform registry proof green