### PR TITLE
docs(release): record 3.2.0 five-platform registry pure-Rust initialize proof

### DIFF
--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -330,9 +330,8 @@
     "publishFreeze": false,
     "dropInFor3014": true,
     "nextActions": [
-      "Publish 3.2.0 main + five native packages",
-      "Re-run registry-install-proof.yml for 3.2.0",
-      "Monitor TypeScript fallback rate and remaining PARTIAL capability depth"
+      "Monitor sole-runtime 3.2.0 adoption and TypeScript fallback usage",
+      "Optionally deepen PARTIAL capabilities under ADR-0005 task-eval corpus"
     ],
     "semanticContracts": "docs/specs/semantic-contracts/",
     "agentTaskCorpus": "docs/specs/agent-task-corpus/",
@@ -353,22 +352,22 @@
       ]
     },
     "nativePackageProof": {
-      "status": "five-platform-registry-initialize-proven-for-3.1.4",
+      "status": "five-platform-registry-initialize-proven-for-3.2.0",
       "registryInstall": true,
       "packagesPublishable": true,
       "optionalDependenciesWired": true,
       "publishedVersion": "3.2.0",
       "publishedNatives": [
-        "@sylphx/pdf-reader-mcp-darwin-arm64@3.1.4",
-        "@sylphx/pdf-reader-mcp-darwin-x64@3.1.4",
-        "@sylphx/pdf-reader-mcp-linux-arm64-gnu@3.1.4",
-        "@sylphx/pdf-reader-mcp-linux-x64-gnu@3.1.4",
-        "@sylphx/pdf-reader-mcp-win32-x64-msvc@3.1.4"
+        "@sylphx/pdf-reader-mcp-darwin-arm64@3.2.0",
+        "@sylphx/pdf-reader-mcp-darwin-x64@3.2.0",
+        "@sylphx/pdf-reader-mcp-linux-arm64-gnu@3.2.0",
+        "@sylphx/pdf-reader-mcp-linux-x64-gnu@3.2.0",
+        "@sylphx/pdf-reader-mcp-win32-x64-msvc@3.2.0"
       ],
       "publishFreeze": false,
       "commands": [
-        "bun run check:registry-install-proof -- --registry --version=3.1.4",
-        "gh workflow run registry-install-proof.yml -f version=3.1.4"
+        "bun run check:registry-install-proof -- --registry --version=3.2.0",
+        "gh workflow run registry-install-proof.yml -f version=3.2.0"
       ],
       "workflow": ".github/workflows/native-package-scaffold.yml",
       "publishWorkflow": ".github/workflows/publish-npm.yml",
@@ -378,8 +377,8 @@
       ],
       "registryProofWorkflow": ".github/workflows/registry-install-proof.yml",
       "linuxBuildImage": "ubuntu-22.04 / ubuntu-22.04-arm",
-      "registryProofEvidence": "verification/pdf-reader-registry-install-proof-3.1.4.json",
-      "registryProofRunUrl": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/29998671429"
+      "registryProofEvidence": "verification/pdf-reader-registry-install-proof-3.2.0.json",
+      "registryProofRunUrl": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30008166478"
     },
     "libraryExports": {
       "status": "published-experimental-opt-in",

--- a/verification/pdf-reader-registry-install-proof-3.2.0.json
+++ b/verification/pdf-reader-registry-install-proof-3.2.0.json
@@ -1,0 +1,27 @@
+{
+  "profile": "pdf_reader_registry_install_proof",
+  "version": "3.2.0",
+  "workflow": ".github/workflows/registry-install-proof.yml",
+  "runUrl": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30008166478",
+  "conclusion": "success",
+  "defaultBin": "./dist/runtime-entry.js",
+  "serverVersionObserved": "3.2.0",
+  "distinctHostTriplesProven": [
+    "linux-x64-gnu",
+    "linux-arm64-gnu",
+    "darwin-arm64",
+    "win32-x64-msvc"
+  ],
+  "jobs": [
+    "proof (linux-x64-gnu, ubuntu-22.04)",
+    "proof (linux-arm64-gnu, ubuntu-22.04-arm)",
+    "proof (darwin-arm64, macos-14)",
+    "proof (darwin-x64, macos-14)",
+    "proof (win32-x64-msvc, windows-latest)"
+  ],
+  "notes": [
+    "All five CI jobs green for npm install + optional native binary + pure-Rust MCP initialize.",
+    "darwin-x64 job runs on arm64 macos-14 host and proves host optional package resolution.",
+    "Sole-runtime default prefers pure-Rust native with TypeScript fallback export ./typescript."
+  ]
+}


### PR DESCRIPTION
## Summary
Records live five-platform registry install + pure-Rust MCP initialize proof for sole-runtime `@sylphx/pdf-reader-mcp@3.2.0`:

https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30008166478

## Test plan
- [x] workflow green
- [x] host registry proof for 3.2.0
- [x] matrix/admission local checks