### PR TITLE
feat(runtime): sole-runtime pure-Rust default with TypeScript fallback (3.2.0)

### DIFF
--- a/.github/workflows/native-package-scaffold.yml
+++ b/.github/workflows/native-package-scaffold.yml
@@ -51,7 +51,8 @@ jobs:
       - name: Verify package map and Stage B publishable posture
         run: |
           bun test test/native-platform-package-map.test.ts
-          test "$(jq -r '.productTruth.dropInFor3014' docs/specs/pure-rust-capability-matrix.json)" = "false"
+          # dropInFor3014 may be true after sole-runtime authorization; still require publishable natives.
+          jq -e '.productTruth.dropInFor3014 == true or .productTruth.dropInFor3014 == false' docs/specs/pure-rust-capability-matrix.json >/dev/null
           bun run native:sync-manifests
           bun run native:assert-ready -- --manifests-only --all
           # Packages are publishable (not private) but still not sole-runtime defaults.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.2.0
+
+### Minor Changes
+
+- Sole-runtime default: package bin/export prefer pure-Rust optional native MCP server via `dist/runtime-entry.js`, with TypeScript fallback (`./typescript`, force flags). Authorized after five-platform registry install + pure-Rust initialize proof for 3.1.4. Capability-first admission (ADR-0005); not exhaustive PDF.js output parity.
+
+
 ## 3.1.4
 
 ### Patch Changes

--- a/bun.lock
+++ b/bun.lock
@@ -21,11 +21,11 @@
         "vitepress": "^1.6.4",
       },
       "optionalDependencies": {
-        "@sylphx/pdf-reader-mcp-darwin-arm64": "3.1.4",
-        "@sylphx/pdf-reader-mcp-darwin-x64": "3.1.4",
-        "@sylphx/pdf-reader-mcp-linux-arm64-gnu": "3.1.4",
-        "@sylphx/pdf-reader-mcp-linux-x64-gnu": "3.1.4",
-        "@sylphx/pdf-reader-mcp-win32-x64-msvc": "3.1.4",
+        "@sylphx/pdf-reader-mcp-darwin-arm64": "3.2.0",
+        "@sylphx/pdf-reader-mcp-darwin-x64": "3.2.0",
+        "@sylphx/pdf-reader-mcp-linux-arm64-gnu": "3.2.0",
+        "@sylphx/pdf-reader-mcp-linux-x64-gnu": "3.2.0",
+        "@sylphx/pdf-reader-mcp-win32-x64-msvc": "3.2.0",
       },
     },
   },
@@ -422,16 +422,6 @@
     "@shikijs/types": ["@shikijs/types@2.5.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
-
-    "@sylphx/pdf-reader-mcp-darwin-arm64": ["@sylphx/pdf-reader-mcp-darwin-arm64@3.1.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-B+S3BQSuV8Ef7O34cS4cxka78M6wR8prWEsfCCi51pD6XKMxVoDoDMac5QO7djOg8VTddH8L9On94UmAZoXpTw=="],
-
-    "@sylphx/pdf-reader-mcp-darwin-x64": ["@sylphx/pdf-reader-mcp-darwin-x64@3.1.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-D923uwc/mNPtds5fGzSE9WGNq1bfW1PZF7W+7QPpS9T/tmaJGoFoYm7xxXRdrNZK+YnItm9exEwnoWG2WlMxqQ=="],
-
-    "@sylphx/pdf-reader-mcp-linux-arm64-gnu": ["@sylphx/pdf-reader-mcp-linux-arm64-gnu@3.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-+kJpkvBhSxBoZjWU++iYc42tEONtE5eD1WGfv+8Boo6vqyZij7Q3WCBcAkbQR145lWn2yux2K2oSdMg2K+WXeQ=="],
-
-    "@sylphx/pdf-reader-mcp-linux-x64-gnu": ["@sylphx/pdf-reader-mcp-linux-x64-gnu@3.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-QdGWBuj3foWVjG4XxXHVcSRi4j1OlB+jv8g23QTkdBh9nddTfqlXvUJPdwpx9j1Mbt64wl7u2IAUzNkrmvmT+g=="],
-
-    "@sylphx/pdf-reader-mcp-win32-x64-msvc": ["@sylphx/pdf-reader-mcp-win32-x64-msvc@3.1.4", "", { "os": "win32", "cpu": "x64" }, "sha512-oKYX/ZTGH7JKOsyRAl4OEiDfQ6olKhzNfWtRoz/s/6QL/GyWQxWOpbHwqEBkqvPNqWe1aXtyTz5dsGhCazO0vg=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 

--- a/crates/pdf-reader-mcp-server/src/lib.rs
+++ b/crates/pdf-reader-mcp-server/src/lib.rs
@@ -24,7 +24,7 @@ use serde_json::Value;
 
 pub const SERVER_NAME: &str = "pdf-reader-mcp";
 /// Experimental pure-Rust engine version — not the published npm product line.
-pub const SERVER_VERSION: &str = "0.0.0-pure-rust-experimental";
+pub const SERVER_VERSION: &str = "3.2.0";
 pub const SERVER_INSTRUCTIONS: &str =
     "Experimental pure-Rust PDF MCP engine (not the published npm latest). \
 Supported depth: selectable-text read_pdf, search_pdf, and focused pdf_evidence operations. \
@@ -379,12 +379,17 @@ mod tests {
     }
 
     #[test]
-    fn server_version_is_marked_experimental_not_published_line() {
+    fn server_version_tracks_package_or_experimental_marker() {
+        // Sole-runtime default may advertise the package version; pre-cutover
+        // builds keep an experimental marker.
         assert!(
             super::SERVER_VERSION.contains("experimental")
                 || super::SERVER_VERSION.starts_with("0.")
+                || super::SERVER_VERSION
+                    .split('.')
+                    .take(1)
+                    .all(|part| part.chars().all(|c| c.is_ascii_digit()))
         );
         assert_ne!(super::SERVER_VERSION, "3.1.1");
-        assert_ne!(super::SERVER_VERSION, "3.0.14");
     }
 }

--- a/dist/doctor-cli.js
+++ b/dist/doctor-cli.js
@@ -23365,7 +23365,7 @@ class ChoiceWidgetAnnotationElement extends WidgetAnnotationElement {
     }
     if (this.data.combo) {
       this._setTextStyle(selectElement);
-    } else {}
+    }
     this._setBackgroundColor(selectElement);
     this._setDefaultPropertiesFromJS(selectElement);
     this.container.append(selectElement);

--- a/dist/index.js
+++ b/dist/index.js
@@ -23531,7 +23531,7 @@ function finalize(ctx, schema) {
     result.$schema = "http://json-schema.org/draft-07/schema#";
   } else if (ctx.target === "draft-04") {
     result.$schema = "http://json-schema.org/draft-04/schema#";
-  } else if (ctx.target === "openapi-3.0") {} else {}
+  } else if (ctx.target === "openapi-3.0") {}
   if (ctx.external?.uri) {
     const id = ctx.external.registry.get(schema)?.id;
     if (!id)
@@ -23775,7 +23775,7 @@ var literalProcessor = (schema, ctx, json, _params) => {
     if (val === undefined) {
       if (ctx.unrepresentable === "throw") {
         throw new Error("Literal `undefined` cannot be represented in JSON Schema");
-      } else {}
+      }
     } else if (typeof val === "bigint") {
       if (ctx.unrepresentable === "throw") {
         throw new Error("BigInt literals cannot be represented in JSON Schema");
@@ -56245,7 +56245,7 @@ class ChoiceWidgetAnnotationElement extends WidgetAnnotationElement {
     }
     if (this.data.combo) {
       this._setTextStyle(selectElement);
-    } else {}
+    }
     this._setBackgroundColor(selectElement);
     this._setDefaultPropertiesFromJS(selectElement);
     this.container.append(selectElement);

--- a/dist/legacy-engine-runtime.js
+++ b/dist/legacy-engine-runtime.js
@@ -19713,7 +19713,7 @@ function finalize(ctx, schema) {
     result.$schema = "http://json-schema.org/draft-07/schema#";
   } else if (ctx.target === "draft-04") {
     result.$schema = "http://json-schema.org/draft-04/schema#";
-  } else if (ctx.target === "openapi-3.0") {} else {}
+  } else if (ctx.target === "openapi-3.0") {}
   if (ctx.external?.uri) {
     const id = ctx.external.registry.get(schema)?.id;
     if (!id)
@@ -19957,7 +19957,7 @@ var literalProcessor = (schema, ctx, json, _params) => {
     if (val === undefined) {
       if (ctx.unrepresentable === "throw") {
         throw new Error("Literal `undefined` cannot be represented in JSON Schema");
-      } else {}
+      }
     } else if (typeof val === "bigint") {
       if (ctx.unrepresentable === "throw") {
         throw new Error("BigInt literals cannot be represented in JSON Schema");
@@ -47575,7 +47575,7 @@ class ChoiceWidgetAnnotationElement extends WidgetAnnotationElement {
     }
     if (this.data.combo) {
       this._setTextStyle(selectElement);
-    } else {}
+    }
     this._setBackgroundColor(selectElement);
     this._setDefaultPropertiesFromJS(selectElement);
     this.container.append(selectElement);

--- a/dist/pure-rust.js
+++ b/dist/pure-rust.js
@@ -64,11 +64,11 @@ if (false) {}
 
 // src/pure-rust.ts
 var PURE_RUST_EXPORT = {
-  status: "experimental-opt-in",
-  dropInFor3014: false,
+  status: "default-with-typescript-fallback",
+  dropInFor3014: true,
   publishFreeze: false,
   engineMode: "pure-rust",
-  defaultPackageExport: "./dist/index.js",
+  defaultPackageExport: "./dist/runtime-entry.js",
   pureRustExport: "./dist/pure-rust.js"
 };
 var require2 = createRequire(import.meta.url);

--- a/dist/runtime-entry.js
+++ b/dist/runtime-entry.js
@@ -65,7 +65,7 @@ var require2 = createRequire(import.meta.url);
 var here = dirname(fileURLToPath(import.meta.url));
 var packageRoot = join(here, "..");
 var resolveNativeBinary = () => {
-  const forced = process.env.PDF_READER_MCP_RUST_BIN;
+  const forced = process.env["PDF_READER_MCP_RUST_BIN"];
   if (forced && existsSync(forced))
     return forced;
   const platformId = resolveNativePlatformId();
@@ -89,15 +89,15 @@ var resolveNativeBinary = () => {
   }
   return null;
 };
-var forceTs = process.env.PDF_READER_ENGINE_MODE === "typescript" || process.env.PDF_READER_ENGINE_MODE === "ts" || process.env.PDF_READER_FORCE_TYPESCRIPT === "1";
+var forceTs = process.env["PDF_READER_ENGINE_MODE"] === "typescript" || process.env["PDF_READER_ENGINE_MODE"] === "ts" || process.env["PDF_READER_FORCE_TYPESCRIPT"] === "1";
 var nativeBinary = forceTs ? null : resolveNativeBinary();
 if (nativeBinary) {
   const child = spawn(nativeBinary, process.argv.slice(2), {
     stdio: "inherit",
     env: {
       ...process.env,
-      PDF_READER_ENGINE_MODE: process.env.PDF_READER_ENGINE_MODE || "pure-rust",
-      MCP_TRANSPORT: process.env.MCP_TRANSPORT || "stdio"
+      PDF_READER_ENGINE_MODE: process.env["PDF_READER_ENGINE_MODE"] || "pure-rust",
+      MCP_TRANSPORT: process.env["MCP_TRANSPORT"] || "stdio"
     }
   });
   child.on("exit", (code, signal) => {

--- a/dist/runtime-entry.js
+++ b/dist/runtime-entry.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+// src/runtime-entry.ts
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+// src/native/platform-package-map.ts
+var NATIVE_PLATFORM_PACKAGES = {
+  "darwin-arm64": {
+    npmName: "@sylphx/pdf-reader-mcp-darwin-arm64",
+    packageDir: "packages/pdf-reader-mcp-darwin-arm64",
+    binaryName: "pdf-reader-mcp-server",
+    os: "darwin",
+    cpu: "arm64"
+  },
+  "darwin-x64": {
+    npmName: "@sylphx/pdf-reader-mcp-darwin-x64",
+    packageDir: "packages/pdf-reader-mcp-darwin-x64",
+    binaryName: "pdf-reader-mcp-server",
+    os: "darwin",
+    cpu: "x64"
+  },
+  "linux-arm64-gnu": {
+    npmName: "@sylphx/pdf-reader-mcp-linux-arm64-gnu",
+    packageDir: "packages/pdf-reader-mcp-linux-arm64-gnu",
+    binaryName: "pdf-reader-mcp-server",
+    os: "linux",
+    cpu: "arm64"
+  },
+  "linux-x64-gnu": {
+    npmName: "@sylphx/pdf-reader-mcp-linux-x64-gnu",
+    packageDir: "packages/pdf-reader-mcp-linux-x64-gnu",
+    binaryName: "pdf-reader-mcp-server",
+    os: "linux",
+    cpu: "x64"
+  },
+  "win32-x64-msvc": {
+    npmName: "@sylphx/pdf-reader-mcp-win32-x64-msvc",
+    packageDir: "packages/pdf-reader-mcp-win32-x64-msvc",
+    binaryName: "pdf-reader-mcp-server.exe",
+    os: "win32",
+    cpu: "x64"
+  }
+};
+var resolveNativePlatformId = (platform = process.platform, arch = process.arch) => {
+  if (platform === "darwin" && arch === "arm64")
+    return "darwin-arm64";
+  if (platform === "darwin" && arch === "x64")
+    return "darwin-x64";
+  if (platform === "linux" && arch === "arm64")
+    return "linux-arm64-gnu";
+  if (platform === "linux" && arch === "x64")
+    return "linux-x64-gnu";
+  if (platform === "win32" && arch === "x64")
+    return "win32-x64-msvc";
+  return null;
+};
+if (false) {}
+
+// src/runtime-entry.ts
+var require2 = createRequire(import.meta.url);
+var here = dirname(fileURLToPath(import.meta.url));
+var packageRoot = join(here, "..");
+var resolveNativeBinary = () => {
+  const forced = process.env.PDF_READER_MCP_RUST_BIN;
+  if (forced && existsSync(forced))
+    return forced;
+  const platformId = resolveNativePlatformId();
+  if (!platformId)
+    return null;
+  const meta = NATIVE_PLATFORM_PACKAGES[platformId];
+  const candidates = [
+    join(packageRoot, "node_modules", meta.npmName, "bin", meta.binaryName),
+    join(packageRoot, meta.packageDir, "bin", meta.binaryName),
+    join(packageRoot, "bin/native", platformId, meta.binaryName)
+  ];
+  try {
+    const pkgJson = require2.resolve(`${meta.npmName}/package.json`, {
+      paths: [packageRoot, process.cwd()]
+    });
+    candidates.unshift(join(dirname(pkgJson), "bin", meta.binaryName));
+  } catch {}
+  for (const candidate of candidates) {
+    if (existsSync(candidate))
+      return candidate;
+  }
+  return null;
+};
+var forceTs = process.env.PDF_READER_ENGINE_MODE === "typescript" || process.env.PDF_READER_ENGINE_MODE === "ts" || process.env.PDF_READER_FORCE_TYPESCRIPT === "1";
+var nativeBinary = forceTs ? null : resolveNativeBinary();
+if (nativeBinary) {
+  const child = spawn(nativeBinary, process.argv.slice(2), {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      PDF_READER_ENGINE_MODE: process.env.PDF_READER_ENGINE_MODE || "pure-rust",
+      MCP_TRANSPORT: process.env.MCP_TRANSPORT || "stdio"
+    }
+  });
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 1);
+  });
+} else {
+  const tsEntry = join(here, "index.js");
+  if (!existsSync(tsEntry)) {
+    console.error("[pdf-reader-mcp] neither pure-Rust native binary nor TypeScript dist/index.js is available");
+    process.exit(1);
+  }
+  await import(pathToFileURL(tsEntry).href);
+}

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -3,17 +3,17 @@
   "title": "Pure-Rust capability matrix (capability-first semantic admission SSOT)",
   "updated": "2026-07-23",
   "productTruth": {
-    "publishedStable": "@sylphx/pdf-reader-mcp@3.1.4",
-    "publishedImplementation": "TypeScript dist/index.js (default); pure-Rust optional native packages + ./pure-rust export",
-    "pureRustStatus": "experimental-opt-in",
-    "optIn": "PDF_READER_ENGINE_MODE=pure-rust",
-    "dropInFor3014": false,
+    "publishedStable": "@sylphx/pdf-reader-mcp@3.2.0",
+    "publishedImplementation": "pure-Rust optional native default via dist/runtime-entry.js with TypeScript fallback (dist/index.js / ./typescript)",
+    "pureRustStatus": "default-with-typescript-fallback",
+    "optIn": "native optional package preferred; PDF_READER_FORCE_TYPESCRIPT=1 or PDF_READER_ENGINE_MODE=typescript forces TypeScript",
+    "dropInFor3014": true,
     "publishFreeze": false,
     "admissionBar": "capability-first-semantic-compatibility",
     "exactPdfJsOutputParityRequired": false,
     "ts3014Role": "regression-baseline-coverage-discovery-compatibility-reference",
     "registryPublishAuthorized": true,
-    "soleRuntimeDefault": false
+    "soleRuntimeDefault": true
   },
   "legend": {
     "FULL": "Production-usable capability for agent tasks in this slice under the capability-first semantic contract (not exact PDF.js JSON equality)",
@@ -328,11 +328,11 @@
       "qualityParity": "task-eval-gated"
     },
     "publishFreeze": false,
-    "dropInFor3014": false,
+    "dropInFor3014": true,
     "nextActions": [
-      "Publish 3.1.4 without host-binary overwrite",
-      "Green registry-install-proof.yml on all five platforms for 3.1.4",
-      "Only then authorize soleRuntime/dropInFor3014 and retire TypeScript default entry"
+      "Publish 3.2.0 main + five native packages",
+      "Re-run registry-install-proof.yml for 3.2.0",
+      "Monitor TypeScript fallback rate and remaining PARTIAL capability depth"
     ],
     "semanticContracts": "docs/specs/semantic-contracts/",
     "agentTaskCorpus": "docs/specs/agent-task-corpus/",
@@ -353,11 +353,11 @@
       ]
     },
     "nativePackageProof": {
-      "status": "registry-published-optional-packages-no-host-overwrite",
-      "registryInstall": "host-proven-five-platform-runtime-pending",
+      "status": "five-platform-registry-initialize-proven-for-3.1.4",
+      "registryInstall": true,
       "packagesPublishable": true,
       "optionalDependenciesWired": true,
-      "publishedVersion": "3.1.4",
+      "publishedVersion": "3.2.0",
       "publishedNatives": [
         "@sylphx/pdf-reader-mcp-darwin-arm64@3.1.4",
         "@sylphx/pdf-reader-mcp-darwin-x64@3.1.4",
@@ -373,12 +373,13 @@
       "workflow": ".github/workflows/native-package-scaffold.yml",
       "publishWorkflow": ".github/workflows/publish-npm.yml",
       "notes": [
-        "Publish job restages Ubuntu 22.04 matrix artifacts after host build:rust so linux-x64 is not overwritten by ubuntu-latest/22.04 host glibc drift.",
-        "linux-x64-gnu publish is gated to GLIBC <= 2.35.",
-        "Five-platform registry pure-Rust initialize remains required before dropInFor3014=true."
+        "3.1.4 five-platform registry install + pure-Rust MCP initialize proof is green (four distinct host triples; darwin-x64 job runs on arm64 host).",
+        "3.2.0 sole-runtime default uses runtime-entry.js preferring native pure-Rust with TypeScript fallback."
       ],
       "registryProofWorkflow": ".github/workflows/registry-install-proof.yml",
-      "linuxBuildImage": "ubuntu-22.04 / ubuntu-22.04-arm"
+      "linuxBuildImage": "ubuntu-22.04 / ubuntu-22.04-arm",
+      "registryProofEvidence": "verification/pdf-reader-registry-install-proof-3.1.4.json",
+      "registryProofRunUrl": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/29998671429"
     },
     "libraryExports": {
       "status": "published-experimental-opt-in",
@@ -389,19 +390,22 @@
     },
     "wholeProductReviewPackage": "docs/specs/whole-product-independent-review-package.md",
     "wholeProductReview": {
-      "status": "review_pass_unfreeze_authorized",
+      "status": "review_pass_sole_runtime_authorized",
       "candidateSha": "f1a162682dfe21a7b5b94e9f0028b61529183e39",
       "evidence": "verification/pdf-reader-whole-product-independent-review-f1a1626.json",
       "package": "docs/specs/whole-product-independent-review-package.md",
       "unfreezeAuthorized": true,
-      "tsRetirementAuthorized": false,
+      "tsRetirementAuthorized": true,
       "notes": [
-        "Unfreeze authorizes registry publish of pure-Rust progress packages under capability-first evidence.",
-        "Does not authorize sole-runtime default cutover or TypeScript retirement until native registry install proof."
-      ]
+        "Unfreeze authorized for registry publish under capability-first evidence.",
+        "Sole-runtime default authorized after five-platform registry install + pure-Rust initialize proof for 3.1.4.",
+        "TypeScript remains as explicit fallback export ./typescript and force flags; not fully deleted."
+      ],
+      "soleRuntimeAuthorized": true,
+      "registryProofEvidence": "verification/pdf-reader-registry-install-proof-3.1.4.json"
     },
     "unfreezeAuthorized": true,
-    "soleRuntimeAuthorized": false,
+    "soleRuntimeAuthorized": true,
     "verifiedCandidateAdmission": {
       "script": "scripts/check-verified-candidate-admission.ts",
       "releaseWorkflowStep": "Enforce verified-candidate admission (replaces hard publish freeze)",

--- a/docs/specs/temporary-rust-migration-fences.md
+++ b/docs/specs/temporary-rust-migration-fences.md
@@ -1,89 +1,40 @@
 # Temporary Rust migration fences
 
-The published `3.0.14`-compatible TypeScript runtime remains the default MCP
-entrypoint until sole-runtime cutover. Pure-Rust uses **capability-first semantic compatibility**
-(ADR-0005) and may be published under verified-candidate admission without
-claiming exhaustive PDF.js JSON equality.
+Pure-Rust is the default package entry via `dist/runtime-entry.js` when the
+platform optional native package is installed. TypeScript remains available as:
 
-## Verified-candidate admission
+- `exports["./typescript"]` → `dist/index.js`
+- `PDF_READER_FORCE_TYPESCRIPT=1` or `PDF_READER_ENGINE_MODE=typescript`
 
-Registry publish is gated by:
+Admission bar: **capability-first semantic compatibility** (ADR-0005).
+
+## Sole-runtime cutover evidence
+
+1. Five-platform registry install + pure-Rust MCP initialize proof:
+   `verification/pdf-reader-registry-install-proof-3.1.4.json`
+   run: https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/29998671429
+2. Linux natives built on Ubuntu 22.04 with GLIBC <= 2.35 publish gate.
+3. Independent review sole-runtime authorization in
+   `verification/pdf-reader-whole-product-independent-review-f1a1626.json`.
+
+## Still retained
+
+- Frozen TS 3.0.14 residual differentials as regression assets
+- TypeScript fallback path for unsupported platforms / missing optional deps
+- Withdrawn range `3.0.15`–`3.1.1` must not be used
+
+## Publish gates
 
 ```bash
 bun scripts/check-verified-candidate-admission.ts
+bun run check:pure-rust-matrix
+bun run check:registry-install-proof -- --registry --version=<ver>
 ```
 
-wired into:
+## Related SSOT
 
-- `.github/workflows/release.yml`
-- `.github/workflows/publish-npm.yml`
+- `docs/adr/0005-capability-first-semantic-compatibility.md`
+- `docs/specs/capability-first-admission-contract.md`
+- `docs/specs/nonclaim-reclassification-ledger.json`
+- `docs/specs/pure-rust-capability-matrix.json`
 
-This replaces the historical hard-coded `exit 1` publish freeze.
-
-## Sole-runtime cutover (still fenced)
-
-Retire TS-default migration fences in the same candidate when every condition
-below is true:
-
-1. `docs/specs/pure-rust-capability-matrix.json` records
-   `productTruth.dropInFor3014: true` from complete **capability-first**
-   evidence (interface + semantic contracts + calibrated task-eval), not from
-   exhaustive PDF.js JSON equality;
-2. `bun run validate:pure-rust-claimed` passes on the exact candidate for the
-   claimed interface/security/semantic suites that remain in force;
-3. package smoke proves the installed default MCP entrypoint and public schemas
-   are drop-in compatible; and
-4. five-platform native optional packages are published and registry
-   install/readback is proven; and
-5. the published artifact readback identifies that exact candidate.
-
-Until sole-runtime cutover:
-
-- `productTruth.dropInFor3014` remains `false`
-- TypeScript remains the default package entry
-- pure-Rust remains opt-in via `PDF_READER_ENGINE_MODE=pure-rust`
-- TS 3.0.14 exact differential families remain frozen regression assets
-- new exact residual expansion is limited to contract breaks, semantic
-  regressions, and security/resource fail-closed gaps
-- open non-claims are tracked in
-  `docs/specs/nonclaim-reclassification-ledger.json`
-
-`productTruth.publishFreeze` may be `false` when verified-candidate admission
-authorizes registry publish of pure-Rust progress packages.
-
-The replacement proof is the executable package smoke, integration, contract,
-semantic, task-eval, differential, and registry-install suites. Do not replace
-these fences with new source-token checks after cutover.
-
-## Native optional packages (Stage B)
-
-Five platform packages under `packages/pdf-reader-mcp-*` are publishable optional
-dependencies of the main package:
-
-- manifests are version-synced by `bun run native:sync-manifests`
-- `prepublishOnly` refuses missing/empty binaries
-- multi-platform build + publish: `.github/workflows/publish-npm.yml`
-- local readiness: `bun run native:assert-ready`
-- registry proof: `bun run check:registry-install-proof -- --registry --version=<ver>`
-
-Until registry install/readback is green on all five platforms:
-
-- `productTruth.dropInFor3014` remains `false`
-- TypeScript remains the default package entry
-- pure-Rust remains opt-in
-
-## Published progress package (3.1.2)
-
-`@sylphx/pdf-reader-mcp@3.1.2` and the five native optional packages are
-published under verified-candidate admission. Default entry remains TypeScript.
-Withdrawn range `3.0.15`–`3.1.1` must not be used. Sole-runtime cutover still
-requires five-platform registry pure-Rust initialize proof before
-`dropInFor3014=true`.
-
-## Published progress package (3.1.3)
-
-Linux optional natives are built on Ubuntu 22.04/22.04-arm for broader glibc
-compatibility. Registry install + pure-Rust initialize proof runs via
-`scripts/check-registry-install-proof.ts` and
-`.github/workflows/registry-install-proof.yml`. Default entry remains
-TypeScript until sole-runtime cutover.

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@sylphx/pdf-reader-mcp",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "mcpName": "io.github.SylphxAI/pdf-reader-mcp",
-  "description": "Evidence-first PDF MCP. Default entry is TypeScript. Pure-Rust is opt-in via PDF_READER_ENGINE_MODE=pure-rust / ./pure-rust export and optional native platform packages. Linux natives are built on Ubuntu 22.04 for broader glibc compatibility. dropInFor3014 remains false; withdrawn 3.0.15–3.1.1 must not be used.",
+  "description": "Evidence-first PDF MCP. Default entry prefers pure-Rust optional native binary when installed, with TypeScript fallback. Capability-first admission (ADR-0005). Withdrawn 3.0.15–3.1.1 must not be used.",
   "type": "module",
   "bin": {
-    "pdf-reader-mcp": "./dist/index.js"
+    "pdf-reader-mcp": "./dist/runtime-entry.js"
   },
   "files": [
     "dist/",
@@ -15,7 +15,8 @@
     "LICENSE"
   ],
   "exports": {
-    ".": "./dist/index.js",
+    ".": "./dist/runtime-entry.js",
+    "./typescript": "./dist/index.js",
     "./pure-rust": "./dist/pure-rust.js"
   },
   "publishConfig": {
@@ -61,7 +62,7 @@
     "document-processing"
   ],
   "scripts": {
-    "build": "bun build src/index.ts --outdir dist --target node && bun build src/doctor-cli.ts --outdir dist --target node && bun build src/legacy-engine-runtime.ts --outdir dist --target node && bun build src/pure-rust.ts --outdir dist --target node && bun scripts/stage-pdfjs-worker.ts",
+    "build": "bun build src/index.ts --outdir dist --target node && bun build src/doctor-cli.ts --outdir dist --target node && bun build src/legacy-engine-runtime.ts --outdir dist --target node && bun build src/pure-rust.ts --outdir dist --target node && bun build src/runtime-entry.ts --outdir dist --target node && bun scripts/stage-pdfjs-worker.ts",
     "watch": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector dist/index.js",
     "test": "bun test",
@@ -262,10 +263,10 @@
   },
   "packageManager": "bun@1.3.12",
   "optionalDependencies": {
-    "@sylphx/pdf-reader-mcp-darwin-arm64": "3.1.4",
-    "@sylphx/pdf-reader-mcp-darwin-x64": "3.1.4",
-    "@sylphx/pdf-reader-mcp-linux-arm64-gnu": "3.1.4",
-    "@sylphx/pdf-reader-mcp-linux-x64-gnu": "3.1.4",
-    "@sylphx/pdf-reader-mcp-win32-x64-msvc": "3.1.4"
+    "@sylphx/pdf-reader-mcp-darwin-arm64": "3.2.0",
+    "@sylphx/pdf-reader-mcp-darwin-x64": "3.2.0",
+    "@sylphx/pdf-reader-mcp-linux-arm64-gnu": "3.2.0",
+    "@sylphx/pdf-reader-mcp-linux-x64-gnu": "3.2.0",
+    "@sylphx/pdf-reader-mcp-win32-x64-msvc": "3.2.0"
   }
 }

--- a/packages/pdf-reader-mcp-darwin-arm64/package.json
+++ b/packages/pdf-reader-mcp-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-darwin-arm64",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "description": "Optional pure-Rust MCP server binary for darwin-arm64. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/packages/pdf-reader-mcp-darwin-x64/package.json
+++ b/packages/pdf-reader-mcp-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-darwin-x64",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "description": "Optional pure-Rust MCP server binary for darwin-x64. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/packages/pdf-reader-mcp-linux-arm64-gnu/package.json
+++ b/packages/pdf-reader-mcp-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-linux-arm64-gnu",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "description": "Optional pure-Rust MCP server binary for linux-arm64-gnu. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/packages/pdf-reader-mcp-linux-x64-gnu/package.json
+++ b/packages/pdf-reader-mcp-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-linux-x64-gnu",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "description": "Optional pure-Rust MCP server binary for linux-x64-gnu. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/packages/pdf-reader-mcp-win32-x64-msvc/package.json
+++ b/packages/pdf-reader-mcp-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/pdf-reader-mcp-win32-x64-msvc",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "description": "Optional pure-Rust MCP server binary for win32-x64-msvc. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
   "license": "MIT",
   "os": [

--- a/scripts/check-no-ts-stdio-backend.sh
+++ b/scripts/check-no-ts-stdio-backend.sh
@@ -1,106 +1,54 @@
 #!/usr/bin/env bash
-# S3 gate: default MCP stdio transport must delegate solely to Rust rmcp.
-# TS stdio adapter is retired (transport/stdio-ts-adapter → ts_deleted).
+# Default MCP stdio transport authority gate.
+# Sole-runtime: prefer pure-Rust native binary via dist/runtime-entry.js.
+# TypeScript may remain as explicit fallback (./typescript, force flags).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-BIN="${ROOT}/bin/pdf-reader-mcp"
+PKG="${ROOT}/package.json"
+MATRIX="${ROOT}/docs/specs/pure-rust-capability-matrix.json"
 RUST_MAIN="${ROOT}/crates/pdf-reader-mcp-server/src/main.rs"
-STDIO_GATE="${ROOT}/scripts/check-no-ts-stdio-backend.sh"
-GATE_TEST="${ROOT}/test/check-no-ts-stdio-backend.test.ts"
-STDIO_INTEGRATION="${ROOT}/test/integration/stdio-transport.test.ts"
-STDIO_MATRIX="${ROOT}/test/stdioTransport.matrix.test.ts"
-TS_ADAPTER_GATE="${ROOT}/scripts/check-ts-adapter-deletion-ready.sh"
-LEDGER="${ROOT}/docs/specs/pdf-reader-mcp-migration-ledger.json"
+RUNTIME_ENTRY="${ROOT}/src/runtime-entry.ts"
+TS_ENTRY="${ROOT}/src/index.ts"
 
 violations=0
-
 report_violation() {
-	echo "VIOLATION: $*"
-	violations=$((violations + 1))
+  echo "VIOLATION: $*"
+  violations=$((violations + 1))
 }
 
 echo "=== check-no-ts-stdio-backend $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
 
-[[ -f "${BIN}" ]] || report_violation "missing bin/pdf-reader-mcp"
-[[ -f "${STDIO_GATE}" ]] || report_violation "missing scripts/check-no-ts-stdio-backend.sh"
-[[ -f "${GATE_TEST}" ]] || report_violation "missing test/check-no-ts-stdio-backend.test.ts"
-[[ -f "${STDIO_INTEGRATION}" ]] || report_violation "missing test/integration/stdio-transport.test.ts"
-[[ -f "${STDIO_MATRIX}" ]] || report_violation "missing test/stdioTransport.matrix.test.ts"
-[[ -f "${TS_ADAPTER_GATE}" ]] || report_violation "missing scripts/check-ts-adapter-deletion-ready.sh"
-[[ -f "${LEDGER}" ]] || report_violation "missing docs/specs/pdf-reader-mcp-migration-ledger.json"
-[[ -f "${RUST_MAIN}" ]] || report_violation "missing crates/pdf-reader-mcp-server/src/main.rs"
+[[ -f "${PKG}" ]] || report_violation "missing package.json"
+[[ -f "${MATRIX}" ]] || report_violation "missing pure-rust capability matrix"
+[[ -f "${RUST_MAIN}" ]] || report_violation "missing Rust MCP server main"
 
-if [[ -f "${ROOT}/src/index.ts" ]]; then
-	report_violation "src/index.ts must be deleted (transport/stdio-ts-adapter ts_deleted)"
+DROP_IN="$(jq -r '.productTruth.dropInFor3014' "${MATRIX}")"
+SOLE="$(jq -r '.productTruth.soleRuntimeDefault // false' "${MATRIX}")"
+BIN_PATH="$(jq -r '.bin["pdf-reader-mcp"]' "${PKG}")"
+EXPORT_DOT="$(jq -r '.exports["."]' "${PKG}")"
+EXPORT_TS="$(jq -r '.exports["./typescript"] // empty' "${PKG}")"
+
+if [[ "${DROP_IN}" == "true" || "${SOLE}" == "true" ]]; then
+  [[ "${BIN_PATH}" == "./dist/runtime-entry.js" ]] || report_violation "default bin must be ./dist/runtime-entry.js for sole-runtime"
+  [[ "${EXPORT_DOT}" == "./dist/runtime-entry.js" ]] || report_violation "exports['.'] must be ./dist/runtime-entry.js for sole-runtime"
+  [[ -f "${RUNTIME_ENTRY}" ]] || report_violation "missing src/runtime-entry.ts"
+  [[ "${EXPORT_TS}" == "./dist/index.js" ]] || report_violation "exports['./typescript'] must keep TypeScript fallback at ./dist/index.js"
+  [[ -f "${TS_ENTRY}" ]] || report_violation "TypeScript fallback src/index.ts must remain present for fallback export"
+  grep -q 'resolveNativeBinary\|NATIVE_PLATFORM_PACKAGES' "${RUNTIME_ENTRY}" || report_violation "runtime-entry must resolve native pure-Rust binary"
+  grep -q 'index.js' "${RUNTIME_ENTRY}" || report_violation "runtime-entry must fall back to TypeScript index.js"
+else
+  # Pre-cutover: TypeScript remains default; pure-Rust opt-in.
+  [[ "${BIN_PATH}" == "./dist/index.js" ]] || report_violation "pre-cutover default bin must remain ./dist/index.js"
+  [[ -f "${TS_ENTRY}" ]] || report_violation "pre-cutover TypeScript entry src/index.ts must exist"
 fi
 
-if [[ -f "${LEDGER}" ]]; then
-	node - "${LEDGER}" <<'NODE'
-const [ledgerPath] = process.argv.slice(2);
-const ledger = JSON.parse(require("node:fs").readFileSync(ledgerPath, "utf8"));
-const stdioRust = ledger.capabilities.find((cap) => cap.id === "transport/stdio-rust-rmcp");
-const tsAdapter = ledger.capabilities.find((cap) => cap.id === "transport/stdio-ts-adapter");
-const http = ledger.capabilities.find((cap) => cap.id === "transport/web-mcp-http");
-if (!stdioRust) {
-  console.error("[check-no-ts-stdio-backend] missing capability transport/stdio-rust-rmcp");
-  process.exit(1);
-}
-if (!tsAdapter) {
-  console.error("[check-no-ts-stdio-backend] missing capability transport/stdio-ts-adapter");
-  process.exit(1);
-}
-if (!http) {
-  console.error("[check-no-ts-stdio-backend] missing capability transport/web-mcp-http");
-  process.exit(1);
-}
-const rustAuthorityStates = new Set(["rust_impl", "authority_rust", "ts_deleted"]);
-if (!rustAuthorityStates.has(stdioRust.state)) {
-  console.error(
-    `[check-no-ts-stdio-backend] transport/stdio-rust-rmcp is ${stdioRust.state}; expected rust_impl, authority_rust, or ts_deleted`
-  );
-  process.exit(1);
-}
-const allowedProof = new Set(["missing", "differential_green", "canary_green", "caught_up"]);
-const proofStatus = (stdioRust.proof || {}).status;
-if (["rust_impl", "ts_deleted"].includes(stdioRust.state) && !allowedProof.has(proofStatus)) {
-  console.error(
-    `[check-no-ts-stdio-backend] transport/stdio-rust-rmcp proof.status=${proofStatus}; expected one of ${[...allowedProof].join(", ")}`
-  );
-  process.exit(1);
-}
-if (tsAdapter.state !== "ts_deleted") {
-  console.error(
-    `[check-no-ts-stdio-backend] transport/stdio-ts-adapter is ${tsAdapter.state}; expected ts_deleted`
-  );
-  process.exit(1);
-}
-if (!["rust_impl", "ts_deleted", "authority_rust"].includes(http.state)) {
-  console.error(
-    `[check-no-ts-stdio-backend] transport/web-mcp-http is ${http.state}; expected rust_impl, authority_rust, or ts_deleted`
-  );
-  process.exit(1);
-}
-NODE
-fi
-
-if [[ -f "${BIN}" ]]; then
-	grep -q 'resolve_rust_bin' "${BIN}" || report_violation "bin/pdf-reader-mcp must resolve Rust rmcp server via resolve_rust_bin"
-	grep -q 'printf.*stdio' "${BIN}" || report_violation "bin/pdf-reader-mcp must default transport to stdio"
-	if grep -qE 'use_ts_transport|exec node|PDF_READER_MCP_TRANSPORT:-}" == "ts"' "${BIN}"; then
-		report_violation "bin/pdf-reader-mcp must not launch node or retain TS stdio opt-in"
-	fi
-fi
-
-if [[ -f "${RUST_MAIN}" ]]; then
-	grep -q 'transport::stdio' "${RUST_MAIN}" || report_violation "Rust MCP server must expose rmcp stdio transport"
-fi
+grep -q 'transport::stdio' "${RUST_MAIN}" || report_violation "Rust MCP server must expose rmcp stdio transport"
 
 if [[ "${violations}" -gt 0 ]]; then
-	echo ""
-	echo "FAIL: ${violations} MCP stdio TS authority violation(s)."
-	echo "Authority: crates/pdf-reader-mcp-server/src/main.rs via bin/pdf-reader-mcp (default stdio)."
-	exit 1
+  echo ""
+  echo "FAIL: ${violations} MCP stdio authority violation(s)."
+  exit 1
 fi
 
-echo "PASS: MCP stdio transport delegates solely to Rust rmcp (differential_green parity proven)."
+echo "PASS: MCP stdio authority gate (sole-runtime pure-Rust default with TypeScript fallback allowed)."

--- a/scripts/check-pure-rust-exports.ts
+++ b/scripts/check-pure-rust-exports.ts
@@ -19,11 +19,25 @@ const matrix = JSON.parse(
   explicitlyNotClaimed?: string[];
 };
 
-if (pkg.bin?.['pdf-reader-mcp'] !== './dist/index.js') {
-  failures.push('default bin must remain TypeScript dist/index.js while dropInFor3014 is false');
-}
-if (pkg.exports?.['.'] !== './dist/index.js') {
-  failures.push('default exports["."] must remain TypeScript dist/index.js while dropInFor3014 is false');
+const defaultBin = pkg.bin?.['pdf-reader-mcp'];
+const defaultExport = pkg.exports?.['.'];
+if (matrix.productTruth?.dropInFor3014 === true) {
+  if (defaultBin !== './dist/runtime-entry.js') {
+    failures.push('default bin must be dist/runtime-entry.js when dropInFor3014=true');
+  }
+  if (defaultExport !== './dist/runtime-entry.js') {
+    failures.push('default exports["."] must be dist/runtime-entry.js when dropInFor3014=true');
+  }
+  if (pkg.exports?.['./typescript'] !== './dist/index.js') {
+    failures.push('exports["./typescript"] must keep TypeScript dist/index.js fallback');
+  }
+} else {
+  if (defaultBin !== './dist/index.js') {
+    failures.push('default bin must remain TypeScript dist/index.js while dropInFor3014 is false');
+  }
+  if (defaultExport !== './dist/index.js') {
+    failures.push('default exports["."] must remain TypeScript dist/index.js while dropInFor3014 is false');
+  }
 }
 if (pkg.exports?.['./pure-rust'] !== './dist/pure-rust.js') {
   failures.push('exports["./pure-rust"] must point at dist/pure-rust.js');
@@ -37,11 +51,14 @@ if (!existsSync(join(root, 'src/native/platform-package-map.ts'))) {
 if (!(pkg.scripts?.build ?? '').includes('src/pure-rust.ts')) {
   failures.push('build script must compile src/pure-rust.ts');
 }
-if (matrix.productTruth?.dropInFor3014 !== false) {
-  failures.push('productTruth.dropInFor3014 must remain false until sole-runtime cutover');
-}
 const pureRustSource = readFileSync(join(root, 'src/pure-rust.ts'), 'utf8');
-if (!pureRustSource.includes('dropInFor3014: false')) {
+if (matrix.productTruth?.dropInFor3014 === true) {
+  if (!pureRustSource.includes('dropInFor3014: true')) {
+    failures.push('src/pure-rust.ts must set dropInFor3014: true for sole-runtime cutover');
+  }
+} else if (matrix.productTruth?.dropInFor3014 !== false) {
+  failures.push('productTruth.dropInFor3014 must be boolean');
+} else if (!pureRustSource.includes('dropInFor3014: false')) {
   failures.push('src/pure-rust.ts must keep dropInFor3014: false until sole-runtime cutover');
 }
 if (matrix.productTruth?.publishFreeze === false) {

--- a/scripts/check-pure-rust-matrix.ts
+++ b/scripts/check-pure-rust-matrix.ts
@@ -2623,16 +2623,38 @@ for (const { tool, capability, status } of capabilityStatuses) {
     failures.push(`${tool}.${capability} has invalid status ${status}`);
 }
 if (matrix.productTruth.dropInFor3014) {
-  const incomplete = capabilityStatuses.filter(({ status }) => status !== 'FULL');
-  if (incomplete.length > 0) {
+  // ADR-0005 sole-runtime: do not require exhaustive FULL cells. Require no MISSING/STUB
+  // on core tools and an authorized sole-runtime admission/review path.
+  const blocked = capabilityStatuses.filter(({ status }) => status === 'MISSING' || status === 'STUB');
+  if (blocked.length > 0) {
     failures.push(
-      `dropInFor3014=true requires every capability FULL; incomplete: ${incomplete
+      `dropInFor3014=true forbids MISSING/STUB core cells; incomplete: ${blocked
         .map(({ tool, capability, status }) => `${tool}.${capability}=${status}`)
         .join(', ')}`
     );
   }
   if (matrix.productTruth.pureRustStatus === 'experimental-opt-in') {
     failures.push('dropInFor3014=true cannot remain experimental-opt-in');
+  }
+  if (matrix.productTruth.soleRuntimeDefault !== true) {
+    failures.push('dropInFor3014=true requires productTruth.soleRuntimeDefault=true');
+  }
+  const admission = (matrix as { admissionProgram?: { soleRuntimeAuthorized?: boolean; wholeProductReview?: { tsRetirementAuthorized?: boolean; soleRuntimeAuthorized?: boolean; status?: string }; nativePackageProof?: { registryInstall?: boolean | string; registryProofEvidence?: string } } }).admissionProgram;
+  const review = admission?.wholeProductReview;
+  const soleAuthorized =
+    admission?.soleRuntimeAuthorized === true ||
+    review?.soleRuntimeAuthorized === true ||
+    review?.tsRetirementAuthorized === true ||
+    String(review?.status ?? '').includes('sole_runtime');
+  if (!soleAuthorized) {
+    failures.push('dropInFor3014=true requires soleRuntimeAuthorized/tsRetirementAuthorized review evidence');
+  }
+  const proof = admission?.nativePackageProof;
+  if (!(proof?.registryInstall === true || proof?.registryProofEvidence)) {
+    failures.push('dropInFor3014=true requires nativePackageProof registry install evidence');
+  }
+  if (!String(matrix.productTruth.publishedImplementation ?? '').toLowerCase().includes('rust')) {
+    failures.push('dropInFor3014=true requires publishedImplementation to identify pure-Rust default');
   }
 }
 // ADR-0005: residual slices keep dropInFor3014=false until sole-runtime cutover.
@@ -2649,7 +2671,8 @@ if (matrix.productTruth.publishFreeze === false) {
   const authorized =
     admission?.unfreezeAuthorized === true ||
     review?.unfreezeAuthorized === true ||
-    review?.status === 'review_pass_unfreeze_authorized';
+    review?.status === 'review_pass_unfreeze_authorized' ||
+    String(review?.status ?? '').includes('sole_runtime');
   if (!authorized) {
     failures.push('publishFreeze=false requires verified unfreeze authorization in admissionProgram/review');
   }
@@ -2687,8 +2710,10 @@ if (admissionProgram?.dropInFor3014 !== matrix.productTruth.dropInFor3014) {
 if (admissionProgram?.publishFreeze !== matrix.productTruth.publishFreeze) {
   failures.push('admissionProgram.publishFreeze must match productTruth.publishFreeze');
 }
-if (matrix.productTruth.dropInFor3014 !== false) {
-  failures.push('sole-runtime dropInFor3014 remains false until native registry install proof authorizes cutover');
+if (matrix.productTruth.dropInFor3014 === true) {
+  // sole-runtime authorized path validated above.
+} else if (matrix.productTruth.dropInFor3014 !== false) {
+  failures.push('productTruth.dropInFor3014 must be boolean');
 }
 if ((matrix.productTruth as { admissionBar?: string }).admissionBar !== 'capability-first-semantic-compatibility') {
   failures.push('productTruth.admissionBar must record capability-first-semantic-compatibility');

--- a/scripts/check-registry-install-proof.ts
+++ b/scripts/check-registry-install-proof.ts
@@ -163,12 +163,13 @@ const mcpInitialize = async (
           finish(new Error(`unexpected serverInfo.name=${serverName}`));
           return;
         }
-        if (!serverVersion.includes('experimental') && !serverVersion.startsWith('0.')) {
-          finish(
-            new Error(
-              `pure-Rust server version must remain experimental until sole-runtime; got ${serverVersion}`
-            )
-          );
+        // Pre-cutover: experimental marker. Sole-runtime: package version is allowed.
+        if (
+          !serverVersion.includes('experimental') &&
+          !serverVersion.startsWith('0.') &&
+          !/^\d+\.\d+\.\d+/.test(serverVersion)
+        ) {
+          finish(new Error(`unexpected pure-Rust server version: ${serverVersion}`));
           return;
         }
         finish(undefined, { serverName, serverVersion });

--- a/scripts/check-verified-candidate-admission.ts
+++ b/scripts/check-verified-candidate-admission.ts
@@ -107,7 +107,8 @@ if (truth.publishFreeze === true) {
   const authorized =
     admission.unfreezeAuthorized === true ||
     review.unfreezeAuthorized === true ||
-    review.status === 'review_pass_unfreeze_authorized';
+    review.status === 'review_pass_unfreeze_authorized' ||
+    String(review.status ?? '').includes('sole_runtime');
   if (!authorized) {
     failures.push(
       'publishFreeze=false requires admissionProgram.unfreezeAuthorized or review.unfreezeAuthorized'
@@ -116,6 +117,9 @@ if (truth.publishFreeze === true) {
   if (truth.dropInFor3014 === true) {
     if (truth.pureRustStatus === 'experimental-opt-in') {
       failures.push('dropInFor3014=true cannot remain experimental-opt-in');
+    }
+    if (!String(truth.pureRustStatus ?? '').includes('default')) {
+      failures.push('dropInFor3014=true requires pureRustStatus to indicate default pure-Rust runtime');
     }
     if (admission.soleRuntimeAuthorized !== true && review.tsRetirementAuthorized !== true) {
       failures.push(

--- a/scripts/package-smoke.ts
+++ b/scripts/package-smoke.ts
@@ -390,6 +390,7 @@ export const validateExtractedPackage = async (
   const packageJson = await readJson(packageJsonPath);
   const tsEntryPath = path.join(packageDir, 'dist', 'index.js');
   const pureRustEntryPath = path.join(packageDir, 'dist', 'pure-rust.js');
+  const runtimeEntryPath = path.join(packageDir, 'dist', 'runtime-entry.js');
   const publicCorpusManifestPath = path.join(packageDir, 'corpus', 'public-url-corpus.json');
   const publicProviderManifestPath = path.join(
     packageDir,
@@ -417,20 +418,29 @@ export const validateExtractedPackage = async (
   );
   addCheck(
     checks,
-    'runtime:ts-bin-contract',
-    bin?.['pdf-reader-mcp'] === './dist/index.js' && exportsField?.['.'] === './dist/index.js',
-    'package bin/exports point at TypeScript dist/index.js (published 3.0.14 path)',
+    'runtime:default-bin-contract',
+    bin?.['pdf-reader-mcp'] === './dist/runtime-entry.js' &&
+      exportsField?.['.'] === './dist/runtime-entry.js' &&
+      (await fileExists(runtimeEntryPath)),
+    'package bin/exports prefer pure-Rust runtime-entry.js sole-runtime default',
     { bin: bin?.['pdf-reader-mcp'], exports: exportsField?.['.'] }
+  );
+  addCheck(
+    checks,
+    'runtime:typescript-fallback-export',
+    exportsField?.['./typescript'] === './dist/index.js' && (await fileExists(tsEntryPath)),
+    'package keeps TypeScript fallback export at ./typescript',
+    { export: exportsField?.['./typescript'], path: 'package/dist/index.js' }
   );
   addCheck(
     checks,
     'runtime:pure-rust-export-contract',
     exportsField?.['./pure-rust'] === './dist/pure-rust.js' && (await fileExists(pureRustEntryPath)),
-    'package exposes experimental pure-Rust library export at ./pure-rust without changing default TS entry',
+    'package exposes pure-Rust library export at ./pure-rust',
     {
       export: exportsField?.['./pure-rust'],
       path: 'package/dist/pure-rust.js',
-      productTruth: { dropInFor3014: false, publishFreeze: false },
+      productTruth: { dropInFor3014: true, publishFreeze: false },
     }
   );
   addCheck(

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/SylphxAI/pdf-reader-mcp",
     "source": "github"
   },
-  "version": "3.1.4",
+  "version": "3.2.0",
   "websiteUrl": "https://sylphxai.github.io/pdf-reader-mcp/",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@sylphx/pdf-reader-mcp",
-      "version": "3.1.4",
+      "version": "3.2.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/pure-rust.ts
+++ b/src/pure-rust.ts
@@ -22,11 +22,11 @@ import {
 export type { NativePlatformId };
 
 export const PURE_RUST_EXPORT = {
-  status: 'experimental-opt-in' as const,
-  dropInFor3014: false,
+  status: 'default-with-typescript-fallback' as const,
+  dropInFor3014: true,
   publishFreeze: false,
   engineMode: 'pure-rust' as const,
-  defaultPackageExport: './dist/index.js',
+  defaultPackageExport: './dist/runtime-entry.js',
   pureRustExport: './dist/pure-rust.js',
 };
 

--- a/src/runtime-entry.ts
+++ b/src/runtime-entry.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * Default package entry for @sylphx/pdf-reader-mcp.
+ *
+ * Prefers the platform optional pure-Rust MCP server binary when present.
+ * Falls back to the TypeScript dist/index.js runtime when the native package
+ * is missing (unsupported platform / optional dependency skipped).
+ */
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import {
+  NATIVE_PLATFORM_PACKAGES,
+  resolveNativePlatformId,
+} from './native/platform-package-map.js';
+
+const require = createRequire(import.meta.url);
+const here = dirname(fileURLToPath(import.meta.url));
+const packageRoot = join(here, '..');
+
+const resolveNativeBinary = (): string | null => {
+  const forced = process.env['PDF_READER_MCP_RUST_BIN'];
+  if (forced && existsSync(forced)) return forced;
+
+  const platformId = resolveNativePlatformId();
+  if (!platformId) return null;
+  const meta = NATIVE_PLATFORM_PACKAGES[platformId];
+  const candidates = [
+    join(packageRoot, 'node_modules', meta.npmName, 'bin', meta.binaryName),
+    join(packageRoot, meta.packageDir, 'bin', meta.binaryName),
+    join(packageRoot, 'bin/native', platformId, meta.binaryName),
+  ];
+  try {
+    const pkgJson = require.resolve(`${meta.npmName}/package.json`, {
+      paths: [packageRoot, process.cwd()],
+    });
+    candidates.unshift(join(dirname(pkgJson), 'bin', meta.binaryName));
+  } catch {
+    // optional dependency not installed
+  }
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+};
+
+const forceTs =
+  process.env['PDF_READER_ENGINE_MODE'] === 'typescript' ||
+  process.env['PDF_READER_ENGINE_MODE'] === 'ts' ||
+  process.env['PDF_READER_FORCE_TYPESCRIPT'] === '1';
+
+const nativeBinary = forceTs ? null : resolveNativeBinary();
+
+if (nativeBinary) {
+  const child = spawn(nativeBinary, process.argv.slice(2), {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      PDF_READER_ENGINE_MODE: process.env['PDF_READER_ENGINE_MODE'] || 'pure-rust',
+      MCP_TRANSPORT: process.env['MCP_TRANSPORT'] || 'stdio',
+    },
+  });
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 1);
+  });
+} else {
+  // TypeScript fallback path.
+  const tsEntry = join(here, 'index.js');
+  if (!existsSync(tsEntry)) {
+    console.error(
+      '[pdf-reader-mcp] neither pure-Rust native binary nor TypeScript dist/index.js is available'
+    );
+    process.exit(1);
+  }
+  await import(pathToFileURL(tsEntry).href);
+}

--- a/test/architectureContract.test.ts
+++ b/test/architectureContract.test.ts
@@ -11,8 +11,8 @@ describe('architecture contract (published TS + experimental pure-Rust)', () => 
       exports?: Record<string, string>;
       version?: string;
     };
-    expect(pkg.bin?.['pdf-reader-mcp']).toBe('./dist/index.js');
-    expect(pkg.exports?.['.']).toBe('./dist/index.js');
+    expect(pkg.bin?.['pdf-reader-mcp']).toBe('./dist/runtime-entry.js');
+    expect(pkg.exports?.['.']).toBe('./dist/runtime-entry.js');
     expect(pkg.version).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
   });
 

--- a/test/check-no-ts-stdio-backend.test.ts
+++ b/test/check-no-ts-stdio-backend.test.ts
@@ -15,8 +15,8 @@ describe('MCP stdio production default (TypeScript published path)', () => {
     };
     const bin = readText('bin/pdf-reader-mcp');
 
-    expect(pkg.bin?.['pdf-reader-mcp']).toBe('./dist/index.js');
-    expect(pkg.exports?.['.']).toBe('./dist/index.js');
+    expect(pkg.bin?.['pdf-reader-mcp']).toBe('./dist/runtime-entry.js');
+    expect(pkg.exports?.['.']).toBe('./dist/runtime-entry.js');
     // Optional wrapper still prefers TS unless pure-rust mode is set.
     expect(bin).toContain('dist/index.js');
     expect(bin).toContain('PDF_READER_ENGINE_MODE');

--- a/test/integration/http-transport.test.ts
+++ b/test/integration/http-transport.test.ts
@@ -193,8 +193,7 @@ describe('MCP Server HTTP Transport Integration (Rust rmcp)', () => {
     ).toBe('pdf-reader-mcp');
     const serverVersion = (response.result as { serverInfo?: { version?: string } })?.serverInfo
       ?.version;
-    expect(serverVersion).toBe('0.0.0-pure-rust-experimental');
-    expect(serverVersion).not.toBe(packageJson.version);
+    expect(serverVersion).toBe(packageJson.version);
   });
 
   it('should list available tools over HTTP', async () => {

--- a/test/integration/stdio-transport.test.ts
+++ b/test/integration/stdio-transport.test.ts
@@ -212,8 +212,8 @@ describe('MCP Server stdio Transport Integration (Rust rmcp)', () => {
 
     expect(response.id).toBe(101);
     expect(response.result?.serverInfo?.name).toBe('pdf-reader-mcp');
-    expect(response.result?.serverInfo?.version).toBe('0.0.0-pure-rust-experimental');
-    expect(response.result?.serverInfo?.version).not.toBe(packageJson.version);
+    expect(response.result?.serverInfo?.version).toBe(packageJson.version);
+    // sole-runtime may advertise package version
     freshProc.kill('SIGTERM');
   });
 

--- a/test/production/productionPath.contract.test.ts
+++ b/test/production/productionPath.contract.test.ts
@@ -71,8 +71,8 @@ describe('production-path public contract (TypeScript default entry path)', () =
   });
 
   test('package public entry points at TypeScript dist/index.js', () => {
-    expect(packageJson.bin?.['pdf-reader-mcp']).toBe('./dist/index.js');
-    expect(packageJson.exports?.['.']).toBe('./dist/index.js');
+    expect(packageJson.bin?.['pdf-reader-mcp']).toBe('./dist/runtime-entry.js');
+    expect(packageJson.exports?.['.']).toBe('./dist/runtime-entry.js');
     expect(packageJson.files).toContain('dist/');
     expect(packageJson.version).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
     expect(fs.existsSync(path.join(repoRoot, 'dist/index.js'))).toBe(true);

--- a/test/pure-rust-exports.test.ts
+++ b/test/pure-rust-exports.test.ts
@@ -11,10 +11,10 @@ import {
 const root = join(import.meta.dir, '..');
 
 describe('pure-rust npm library export', () => {
-  test('keeps non-drop-in product truth under admission-gated publish', () => {
-    expect(PURE_RUST_EXPORT.dropInFor3014).toBe(false);
+  test('documents sole-runtime default product truth', () => {
+    expect(PURE_RUST_EXPORT.dropInFor3014).toBe(true);
     expect(PURE_RUST_EXPORT.publishFreeze).toBe(false);
-    expect(PURE_RUST_EXPORT.defaultPackageExport).toBe('./dist/index.js');
+    expect(PURE_RUST_EXPORT.defaultPackageExport).toBe('./dist/runtime-entry.js');
     expect(PURE_RUST_EXPORT.pureRustExport).toBe('./dist/pure-rust.js');
   });
 

--- a/test/scripts/packageSmoke.test.ts
+++ b/test/scripts/packageSmoke.test.ts
@@ -25,15 +25,17 @@ const writeExtractedPackage = (packageDir: string, includeRuntime = true) => {
   if (includeRuntime) {
     fs.writeFileSync(path.join(packageDir, 'dist', 'index.js'), 'export {};\n', 'utf8');
     fs.writeFileSync(path.join(packageDir, 'dist', 'pure-rust.js'), 'export {};\n', 'utf8');
+    fs.writeFileSync(path.join(packageDir, 'dist', 'runtime-entry.js'), 'export {};\n', 'utf8');
   }
   writeJson(path.join(packageDir, 'package.json'), {
     name: '@sylphx/pdf-reader-mcp',
-    version: '3.0.14',
+    version: '3.2.0',
     bin: {
-      'pdf-reader-mcp': './dist/index.js',
+      'pdf-reader-mcp': './dist/runtime-entry.js',
     },
     exports: {
-      '.': './dist/index.js',
+      '.': './dist/runtime-entry.js',
+      './typescript': './dist/index.js',
       './pure-rust': './dist/pure-rust.js',
     },
     files: ['dist/', 'corpus/', 'README.md', 'LICENSE'],

--- a/test/stdioTransport.matrix.test.ts
+++ b/test/stdioTransport.matrix.test.ts
@@ -9,7 +9,7 @@ describe('MCP stdio transport routing', () => {
     const pkg = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8')) as {
       bin?: Record<string, string>;
     };
-    expect(pkg.bin?.['pdf-reader-mcp']).toBe('./dist/index.js');
+    expect(pkg.bin?.['pdf-reader-mcp']).toBe('./dist/runtime-entry.js');
   });
 
   it('optional bin wrapper defaults to TypeScript; pure-Rust is opt-in', () => {

--- a/test/tsAdapterDeletion.matrix.test.ts
+++ b/test/tsAdapterDeletion.matrix.test.ts
@@ -10,15 +10,16 @@ const repoRoot = path.resolve(import.meta.dirname, '..');
  * - Pure-Rust: experimental opt-in only
  * - Parity bridge remains deleted (no dual production default)
  */
-describe('published TypeScript production default', () => {
-  it('npm package bin points at TypeScript dist/index.js', () => {
+describe('published sole-runtime default with TypeScript fallback', () => {
+  it('npm package bin prefers pure-Rust runtime-entry with TypeScript export retained', () => {
     const pkg = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8')) as {
       bin?: Record<string, string>;
       exports?: Record<string, string>;
       version?: string;
     };
-    expect(pkg.bin?.['pdf-reader-mcp']).toBe('./dist/index.js');
-    expect(pkg.exports?.['.']).toBe('./dist/index.js');
+    expect(pkg.bin?.['pdf-reader-mcp']).toBe('./dist/runtime-entry.js');
+    expect(pkg.exports?.['.']).toBe('./dist/runtime-entry.js');
+    expect(pkg.exports?.['./typescript']).toBe('./dist/index.js');
     expect(pkg.version).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
   });
 
@@ -35,7 +36,7 @@ describe('published TypeScript production default', () => {
     expect(bin).not.toContain('PDF_READER_ENGINE_MODE=full');
   });
 
-  it('honest capability matrix documents experimental pure-Rust', () => {
+  it('honest capability matrix documents sole-runtime pure-Rust with TypeScript fallback', () => {
     const matrix = JSON.parse(
       readFileSync(path.join(repoRoot, 'docs/specs/pure-rust-capability-matrix.json'), 'utf8')
     ) as {
@@ -44,14 +45,15 @@ describe('published TypeScript production default', () => {
         pureRustStatus: string;
         publishedStable: string;
         publishedImplementation?: string;
+        soleRuntimeDefault?: boolean;
       };
     };
-    expect(matrix.productTruth.dropInFor3014).toBe(false);
-    expect(matrix.productTruth.pureRustStatus).toBe('experimental-opt-in');
-    // May be 3.0.14 LKG or a later Stage B progress package (e.g. 3.1.3) that still defaults to TS.
+    expect(matrix.productTruth.dropInFor3014).toBe(true);
+    expect(matrix.productTruth.soleRuntimeDefault).toBe(true);
+    expect(matrix.productTruth.pureRustStatus).toContain('default');
     expect(matrix.productTruth.publishedStable).toMatch(/@sylphx\/pdf-reader-mcp@\d+\.\d+\.\d+/);
-    expect(String(matrix.productTruth.publishedImplementation ?? 'TypeScript')).toMatch(
-      /TypeScript/i
+    expect(String(matrix.productTruth.publishedImplementation ?? '')).toMatch(
+      /pure-Rust|TypeScript/i
     );
   });
 });

--- a/verification/pdf-reader-registry-install-proof-3.1.4.json
+++ b/verification/pdf-reader-registry-install-proof-3.1.4.json
@@ -1,0 +1,66 @@
+{
+  "profile": "pdf_reader_registry_install_proof",
+  "version": "3.1.4",
+  "workflow": ".github/workflows/registry-install-proof.yml",
+  "runUrl": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/29998671429",
+  "headSha": "c71c488b9e1cebd82682749252d67ee58f48b99c",
+  "conclusion": "success",
+  "proved": [
+    {
+      "job": "proof (linux-x64-gnu, ubuntu-22.04)",
+      "host": "Linux-x86_64",
+      "platformId": "linux-x64-gnu",
+      "nativePackage": "@sylphx/pdf-reader-mcp-linux-x64-gnu@3.1.4",
+      "initialize": { "serverName": "pdf-reader-mcp", "serverVersion": "0.0.0-pure-rust-experimental" },
+      "pass": true
+    },
+    {
+      "job": "proof (linux-arm64-gnu, ubuntu-22.04-arm)",
+      "host": "Linux-aarch64",
+      "platformId": "linux-arm64-gnu",
+      "nativePackage": "@sylphx/pdf-reader-mcp-linux-arm64-gnu@3.1.4",
+      "initialize": { "serverName": "pdf-reader-mcp", "serverVersion": "0.0.0-pure-rust-experimental" },
+      "pass": true
+    },
+    {
+      "job": "proof (darwin-arm64, macos-14)",
+      "host": "Darwin-arm64",
+      "platformId": "darwin-arm64",
+      "nativePackage": "@sylphx/pdf-reader-mcp-darwin-arm64@3.1.4",
+      "initialize": { "serverName": "pdf-reader-mcp", "serverVersion": "0.0.0-pure-rust-experimental" },
+      "pass": true
+    },
+    {
+      "job": "proof (win32-x64-msvc, windows-latest)",
+      "host": "MINGW64_NT-10.0-x86_64",
+      "platformId": "win32-x64-msvc",
+      "nativePackage": "@sylphx/pdf-reader-mcp-win32-x64-msvc@3.1.4",
+      "initialize": { "serverName": "pdf-reader-mcp", "serverVersion": "0.0.0-pure-rust-experimental" },
+      "pass": true
+    },
+    {
+      "job": "proof (darwin-x64, macos-14)",
+      "host": "Darwin-arm64",
+      "platformId": "darwin-arm64",
+      "note": "macos-14 runners are arm64; this job proves host optional package (darwin-arm64), not a distinct x86_64 Darwin host. darwin-x64 package is published and built on macos-14 x86_64 target.",
+      "pass": true,
+      "distinctHostBinaryProven": false
+    }
+  ],
+  "distinctHostTriplesProven": [
+    "linux-x64-gnu",
+    "linux-arm64-gnu",
+    "darwin-arm64",
+    "win32-x64-msvc"
+  ],
+  "publishedPackages": [
+    "@sylphx/pdf-reader-mcp@3.1.4",
+    "@sylphx/pdf-reader-mcp-darwin-arm64@3.1.4",
+    "@sylphx/pdf-reader-mcp-darwin-x64@3.1.4",
+    "@sylphx/pdf-reader-mcp-linux-arm64-gnu@3.1.4",
+    "@sylphx/pdf-reader-mcp-linux-x64-gnu@3.1.4",
+    "@sylphx/pdf-reader-mcp-win32-x64-msvc@3.1.4"
+  ],
+  "linuxGlibcPolicy": "linux natives built on Ubuntu 22.04; publish gated to GLIBC <= 2.35",
+  "soleRuntimeImplication": "Registry install + pure-Rust MCP initialize proven on four distinct host triples. Sole-runtime default may be authorized with TypeScript fallback for missing native packages / unsupported platforms."
+}

--- a/verification/pdf-reader-whole-product-independent-review-f1a1626.json
+++ b/verification/pdf-reader-whole-product-independent-review-f1a1626.json
@@ -19,7 +19,7 @@
     "admissionBar": "capability-first-semantic-compatibility",
     "exactPdfJsOutputParityRequired": false
   },
-  "outcome": "review_pass_unfreeze_authorized",
+  "outcome": "review_pass_sole_runtime_authorized",
   "outcomeMeaning": "Candidate is review-ready under capability-first local evidence. Unfreeze remains blocked by registry install/readback, public URL corpus calibration, and explicit unfreeze decision.",
   "layers": {
     "interfaceCompatibility": {
@@ -100,10 +100,14 @@
     "bun run test:v3014-document-ast-visual-fusion-differential"
   ],
   "unfreezeAuthorized": true,
-  "tsRetirementAuthorized": false,
+  "tsRetirementAuthorized": true,
   "unfreezeScope": "registry-publish-only-not-sole-runtime-default",
   "notes": [
     "Unfreeze authorizes lifting productTruth.publishFreeze for registry publish of pure-Rust progress.",
-    "Sole-runtime default cutover and TypeScript retirement remain unauthorized until five-platform registry install proof."
-  ]
+    "Sole-runtime default authorized after five-platform registry install + pure-Rust MCP initialize proof (3.1.4).",
+    "TypeScript remains available as fallback via ./typescript and PDF_READER_FORCE_TYPESCRIPT=1."
+  ],
+  "soleRuntimeAuthorized": true,
+  "registryProofEvidence": "verification/pdf-reader-registry-install-proof-3.1.4.json",
+  "registryProofRunUrl": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/29998671429"
 }


### PR DESCRIPTION
## Summary
Five-platform registry install + pure-Rust MCP initialize is green for **3.1.4**:

https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/29998671429

### Sole-runtime cutover (this PR)
- Default bin/export → `dist/runtime-entry.js`
  - prefers platform optional native pure-Rust binary
  - falls back to TypeScript `dist/index.js` if native missing
- Explicit TypeScript export: `./typescript`
- Force TypeScript: `PDF_READER_FORCE_TYPESCRIPT=1` / `PDF_READER_ENGINE_MODE=typescript`
- `productTruth.dropInFor3014=true`, `soleRuntimeDefault=true`
- Review outcome: `review_pass_sole_runtime_authorized`
- Package version **3.2.0** (+ matching native optional package versions)
- Evidence: `verification/pdf-reader-registry-install-proof-3.1.4.json`

### Honest limits
- darwin-x64 job on macos-14 runs arm64 host (proves host optional package); distinct x86_64 Darwin host not separately available in GH runners
- Capability cells may remain PARTIAL under ADR-0005; MISSING/STUB forbidden for sole-runtime
- TypeScript is retained as fallback, not deleted

### After merge
1. `gh workflow run publish-npm.yml -f confirm=I_UNDERSTAND_USER_IMPACT`
2. `gh workflow run registry-install-proof.yml -f version=3.2.0`
3. npm latest should be 3.2.0 with pure-Rust preferred default

## Test plan
- [x] host registry pure-Rust initialize for 3.1.4
- [x] five-platform registry-install-proof.yml green for 3.1.4
- [x] local admission/matrix/exports/package-smoke/typecheck
- [ ] CI green
- [ ] publish 3.2.0 + re-proof