### PR TITLE
docs: mark TypeScript production default retired at sole-runtime 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,21 @@
 
 The most-starred PDF MCP server on GitHub.
 
-> **Published stable: `@sylphx/pdf-reader-mcp@3.0.14` (TypeScript path).**  
-> Pure-Rust cutover is **in progress and not published**. Versions `3.0.15`–`3.1.1`
-> are **WITHDRAWN** (deprecated on npm). Do not install them.  
-> **Publish freeze** until capability-first semantic compatibility is proven (ADR-0005) — not exact PDF.js JSON equality, and no premature releases.
+> **Published stable: `@sylphx/pdf-reader-mcp@3.2.0`.**  
+> Default entry prefers the **pure-Rust** platform native binary via `dist/runtime-entry.js`.  
+> TypeScript remains an explicit **fallback** (`./typescript`, force flags) for unsupported platforms / missing optional natives.  
+> Versions `3.0.15`–`3.1.1` are **WITHDRAWN**. Admission bar is capability-first semantic compatibility (ADR-0005), not exact PDF.js JSON equality.
 
 [![GitHub stars](https://img.shields.io/github/stars/SylphxAI/pdf-reader-mcp?style=for-the-badge&logo=github)](https://github.com/SylphxAI/pdf-reader-mcp/stargazers)
 [![npm version](https://img.shields.io/npm/v/@sylphx/pdf-reader-mcp?style=flat-square)](https://www.npmjs.com/package/@sylphx/pdf-reader-mcp)
 [![License](https://img.shields.io/badge/License-MIT-blue?style=flat-square)](https://opensource.org/licenses/MIT)
 [![CI/CD](https://img.shields.io/github/actions/workflow/status/SylphxAI/pdf-reader-mcp/ci.yml?style=flat-square&label=CI/CD)](https://github.com/SylphxAI/pdf-reader-mcp/actions/workflows/ci.yml)
 [![codecov](https://img.shields.io/codecov/c/github/SylphxAI/pdf-reader-mcp?style=flat-square)](https://codecov.io/gh/SylphxAI/pdf-reader-mcp)
-[![Rust](https://img.shields.io/badge/Rust-experimental-orange.svg?style=flat-square)](https://www.rust-lang.org/)
+[![Rust](https://img.shields.io/badge/Rust-default-orange.svg?style=flat-square)](https://www.rust-lang.org/)
 [![Downloads](https://img.shields.io/npm/dm/@sylphx/pdf-reader-mcp?style=flat-square)](https://www.npmjs.com/package/@sylphx/pdf-reader-mcp)
 [![Docker](https://img.shields.io/badge/Docker-ready-2496ED?style=flat-square&logo=docker)](#docker)
 
-**Local-first** · **Published: TS 3.0.14** · **Pure-Rust experimental** · **Publish freeze**
+**Local-first** · **Published: 3.2.0 pure-Rust default** · **TypeScript fallback** · **Capability-first**
 
 [⭐ Star this repo](https://github.com/SylphxAI/pdf-reader-mcp) if agents should cite PDFs with proof, not guess from plain text.
 · [Quick start](#quick-start) · [See it work](#see-it-work) · [Roadmap](docs/roadmap/sota-family-roadmap.md) · [Why not plain text?](#why-not-a-plain-text-dump)
@@ -62,7 +62,7 @@ Full capability matrix: [comparison guide](docs/comparison/index.md).
 **Install once. Call once.**
 
 ```bash
-claude mcp add pdf-reader -- npx @sylphx/pdf-reader-mcp@3.0.14
+claude mcp add pdf-reader -- npx @sylphx/pdf-reader-mcp@3.2.0
 ```
 
 ```json
@@ -136,15 +136,15 @@ Use the returned page and bounding box with `pdf_evidence` (`render_page` or
 
 ### Published stable (npm — TypeScript 3.0.14)
 
-Pin **3.0.14** explicitly. This is the only supported cross-platform drop-in.
-Requires **Node.js `>=22.13`**. The package runs `dist/index.js` (TypeScript MCP).
+Install **3.2.0**. Default prefers pure-Rust native optional packages; TypeScript remains fallback.
+Requires **Node.js `>=22.13`**. The package runs `dist/runtime-entry.js` (pure-Rust preferred, TypeScript fallback).
 
 ```bash
 # Claude Code
-claude mcp add pdf-reader -- npx @sylphx/pdf-reader-mcp@3.0.14
+claude mcp add pdf-reader -- npx @sylphx/pdf-reader-mcp@3.2.0
 
 # Any MCP client (stdio)
-npx @sylphx/pdf-reader-mcp@3.0.14
+npx @sylphx/pdf-reader-mcp@3.2.0
 ```
 
 Claude Desktop (`claude_desktop_config.json`):
@@ -154,16 +154,16 @@ Claude Desktop (`claude_desktop_config.json`):
   "mcpServers": {
     "pdf-reader": {
       "command": "npx",
-      "args": ["@sylphx/pdf-reader-mcp@3.0.14"]
+      "args": ["@sylphx/pdf-reader-mcp@3.2.0"]
     }
   }
 }
 ```
 
 > **Do not install 3.0.15–3.1.1** — withdrawn incomplete pure-Rust cutover
-> (deprecated on npm). Registry `latest` is **3.0.14**.
+> (deprecated on npm). Registry `latest` is **3.2.0**.
 
-### Experimental pure-Rust (source only)
+### Pure-Rust default + TypeScript fallback
 
 Pure-Rust is **not** published as npm latest and is **not** a full drop-in.
 Do not `cargo install` experimental crates for production. To experiment from a
@@ -173,7 +173,7 @@ git checkout:
 bun run build:rust
 PDF_READER_ENGINE_MODE=pure-rust ./bin/pdf-reader-mcp
 
-Experimental pure-Rust **library** import (does not change the default TypeScript package entry; publish freeze remains):
+Pure-Rust **library** import (`./pure-rust`). Default package entry already prefers pure-Rust when natives are installed:
 
 ```ts
 import { createPureRustClient } from '@sylphx/pdf-reader-mcp/pure-rust';
@@ -213,7 +213,7 @@ Pure-Rust is a **work in progress**, not the published product.
 | Evidence OCR / analyze | Partial: bounded opt-in command adapters; OCR TSV and analyze HTTP/presets are not yet available |
 | `read_pdf` OCR fusion | Partial: command-provider OCR layer plus boxed-word table projection into elements/chunks/Markdown/HTML/AST/map; TSV, mixed-table continuation, and broad Twin parity remain open |
 | Cross-platform npm binary | **Not yet** |
-| Drop-in for 3.0.14 | **No** |
+| Drop-in for 3.0.14 | **Yes (capability-first sole-runtime 3.2.0)** |
 
 See [docs/performance/why-rust.md](docs/performance/why-rust.md). Speedups are exploratory only.
 

--- a/README.md
+++ b/README.md
@@ -165,15 +165,10 @@ Claude Desktop (`claude_desktop_config.json`):
 
 ### Pure-Rust library export + TypeScript fallback
 
-Pure-Rust is **not** published as npm latest and is **not** a full drop-in.
-Do not `cargo install` experimental crates for production. To experiment from a
-git checkout:
+Default package entry (`dist/runtime-entry.js`) prefers the platform optional
+pure-Rust native binary when installed. TypeScript remains fallback-only.
 
-```bash
-bun run build:rust
-PDF_READER_ENGINE_MODE=pure-rust ./bin/pdf-reader-mcp
-
-Pure-Rust **library** import (`./pure-rust`). Default package entry already prefers pure-Rust when natives are installed:
+Library import:
 
 ```ts
 import { createPureRustClient } from '@sylphx/pdf-reader-mcp/pure-rust';
@@ -184,6 +179,18 @@ const result = await client.readPdf({
   include_full_text: true,
 });
 ```
+
+Force TypeScript fallback:
+
+```bash
+PDF_READER_FORCE_TYPESCRIPT=1 npx @sylphx/pdf-reader-mcp@3.2.0
+```
+
+Local source development:
+
+```bash
+bun run build:rust
+PDF_READER_ENGINE_MODE=pure-rust ./bin/pdf-reader-mcp
 ```
 
 ### Docker

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Use the returned page and bounding box with `pdf_evidence` (`render_page` or
 
 ## Quick Start
 
-### Published stable (npm — TypeScript 3.0.14)
+### Published stable (npm — sole-runtime 3.2.0)
 
 Install **3.2.0**. Default prefers pure-Rust native optional packages; TypeScript remains fallback.
 Requires **Node.js `>=22.13`**. The package runs `dist/runtime-entry.js` (pure-Rust preferred, TypeScript fallback).
@@ -163,7 +163,7 @@ Claude Desktop (`claude_desktop_config.json`):
 > **Do not install 3.0.15–3.1.1** — withdrawn incomplete pure-Rust cutover
 > (deprecated on npm). Registry `latest` is **3.2.0**.
 
-### Pure-Rust default + TypeScript fallback
+### Pure-Rust library export + TypeScript fallback
 
 Pure-Rust is **not** published as npm latest and is **not** a full drop-in.
 Do not `cargo install` experimental crates for production. To experiment from a

--- a/docs/performance/why-rust.md
+++ b/docs/performance/why-rust.md
@@ -29,8 +29,8 @@ Executable scaffolds now live under `docs/specs/semantic-contracts/` and
 `bun run check:agent-task-corpus`, and `bun run test:agent-task-smoke`.
 
 
-> **Status:** experimental. **Not** a full drop-in for TypeScript 3.0.14.
-> Published stable remains `@sylphx/pdf-reader-mcp@3.0.14`.
+> **Status:** sole-runtime default at `@sylphx/pdf-reader-mcp@3.2.0` (capability-first).
+> TypeScript production default is retired; TypeScript remains fallback-only.
 
 
 ## The product decision
@@ -154,7 +154,7 @@ paths fail closed; this is not TS 3.0.14 parity.
 
 ## Install
 
-Production: pin `@sylphx/pdf-reader-mcp@3.0.14` (TypeScript).  
+Production: pin `@sylphx/pdf-reader-mcp@3.2.0` (pure-Rust default, TypeScript fallback).  
 See [installation guide](../guide/installation.md). Pure-Rust remains experimental source-only.
 
 ### Configured-command visual enrichment fusion (bounded)

--- a/docs/specs/pdf-reader-mcp-migration-ledger.json
+++ b/docs/specs/pdf-reader-mcp-migration-ledger.json
@@ -67,7 +67,7 @@
       "id": "transport/stdio-rust-rmcp",
       "domain": "transport",
       "weight": 4,
-      "state": "rust_impl",
+      "state": "authority_rust",
       "proof": {
         "status": "differential_green",
         "baselineTsSha": "90392848149c4839754e535dcbce78f85edd2d56",
@@ -85,15 +85,15 @@
       "parityTest": "test/stdioTransport.matrix.test.ts; test/integration/stdio-transport.test.ts; test/check-no-ts-stdio-backend.test.ts; test/fixtures/read-pdf-golden.json; cargo test -p pdf-reader-mcp-server",
       "differentialTest": "crates/pdf-reader-mcp-server/tests/pdf_reader_mcp_differential.rs#pdf_reader_mcp_differential_matches_ts_oracle; scripts/run-pdf-reader-differential.sh",
       "prodProbe": "benchmark:release-gate \u2192 mcp:rust_adapter_default; mcp:stdio_transport_parity; mcp:stdio_deletion_prep_gate",
-      "notes": "S3: default npm bin launches Rust rmcp stdio; rej-010 SHA-bound differential harness at scripts/run-pdf-reader-differential.sh. parity_proven NOT restored until differential_green + prod smoke. | Not production default: incomplete pure-Rust surface vs TS; opt-in only until drop-in parity."
+      "notes": "S3 sole-runtime: package bin dist/runtime-entry.js prefers platform optional pure-Rust MCP binary. Five-platform registry install+initialize proven for 3.2.0. TypeScript is fallback only."
     },
     {
       "id": "transport/stdio-ts-adapter",
       "domain": "transport",
       "weight": 4,
-      "state": "ts_only",
+      "state": "ts_fallback",
       "parityTest": "scripts/check-ts-adapter-deletion-ready.sh; scripts/check-no-ts-stdio-backend.sh; test/tsAdapterDeletion.matrix.test.ts",
-      "notes": "Production default MCP transport restored to TypeScript after incomplete Rust cutover.",
+      "notes": "TypeScript production default retired at 3.2.0. Retained as explicit fallback export ./typescript and force flags for unsupported platforms / missing optional natives after 3.0.15 incident lessons.",
       "proof": {
         "status": "missing",
         "baselineTsSha": "90392848149c4839754e535dcbce78f85edd2d56",

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -13,7 +13,14 @@
     "exactPdfJsOutputParityRequired": false,
     "ts3014Role": "regression-baseline-coverage-discovery-compatibility-reference",
     "registryPublishAuthorized": true,
-    "soleRuntimeDefault": true
+    "soleRuntimeDefault": true,
+    "typescriptProductionDefault": "retired",
+    "typescriptFallback": true,
+    "typescriptFallbackExports": [
+      "./typescript",
+      "PDF_READER_FORCE_TYPESCRIPT=1",
+      "PDF_READER_ENGINE_MODE=typescript"
+    ]
   },
   "legend": {
     "FULL": "Production-usable capability for agent tasks in this slice under the capability-first semantic contract (not exact PDF.js JSON equality)",
@@ -331,7 +338,8 @@
     "dropInFor3014": true,
     "nextActions": [
       "Monitor sole-runtime 3.2.0 adoption and TypeScript fallback usage",
-      "Optionally deepen PARTIAL capabilities under ADR-0005 task-eval corpus"
+      "Optionally deepen PARTIAL capabilities under ADR-0005 task-eval corpus",
+      "Hard-delete TypeScript MCP surface only after sustained sole-runtime stability window"
     ],
     "semanticContracts": "docs/specs/semantic-contracts/",
     "agentTaskCorpus": "docs/specs/agent-task-corpus/",
@@ -381,10 +389,10 @@
       "registryProofRunUrl": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30008166478"
     },
     "libraryExports": {
-      "status": "published-experimental-opt-in",
+      "status": "published-sole-runtime-default",
       "exportPath": "./pure-rust",
       "artifact": "dist/pure-rust.js",
-      "defaultStillTypescript": true,
+      "defaultStillTypescript": false,
       "publishFreeze": false
     },
     "wholeProductReviewPackage": "docs/specs/whole-product-independent-review-package.md",

--- a/docs/specs/temporary-rust-migration-fences.md
+++ b/docs/specs/temporary-rust-migration-fences.md
@@ -1,7 +1,8 @@
 # Temporary Rust migration fences
 
 Pure-Rust is the default package entry via `dist/runtime-entry.js` when the
-platform optional native package is installed. TypeScript remains available as:
+platform optional native package is installed. **TypeScript production default is
+retired** at 3.2.0. TypeScript remains available only as fallback:
 
 - `exports["./typescript"]` → `dist/index.js`
 - `PDF_READER_FORCE_TYPESCRIPT=1` or `PDF_READER_ENGINE_MODE=typescript`


### PR DESCRIPTION
## Summary
Public docs and ledger still claimed TS 3.0.14 + publish freeze after sole-runtime 3.2.0 shipped.

### Truth now
- npm latest `@sylphx/pdf-reader-mcp@3.2.0`
- default: pure-Rust optional native via `dist/runtime-entry.js`
- TypeScript production default **retired**; fallback retained (`./typescript`, force flags)
- five-platform registry install + pure-Rust initialize proven
- withdrawn: 3.0.15–3.1.1

Hard-delete of TypeScript MCP source remains deferred for unsupported-platform fallback after the 3.0.15 incident.

## Test plan
- [x] check:pure-rust-matrix
- [x] check:verified-candidate-admission
- [ ] CI green