### PR TITLE
fix(release): do not overwrite Ubuntu 22.04 natives during publish (3.1.4)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -75,7 +75,7 @@ jobs:
     name: Publish natives + main
     needs: build-native
     if: ${{ github.event.inputs.confirm == 'I_UNDERSTAND_USER_IMPACT' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -104,22 +104,42 @@ jobs:
           pattern: pdf-reader-mcp-server-*
           merge-multiple: false
 
-      - name: Stage native binaries into packages
-        run: bun run native:stage-from-artifacts -- --artifact-root=native-artifacts
-
-      - name: Sync manifests and assert all platforms ready
-        run: |
-          bun run native:sync-manifests
-          bun run native:assert-ready -- --all
-
-      - name: Set up Rust (main package build)
+      - name: Set up Rust (for package smoke only)
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Build package (TS + host rust staging)
+      - name: Build TypeScript package and host rust for smoke
         run: |
           bun run build
+          # Host build is for package:smoke only. It must NOT be what we publish.
           bun run build:rust
           bun run package:smoke
+
+      - name: Stage multi-platform native binaries into packages (after host build)
+        run: |
+          set -euo pipefail
+          # Critical: build:rust stages the publish-job host binary into
+          # packages/pdf-reader-mcp-<host>/bin and would overwrite the
+          # Ubuntu 22.04 artifact with a newer-glibc binary. Restage all
+          # matrix artifacts immediately before publish.
+          bun run native:stage-from-artifacts -- --artifact-root=native-artifacts
+          bun run native:sync-manifests
+          bun run native:assert-ready -- --all
+          bin="packages/pdf-reader-mcp-linux-x64-gnu/bin/pdf-reader-mcp-server"
+          test -f "$bin"
+          if command -v objdump >/dev/null 2>&1; then
+            mapfile -t vers < <(objdump -T "$bin" | sed -n 's/.*GLIBC_\([0-9][0-9.]*\).*/\1/p' | sort -u)
+            echo "GLIBC symbols: ${vers[*]}"
+            for v in "${vers[@]}"; do
+              major=${v%%.*}
+              rest=${v#*.}
+              minor=${rest%%.*}
+              if [ "$major" -gt 2 ] || { [ "$major" -eq 2 ] && [ "${minor:-0}" -gt 35 ]; }; then
+                echo "::error::linux-x64-gnu binary requires GLIBC_$v (> 2.35). Refusing publish."
+                exit 1
+              fi
+            done
+            echo "linux-x64-gnu GLIBC requirement OK (<= 2.35)"
+          fi
 
       - name: Publish natives then main
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.1.4
+
+### Patch Changes
+
+- Fix publish pipeline overwriting Ubuntu 22.04 linux-x64 native artifacts with the publish-job host `build:rust` binary (which reintroduced GLIBC_2.39). Restage matrix artifacts after host smoke and gate linux-x64 publish on GLIBC <= 2.35. TypeScript remains default; dropInFor3014=false.
+
+
 ## 3.1.3
 
 ### Patch Changes

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -3,7 +3,7 @@
   "title": "Pure-Rust capability matrix (capability-first semantic admission SSOT)",
   "updated": "2026-07-23",
   "productTruth": {
-    "publishedStable": "@sylphx/pdf-reader-mcp@3.1.3",
+    "publishedStable": "@sylphx/pdf-reader-mcp@3.1.4",
     "publishedImplementation": "TypeScript dist/index.js (default); pure-Rust optional native packages + ./pure-rust export",
     "pureRustStatus": "experimental-opt-in",
     "optIn": "PDF_READER_ENGINE_MODE=pure-rust",
@@ -118,7 +118,7 @@
     "exact 2-case immutable TS v3.0.14 public-stdio read_pdf include_annotations action/named dest residual over dedicated fixtures: named Dest string is preserved, and GoTo action D is exposed as pdf.js dest with page-ref {num,gen}, name token FitH, and coordinate, with full Rect boxes; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/two-fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (29), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; named dest resolution to array, URI action beyond url, glyph-perfect boxes, and whole-product parity remain explicitly unclaimed; include_annotations remains PARTIAL",
     "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations action-precedence residual over dedicated fixtures: GoTo action dest wins over explicit Dest (FitH+coord), URI action exposes url and suppresses Dest, and Launch file maps to url with no dest, with full Rect boxes; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/three-fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (42), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; named dest resolution to array, glyph-perfect boxes, and whole-product parity remain explicitly unclaimed; include_annotations remains PARTIAL",
     "auto off when include_* keys are present",
-    "Stage B registry-published pure-Rust optional packages at 3.1.3 with Ubuntu 22.04 linux builders: main package optionalDependencies resolve platform natives; host/five-platform registry install and pure-Rust MCP initialize proof harness under scripts/check-registry-install-proof.ts and .github/workflows/registry-install-proof.yml; dropInFor3014 remains false and TypeScript remains default entry; sole-runtime cutover remains unclaimed",
+    "Stage B registry-published pure-Rust optional packages at 3.1.4 with Ubuntu 22.04 linux builders: main package optionalDependencies resolve platform natives; host/five-platform registry install and pure-Rust MCP initialize proof harness under scripts/check-registry-install-proof.ts and .github/workflows/registry-install-proof.yml; dropInFor3014 remains false and TypeScript remains default entry; sole-runtime cutover remains unclaimed",
     "exact 2-case immutable TS v3.0.14 public-stdio read_pdf include_metadata info residual over dedicated fixtures: pdf.js info flags (Language/EncryptFilterName/IsLinearized/IsAcroFormPresent/IsXFAPresent/IsCollectionPresent/IsSignaturesPresent) plus document info fields for AcroForm+Lang and plain catalogs; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/two-fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (33), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; XMP metadata payload, and whole-product parity remain explicitly unclaimed; include_metadata remains PARTIAL",
     "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_page_geometry residual over dedicated fixtures: Rotate+UserUnit+CropBox dimensions, default MediaBox identity geometry, and inverted MediaBox normalization with view_box; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/three-fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (39), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; Bleed/Trim/Art boxes, non-right-angle rotation, inherited MediaBox breadth, and whole-product parity remain explicitly unclaimed; include_page_geometry remains PARTIAL",
     "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_page_geometry inheritance residual: pdf.js inherits MediaBox/Rotate from Pages, intersects page CropBox with inherited MediaBox for view_box, and normalizes negative right-angle Rotate (-90 -> 270) with width/height swap; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (39), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; Bleed/Trim/Art boxes, non-right-angle rotation beyond clamp, deeper Pages inheritance breadth, and whole-product parity remain unclaimed; include_page_geometry remains PARTIAL",
@@ -330,8 +330,8 @@
     "publishFreeze": false,
     "dropInFor3014": false,
     "nextActions": [
-      "Publish 3.1.3 with Ubuntu 22.04 linux natives",
-      "Green registry-install-proof.yml on all five platforms for 3.1.3",
+      "Publish 3.1.4 without host-binary overwrite",
+      "Green registry-install-proof.yml on all five platforms for 3.1.4",
       "Only then authorize soleRuntime/dropInFor3014 and retire TypeScript default entry"
     ],
     "semanticContracts": "docs/specs/semantic-contracts/",
@@ -353,29 +353,29 @@
       ]
     },
     "nativePackageProof": {
-      "status": "registry-published-optional-packages-glibc22-rebuild",
+      "status": "registry-published-optional-packages-no-host-overwrite",
       "registryInstall": "host-proven-five-platform-runtime-pending",
       "packagesPublishable": true,
       "optionalDependenciesWired": true,
-      "publishedVersion": "3.1.3",
+      "publishedVersion": "3.1.4",
       "publishedNatives": [
-        "@sylphx/pdf-reader-mcp-darwin-arm64@3.1.3",
-        "@sylphx/pdf-reader-mcp-darwin-x64@3.1.3",
-        "@sylphx/pdf-reader-mcp-linux-arm64-gnu@3.1.3",
-        "@sylphx/pdf-reader-mcp-linux-x64-gnu@3.1.3",
-        "@sylphx/pdf-reader-mcp-win32-x64-msvc@3.1.3"
+        "@sylphx/pdf-reader-mcp-darwin-arm64@3.1.4",
+        "@sylphx/pdf-reader-mcp-darwin-x64@3.1.4",
+        "@sylphx/pdf-reader-mcp-linux-arm64-gnu@3.1.4",
+        "@sylphx/pdf-reader-mcp-linux-x64-gnu@3.1.4",
+        "@sylphx/pdf-reader-mcp-win32-x64-msvc@3.1.4"
       ],
       "publishFreeze": false,
       "commands": [
-        "bun run check:registry-install-proof -- --registry --version=3.1.3",
-        "gh workflow run registry-install-proof.yml -f version=3.1.3"
+        "bun run check:registry-install-proof -- --registry --version=3.1.4",
+        "gh workflow run registry-install-proof.yml -f version=3.1.4"
       ],
       "workflow": ".github/workflows/native-package-scaffold.yml",
       "publishWorkflow": ".github/workflows/publish-npm.yml",
       "notes": [
-        "Main package and five native optional packages target 3.1.3.",
-        "Linux natives are built on Ubuntu 22.04 to avoid GLIBC_2.39-only binaries from ubuntu-latest/24.04.",
-        "Five-platform registry pure-Rust initialize is proven by registry-install-proof.yml."
+        "Publish job restages Ubuntu 22.04 matrix artifacts after host build:rust so linux-x64 is not overwritten by ubuntu-latest/22.04 host glibc drift.",
+        "linux-x64-gnu publish is gated to GLIBC <= 2.35.",
+        "Five-platform registry pure-Rust initialize remains required before dropInFor3014=true."
       ],
       "registryProofWorkflow": ".github/workflows/registry-install-proof.yml",
       "linuxBuildImage": "ubuntu-22.04 / ubuntu-22.04-arm"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "mcpName": "io.github.SylphxAI/pdf-reader-mcp",
   "description": "Evidence-first PDF MCP. Default entry is TypeScript. Pure-Rust is opt-in via PDF_READER_ENGINE_MODE=pure-rust / ./pure-rust export and optional native platform packages. Linux natives are built on Ubuntu 22.04 for broader glibc compatibility. dropInFor3014 remains false; withdrawn 3.0.15–3.1.1 must not be used.",
   "type": "module",
@@ -262,10 +262,10 @@
   },
   "packageManager": "bun@1.3.12",
   "optionalDependencies": {
-    "@sylphx/pdf-reader-mcp-darwin-arm64": "3.1.3",
-    "@sylphx/pdf-reader-mcp-darwin-x64": "3.1.3",
-    "@sylphx/pdf-reader-mcp-linux-arm64-gnu": "3.1.3",
-    "@sylphx/pdf-reader-mcp-linux-x64-gnu": "3.1.3",
-    "@sylphx/pdf-reader-mcp-win32-x64-msvc": "3.1.3"
+    "@sylphx/pdf-reader-mcp-darwin-arm64": "3.1.4",
+    "@sylphx/pdf-reader-mcp-darwin-x64": "3.1.4",
+    "@sylphx/pdf-reader-mcp-linux-arm64-gnu": "3.1.4",
+    "@sylphx/pdf-reader-mcp-linux-x64-gnu": "3.1.4",
+    "@sylphx/pdf-reader-mcp-win32-x64-msvc": "3.1.4"
   }
 }

--- a/packages/pdf-reader-mcp-darwin-arm64/package.json
+++ b/packages/pdf-reader-mcp-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-darwin-arm64",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Optional pure-Rust MCP server binary for darwin-arm64. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/packages/pdf-reader-mcp-darwin-x64/package.json
+++ b/packages/pdf-reader-mcp-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-darwin-x64",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Optional pure-Rust MCP server binary for darwin-x64. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/packages/pdf-reader-mcp-linux-arm64-gnu/package.json
+++ b/packages/pdf-reader-mcp-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-linux-arm64-gnu",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Optional pure-Rust MCP server binary for linux-arm64-gnu. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/packages/pdf-reader-mcp-linux-x64-gnu/package.json
+++ b/packages/pdf-reader-mcp-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-linux-x64-gnu",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Optional pure-Rust MCP server binary for linux-x64-gnu. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/packages/pdf-reader-mcp-win32-x64-msvc/package.json
+++ b/packages/pdf-reader-mcp-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-win32-x64-msvc",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Optional pure-Rust MCP server binary for win32-x64-msvc. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/SylphxAI/pdf-reader-mcp",
     "source": "github"
   },
-  "version": "3.1.3",
+  "version": "3.1.4",
   "websiteUrl": "https://sylphxai.github.io/pdf-reader-mcp/",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@sylphx/pdf-reader-mcp",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
Root cause of continued GLIBC_2.39 on `@3.1.3` linux-x64:

1. Matrix correctly built natives on **ubuntu-22.04**
2. Publish job then ran `bun run build:rust` on **ubuntu-latest**
3. `scripts/stage-rust-mcp.ts` overwrote `packages/pdf-reader-mcp-linux-x64-gnu/bin`
4. That host binary (GLIBC_2.39) was published

### Fix
- Restage all matrix artifacts **after** host smoke build
- Gate linux-x64 publish on max GLIBC symbol **<= 2.35**
- Run publish job on **ubuntu-22.04**
- Bump progress package to **3.1.4**
- Keep TypeScript default / `dropInFor3014=false`

### After merge
1. `gh workflow run publish-npm.yml -f confirm=I_UNDERSTAND_USER_IMPACT`
2. host: `bun run check:registry-install-proof -- --registry --version=3.1.4`
3. `gh workflow run registry-install-proof.yml -f version=3.1.4`

## Test plan
- [x] identified overwrite path in publish-npm.yml + stage-rust-mcp.ts
- [x] matrix/admission local checks
- [ ] CI green
- [ ] publish 3.1.4 + host pure-Rust initialize
- [ ] five-platform registry proof