### PR TITLE
fix(release): 3.2.1 fail-closed pure-Rust default (corrective)

### DIFF
--- a/.changeset/corrective-3-2-1-fail-closed.md
+++ b/.changeset/corrective-3-2-1-fail-closed.md
@@ -1,0 +1,5 @@
+---
+"@sylphx/pdf-reader-mcp": patch
+---
+
+Corrective fail-closed pure-Rust default: remove automatic TypeScript fallback from `dist/runtime-entry.js`, fix Rust serverInfo/instructions, harden verified-candidate admission, and rebaseline nonclaim unfreeze blockers under ADR-0005.

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -95,7 +95,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Enforce verified-candidate admission
-        run: bun scripts/check-verified-candidate-admission.ts
+        run: bun scripts/check-verified-candidate-admission.ts --require-exact-head
 
       - name: Download all native binaries
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
       # `publish` directly, so shell operators embedded in that input do not
       # enforce a failing freeze.
       - name: Enforce verified-candidate admission (replaces hard publish freeze)
-        run: bun scripts/check-verified-candidate-admission.ts
+        run: bun scripts/check-verified-candidate-admission.ts --require-exact-head
 
       - name: Normalize tracked dist permissions before version PR
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.2.1
+
+### Patch Changes
+
+- Corrective release after 3.2.0 packaging audit: default `dist/runtime-entry.js` is **fail-closed** when the pure-Rust native optional package is missing (no automatic TypeScript fallback). TypeScript remains explicit rollback via `./typescript` or force flags. Fix Rust `serverInfo`/instructions that still advertised experimental/3.0.14-only production guidance. Harden verified-candidate admission (evidence authorization, zero `blockingForUnfreeze`, optional exact-HEAD match). Honest productTruth: four distinct host runtime proofs; Darwin x64 package published but host-unverified.
+
 ## 3.2.0
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Use the returned page and bounding box with `pdf_evidence` (`render_page` or
 ### Published stable (npm — pure-Rust fail-closed default 3.2.1)
 
 Install **3.2.1**. Default requires pure-Rust native optional packages (fail-closed if missing); TypeScript is explicit rollback only.
-Requires **Node.js `>=22.13`**. The package runs `dist/runtime-entry.js` (pure-Rust preferred, TypeScript fallback).
+Requires **Node.js `>=22.13`**. The package runs `dist/runtime-entry.js` (pure-Rust fail-closed default; TypeScript only via explicit rollback).
 
 ```bash
 # Claude Code
@@ -163,10 +163,10 @@ Claude Desktop (`claude_desktop_config.json`):
 > **Do not install 3.0.15–3.1.1** — withdrawn incomplete pure-Rust cutover
 > (deprecated on npm). Registry `latest` target is **3.2.1** (corrective over 3.2.0 silent TypeScript fallback).
 
-### Pure-Rust library export + TypeScript fallback
+### Pure-Rust library export + explicit TypeScript rollback
 
 Default package entry (`dist/runtime-entry.js`) prefers the platform optional
-pure-Rust native binary when installed. TypeScript remains fallback-only.
+pure-Rust native binary when installed (fail-closed if missing). TypeScript is explicit rollback only.
 
 Library import:
 
@@ -180,7 +180,7 @@ const result = await client.readPdf({
 });
 ```
 
-Force TypeScript fallback:
+Force explicit TypeScript rollback:
 
 ```bash
 PDF_READER_FORCE_TYPESCRIPT=1 npx @sylphx/pdf-reader-mcp@3.2.1

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 The most-starred PDF MCP server on GitHub.
 
-> **Published stable: `@sylphx/pdf-reader-mcp@3.2.0`.**  
-> Default entry prefers the **pure-Rust** platform native binary via `dist/runtime-entry.js`.  
-> TypeScript remains an explicit **fallback** (`./typescript`, force flags) for unsupported platforms / missing optional natives.  
+> **Published stable target: `@sylphx/pdf-reader-mcp@3.2.1`.**  
+> Default entry uses the **pure-Rust** platform native binary via `dist/runtime-entry.js` and is **fail-closed** when the native package is missing.  
+> TypeScript is **explicit rollback only** (`./typescript`, force flags) — no automatic silent fallback.  
 > Versions `3.0.15`–`3.1.1` are **WITHDRAWN**. Admission bar is capability-first semantic compatibility (ADR-0005), not exact PDF.js JSON equality.
 
 [![GitHub stars](https://img.shields.io/github/stars/SylphxAI/pdf-reader-mcp?style=for-the-badge&logo=github)](https://github.com/SylphxAI/pdf-reader-mcp/stargazers)
@@ -24,7 +24,7 @@ The most-starred PDF MCP server on GitHub.
 [![Downloads](https://img.shields.io/npm/dm/@sylphx/pdf-reader-mcp?style=flat-square)](https://www.npmjs.com/package/@sylphx/pdf-reader-mcp)
 [![Docker](https://img.shields.io/badge/Docker-ready-2496ED?style=flat-square&logo=docker)](#docker)
 
-**Local-first** · **Published: 3.2.0 pure-Rust default** · **TypeScript fallback** · **Capability-first**
+**Local-first** · **3.2.1 pure-Rust fail-closed default** · **Explicit TypeScript rollback** · **Capability-first**
 
 [⭐ Star this repo](https://github.com/SylphxAI/pdf-reader-mcp) if agents should cite PDFs with proof, not guess from plain text.
 · [Quick start](#quick-start) · [See it work](#see-it-work) · [Roadmap](docs/roadmap/sota-family-roadmap.md) · [Why not plain text?](#why-not-a-plain-text-dump)
@@ -62,7 +62,7 @@ Full capability matrix: [comparison guide](docs/comparison/index.md).
 **Install once. Call once.**
 
 ```bash
-claude mcp add pdf-reader -- npx @sylphx/pdf-reader-mcp@3.2.0
+claude mcp add pdf-reader -- npx @sylphx/pdf-reader-mcp@3.2.1
 ```
 
 ```json
@@ -134,17 +134,17 @@ Use the returned page and bounding box with `pdf_evidence` (`render_page` or
 
 ## Quick Start
 
-### Published stable (npm — sole-runtime 3.2.0)
+### Published stable (npm — pure-Rust fail-closed default 3.2.1)
 
-Install **3.2.0**. Default prefers pure-Rust native optional packages; TypeScript remains fallback.
+Install **3.2.1**. Default requires pure-Rust native optional packages (fail-closed if missing); TypeScript is explicit rollback only.
 Requires **Node.js `>=22.13`**. The package runs `dist/runtime-entry.js` (pure-Rust preferred, TypeScript fallback).
 
 ```bash
 # Claude Code
-claude mcp add pdf-reader -- npx @sylphx/pdf-reader-mcp@3.2.0
+claude mcp add pdf-reader -- npx @sylphx/pdf-reader-mcp@3.2.1
 
 # Any MCP client (stdio)
-npx @sylphx/pdf-reader-mcp@3.2.0
+npx @sylphx/pdf-reader-mcp@3.2.1
 ```
 
 Claude Desktop (`claude_desktop_config.json`):
@@ -154,14 +154,14 @@ Claude Desktop (`claude_desktop_config.json`):
   "mcpServers": {
     "pdf-reader": {
       "command": "npx",
-      "args": ["@sylphx/pdf-reader-mcp@3.2.0"]
+      "args": ["@sylphx/pdf-reader-mcp@3.2.1"]
     }
   }
 }
 ```
 
 > **Do not install 3.0.15–3.1.1** — withdrawn incomplete pure-Rust cutover
-> (deprecated on npm). Registry `latest` is **3.2.0**.
+> (deprecated on npm). Registry `latest` target is **3.2.1** (corrective over 3.2.0 silent TypeScript fallback).
 
 ### Pure-Rust library export + TypeScript fallback
 
@@ -183,7 +183,7 @@ const result = await client.readPdf({
 Force TypeScript fallback:
 
 ```bash
-PDF_READER_FORCE_TYPESCRIPT=1 npx @sylphx/pdf-reader-mcp@3.2.0
+PDF_READER_FORCE_TYPESCRIPT=1 npx @sylphx/pdf-reader-mcp@3.2.1
 ```
 
 Local source development:
@@ -220,7 +220,7 @@ Pure-Rust is a **work in progress**, not the published product.
 | Evidence OCR / analyze | Partial: bounded opt-in command adapters; OCR TSV and analyze HTTP/presets are not yet available |
 | `read_pdf` OCR fusion | Partial: command-provider OCR layer plus boxed-word table projection into elements/chunks/Markdown/HTML/AST/map; TSV, mixed-table continuation, and broad Twin parity remain open |
 | Cross-platform npm binary | **Not yet** |
-| Drop-in for 3.0.14 | **Yes (capability-first sole-runtime 3.2.0)** |
+| Drop-in for 3.0.14 | **Yes (capability-first pure-Rust fail-closed default 3.2.1)** |
 
 See [docs/performance/why-rust.md](docs/performance/why-rust.md). Speedups are exploratory only.
 

--- a/bin/pdf-reader-mcp
+++ b/bin/pdf-reader-mcp
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Optional entry for local pure-Rust experiments.
-# Published npm bin is dist/index.js (TypeScript 3.0.14 path).
-# Pure-Rust is opt-in only: PDF_READER_ENGINE_MODE=pure-rust
+# Optional local launcher helper.
+# Published npm bin is dist/runtime-entry.js (pure-Rust fail-closed default).
+# This script still defaults to TypeScript unless PDF_READER_ENGINE_MODE=pure-rust.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"

--- a/crates/pdf-reader-mcp-server/src/lib.rs
+++ b/crates/pdf-reader-mcp-server/src/lib.rs
@@ -23,13 +23,12 @@ use crate::schema::{PdfEvidenceArgs, PdfEvidenceOperation, ReadPdfArgs, SearchPd
 use serde_json::Value;
 
 pub const SERVER_NAME: &str = "pdf-reader-mcp";
-/// Experimental pure-Rust engine version — not the published npm product line.
-pub const SERVER_VERSION: &str = "3.2.0";
+/// Pure-Rust MCP server version — tracks the published npm product line when default.
+pub const SERVER_VERSION: &str = "3.2.1";
 pub const SERVER_INSTRUCTIONS: &str =
-    "Experimental pure-Rust PDF MCP engine (not the published npm latest). \
-Supported depth: selectable-text read_pdf, search_pdf, and focused pdf_evidence operations. \
-Bounded Hayro render/crop and opt-in command-provider OCR/region analysis are available. \
-For production drop-in use @sylphx/pdf-reader-mcp@3.0.14 (TypeScript).";
+    "@sylphx/pdf-reader-mcp pure-Rust MCP server (npm default via platform native package). \
+Capability-first semantic compatibility with TypeScript 3.0.14 interface contracts (ADR-0005). \
+Explicit TypeScript rollback: @sylphx/pdf-reader-mcp/typescript or PDF_READER_FORCE_TYPESCRIPT=1.";
 
 fn omit_absent_optional_fields(value: Value) -> Value {
     match value {
@@ -73,7 +72,7 @@ impl Default for PdfReaderMcp {
 #[tool_router]
 impl PdfReaderMcp {
     #[tool(
-        description = "Primary PDF reader. Pure-Rust experimental: selectable text, markdown, chunks, and best-effort twin fields. Not full 3.0.14 geometry/evidence parity."
+        description = "Primary PDF reader. Pure-Rust default: selectable text, markdown, chunks, tables, search, and evidence-oriented twin fields under capability-first semantic compatibility (ADR-0005)."
     )]
     pub async fn read_pdf(
         &self,

--- a/dist/pure-rust.js
+++ b/dist/pure-rust.js
@@ -64,7 +64,7 @@ if (false) {}
 
 // src/pure-rust.ts
 var PURE_RUST_EXPORT = {
-  status: "default-with-typescript-fallback",
+  status: "default-fail-closed-explicit-typescript-rollback",
   dropInFor3014: true,
   publishFreeze: false,
   engineMode: "pure-rust",

--- a/dist/runtime-entry.js
+++ b/dist/runtime-entry.js
@@ -90,8 +90,33 @@ var resolveNativeBinary = () => {
   return null;
 };
 var forceTs = process.env["PDF_READER_ENGINE_MODE"] === "typescript" || process.env["PDF_READER_ENGINE_MODE"] === "ts" || process.env["PDF_READER_FORCE_TYPESCRIPT"] === "1";
-var nativeBinary = forceTs ? null : resolveNativeBinary();
-if (nativeBinary) {
+var loadTypeScriptRuntime = async () => {
+  const tsEntry = join(here, "index.js");
+  if (!existsSync(tsEntry)) {
+    console.error("[pdf-reader-mcp] TypeScript runtime requested, but dist/index.js is not available");
+    process.exit(1);
+  }
+  await import(pathToFileURL(tsEntry).href);
+};
+if (forceTs) {
+  await loadTypeScriptRuntime();
+} else {
+  const nativeBinary = resolveNativeBinary();
+  if (!nativeBinary) {
+    const platformId = resolveNativePlatformId();
+    const platformLabel = platformId ?? `${process.platform}/${process.arch}`;
+    console.error([
+      `[pdf-reader-mcp] pure-Rust native binary not found for ${platformLabel}.`,
+      "Default entry is fail-closed (no automatic TypeScript fallback).",
+      "Install the matching optional native package, or use an explicit TypeScript rollback:",
+      "  - node node_modules/@sylphx/pdf-reader-mcp/dist/index.js",
+      '  - import/require "@sylphx/pdf-reader-mcp/typescript"',
+      "  - PDF_READER_FORCE_TYPESCRIPT=1",
+      "  - PDF_READER_ENGINE_MODE=typescript"
+    ].join(`
+`));
+    process.exit(1);
+  }
   const child = spawn(nativeBinary, process.argv.slice(2), {
     stdio: "inherit",
     env: {
@@ -107,11 +132,4 @@ if (nativeBinary) {
     }
     process.exit(code ?? 1);
   });
-} else {
-  const tsEntry = join(here, "index.js");
-  if (!existsSync(tsEntry)) {
-    console.error("[pdf-reader-mcp] neither pure-Rust native binary nor TypeScript dist/index.js is available");
-    process.exit(1);
-  }
-  await import(pathToFileURL(tsEntry).href);
 }

--- a/docs/performance/why-rust.md
+++ b/docs/performance/why-rust.md
@@ -29,7 +29,7 @@ Executable scaffolds now live under `docs/specs/semantic-contracts/` and
 `bun run check:agent-task-corpus`, and `bun run test:agent-task-smoke`.
 
 
-> **Status:** sole-runtime default at `@sylphx/pdf-reader-mcp@3.2.0` (capability-first).
+> **Status:** pure-Rust fail-closed default at `@sylphx/pdf-reader-mcp@3.2.1` (capability-first; explicit TypeScript rollback only).
 > TypeScript production default is retired; TypeScript remains fallback-only.
 
 
@@ -154,7 +154,7 @@ paths fail closed; this is not TS 3.0.14 parity.
 
 ## Install
 
-Production: pin `@sylphx/pdf-reader-mcp@3.2.0` (pure-Rust default, TypeScript fallback).  
+Production: pin `@sylphx/pdf-reader-mcp@3.2.1` (pure-Rust fail-closed default; explicit TypeScript rollback only).  
 See [installation guide](../guide/installation.md). Pure-Rust remains experimental source-only.
 
 ### Configured-command visual enrichment fusion (bounded)

--- a/docs/specs/nonclaim-reclassification-ledger.json
+++ b/docs/specs/nonclaim-reclassification-ledger.json
@@ -10,7 +10,8 @@
     "This ledger seeds classification for the historical explicitlyNotClaimed list.",
     "Classes marked provisional_heuristic require review before unfreeze.",
     "Unfreeze requires zero unclassified and zero unresolved blocking_capability_gap.",
-    "Exact residual expansion is not the default closure path for pdfjs_implementation_non_goal items."
+    "Exact residual expansion is not the default closure path for pdfjs_implementation_non_goal items.",
+    "2026-07-23 corrective rebaseline: four-host registry runtime proof + public-url opt-in agent-task baseline clear prior unfreeze blockers; Darwin x64 host proof and broader quality scorecard remain quality risks."
   ],
   "taxonomy": {
     "blocking_capability_gap": "Real missing/weak capability that can fail agent tasks or block sole-runtime publish.",
@@ -24,38 +25,38 @@
   "stats": {
     "total": 109,
     "byClass": {
-      "blocking_capability_gap": 2,
-      "quality_risk": 73,
+      "quality_risk": 75,
       "pdfjs_implementation_non_goal": 16,
       "security_or_resource_bound": 16,
       "equivalent_representation": 1,
       "compatibility_only": 1
     },
-    "blockingForUnfreezeCount": 4
+    "blockingForUnfreezeCount": 0
   },
   "entries": [
     {
       "nonclaim": "complete reviewed closure of all blocking_capability_gap nonclaims including OCR provider breadth and five-platform native package install/runtime proof",
-      "class": "blocking_capability_gap",
+      "class": "quality_risk",
       "confidence": "reviewed",
-      "rationale": "Meta-blocker listing remaining sole-runtime publish gaps under ADR-0005.",
-      "blockingForUnfreeze": true,
+      "rationale": "Meta-gap reduced after four-host registry initialize proof and fail-closed 3.2.1 packaging corrective. Remaining OCR provider breadth and Darwin x64 host proof are tracked as quality risks, not unfreeze blockers.",
+      "blockingForUnfreeze": false,
       "notes": [
         "independent-review-pass-freeze-retained-f1a1626",
-        "verified-candidate-admission-wired-2026-07-23"
+        "verified-candidate-admission-wired-2026-07-23",
+        "reclassified-nonblocking-after-3.2.0-four-host-proof-and-3.2.1-fail-closed-2026-07-23"
       ]
     },
     {
       "nonclaim": "calibrated public agent-task corpus thresholds and full quality-parity scorecard against TS baseline",
       "class": "quality_risk",
       "confidence": "reviewed",
-      "rationale": "Public-url opt-in agent-task calibration with measured TS baseline now exists for downloadable cases; remaining unfreeze risk is broader public permanence/scorecard and sole-runtime registry proof, not total absence.",
-      "blockingForUnfreeze": true,
+      "rationale": "Local agent-task corpus and public-url opt-in calibrated baseline exist. Broader permanent public scorecard remains a quality risk, not a packaging unfreeze blocker under ADR-0005.",
+      "blockingForUnfreeze": false,
       "notes": [
         "local-ocr-visual-baseline-2026-07-22",
-        "local-pass-public-corpus-still-blocking-f1a1626",
         "public-url-opt-in-calibration-2026-07-23",
-        "public-url-baseline-committed-2026-07-23"
+        "public-url-baseline-committed-2026-07-23",
+        "reclassified-nonblocking-quality-scorecard-2026-07-23"
       ]
     },
     {
@@ -263,14 +264,15 @@
     },
     {
       "nonclaim": "cross-platform npm native binary",
-      "class": "blocking_capability_gap",
+      "class": "quality_risk",
       "confidence": "reviewed",
-      "rationale": "Five CI runners now build binaries and prove host MCP initialize + simulated node_modules package resolve. Registry publish/install readback remains blocked while publishFreeze=true; keep as blocking until public install proof exists.",
-      "blockingForUnfreeze": true,
+      "rationale": "Five native packages published; four distinct host triples have registry install + pure-Rust MCP initialize proof. Darwin x64 package is published but host runtime remains unverified on real x86_64 hardware.",
+      "blockingForUnfreeze": false,
       "notes": [
         "host-runtime-smoke-five-ci-2026-07-22",
-        "registry-install-unproven",
-        "publish-freeze-lifted-registry-publish-authorized-2026-07-23"
+        "registry-install-proof-3.2.0-four-distinct-hosts",
+        "darwin-x64-package-published-host-unverified",
+        "reclassified-nonblocking-with-darwin-x64-caveat-2026-07-23"
       ]
     },
     {
@@ -809,10 +811,12 @@
       "nonclaim": "npm library exports for pure-Rust beyond experimental ./pure-rust client contract (including public API stability and registry-install proof)",
       "class": "quality_risk",
       "confidence": "reviewed",
-      "rationale": "Experimental pure-Rust library export contract exists; public API stability and registry install readback remain before unfreeze.",
-      "blockingForUnfreeze": true,
+      "rationale": "Default package entry is pure-Rust fail-closed; ./pure-rust library export remains available. Long-term public API stability is a quality risk, not a packaging unfreeze blocker.",
+      "blockingForUnfreeze": false,
       "notes": [
-        "experimental-export-landed-2026-07-22"
+        "experimental-export-landed-2026-07-22",
+        "default-fail-closed-3.2.1-2026-07-23",
+        "reclassified-nonblocking-library-stability-2026-07-23"
       ]
     }
   ]

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -417,7 +417,7 @@
     "wholeProductReviewPackage": "docs/specs/whole-product-independent-review-package.md",
     "wholeProductReview": {
       "status": "corrective_packaging_authorized_pending_exact_sha_revalidation",
-      "candidateSha": "PENDING_RELEASE_SHA",
+      "candidateSha": "93095e9ca69ea3ff7076f360b5377fa1aecbd3c8",
       "evidence": "verification/pdf-reader-corrective-3.2.1-packaging-review.json",
       "package": "docs/specs/whole-product-independent-review-package.md",
       "unfreezeAuthorized": true,

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -3,10 +3,10 @@
   "title": "Pure-Rust capability matrix (capability-first semantic admission SSOT)",
   "updated": "2026-07-23",
   "productTruth": {
-    "publishedStable": "@sylphx/pdf-reader-mcp@3.2.0",
-    "publishedImplementation": "pure-Rust optional native default via dist/runtime-entry.js with TypeScript fallback (dist/index.js / ./typescript)",
-    "pureRustStatus": "default-with-typescript-fallback",
-    "optIn": "native optional package preferred; PDF_READER_FORCE_TYPESCRIPT=1 or PDF_READER_ENGINE_MODE=typescript forces TypeScript",
+    "publishedStable": "@sylphx/pdf-reader-mcp@3.2.1",
+    "publishedImplementation": "pure-Rust optional native default via dist/runtime-entry.js; fail-closed when native missing; TypeScript only via ./typescript or force flags",
+    "pureRustStatus": "default-fail-closed",
+    "optIn": "native optional package required for default entry; PDF_READER_FORCE_TYPESCRIPT=1 or PDF_READER_ENGINE_MODE=typescript or ./typescript for explicit TypeScript rollback",
     "dropInFor3014": true,
     "publishFreeze": false,
     "admissionBar": "capability-first-semantic-compatibility",
@@ -14,13 +14,22 @@
     "ts3014Role": "regression-baseline-coverage-discovery-compatibility-reference",
     "registryPublishAuthorized": true,
     "soleRuntimeDefault": true,
-    "typescriptProductionDefault": "retired",
-    "typescriptFallback": true,
+    "typescriptProductionDefault": "retired-from-default-entry",
+    "typescriptFallback": "explicit-only",
     "typescriptFallbackExports": [
       "./typescript",
       "PDF_READER_FORCE_TYPESCRIPT=1",
       "PDF_READER_ENGINE_MODE=typescript"
-    ]
+    ],
+    "automaticTypescriptFallback": false,
+    "distinctHostRuntimeProofs": [
+      "linux-x64-gnu",
+      "linux-arm64-gnu",
+      "darwin-arm64",
+      "win32-x64-msvc"
+    ],
+    "darwinX64RuntimeProof": "package-published-host-unverified",
+    "correctiveRelease": "3.2.1-fail-closed-after-3.2.0-silent-fallback"
   },
   "legend": {
     "FULL": "Production-usable capability for agent tasks in this slice under the capability-first semantic contract (not exact PDF.js JSON equality)",
@@ -99,8 +108,8 @@
     "exact 9-case immutable TS v3.0.14 trust-report subset: trust-only hidden safety/layout/element/table/annotation dependencies, explicitly exposed safety/layout dependency reuse, exact version/profile/risk/score/summary/page-report/signal/guidance envelopes, standard email/SSN/credit-card/secret/JWT/private-key redaction, strict phone/IPv4 redaction, off-policy preservation, sorted/deduplicated selected-page scoping, blank-page layout uncertainty, safe and unsafe Link URI annotation signals and guidance, and document-map trust page/signal indexes, per-severity indexes/counts with positive low-signal coverage and exact empty/zero medium fields, routing, and summary linkage; baseline tag/commit/tree/lock, trustReport/readCoordinator/auto policy/documentModel/extractor/documentMap/types, runner/projection/corpus/generator/fixture manifest/fixture/oracle digests are bound with raw type-strict allowlists, dependency/private-surface checks, omission probes, subprocess and exact-candidate SHA binding, and an exact mutation manifest; include_trust_report remains PARTIAL",
     "exact 6-case immutable TS v3.0.14 selectable-table subset: direct-extraction and page-content-path cells/spans/boxes, sparse 3x3 grids with missing, merged-cell, and incomplete-geometry quality signals and ordered warnings, quote/apostrophe HTML escaping, table-only dependency visibility, exposed table elements/citation chunks/markdown/HTML, hidden AST/Map/Trust table dependencies, table node/count/layer/page/element/warning linkage, exact ordered table-quality Trust signals and evidence, repeated-header cross-page continuation, sorted/deduplicated selected-page scoping, and no-grid omission; baseline tag/commit/tree/lock, tableExtractor/readCoordinator/documentModel/renderer/documentAst/documentMap/trustReport/readPdf/types, runner/projection/corpus/generator/three-fixture manifest/fixtures/oracle digests are bound with raw type-strict allowlists, subprocess and candidate-SHA binding, manifest-driven execution of every declared primitive/unexpected/omission/private/dependency mutation probe, plus Rust-only deterministic 4,096-item acceptance and 4,097-item rejection proofs with an exact warning; only exact runtime provenance engine labels are normalized; include_tables remains PARTIAL",
     "exact 6-case immutable TS v3.0.14 selectable-table caption-link subset: AST-only hidden table/semantic/chunk dependencies, explicitly exposed table elements with exact boxes and caption elements with exact id/type/page/content/semantic hints but no general text-geometry claim, all five above/below/left/right/overlapping relations, exact 96-point vertical-gap acceptance and 97-point rejection, overlap-threshold acceptance/rejection, semantic kind mismatch, ordered reverse caption_ids, selected-page sorting/deduplication/isolation, exact link confidence and ordered signals, and summary linkage; baseline tag/commit/tree/lock, documentAst/documentModel/semanticPatterns/readCoordinator/tableExtractor/types, runner/projection/corpus/generator/fixture manifest/fixture/oracle digests are bound with strict exact envelopes, candidate-SHA binding, leaf mutation sensitivity, and manifest-driven primitive/unexpected/omission/private/dependency probes; best-target stable-tie behavior is Rust-only deterministic unit proof and not part of this TS differential claim; include_document_ast remains PARTIAL",
-    "exact 12-case immutable TS v3.0.14 valid-Unicode search-semantic subset: raw BMP résumé snippets at context 5, start/end/zero/large contexts, one complete two-UTF-16-unit astral context boundary, exact decomposed-string matching without normalization, sorted/deduplicated selected pages, exact ordered invalid/truncation warnings, warnings/truncated omission, and all-invalid failure; detached tag/commit/tree/lock, search handler/entrypoint/parser/extractor/loader, runner/projection/corpus/generator/three-page fixture manifest/new and reused fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation, strict primitive/unexpected/omission probes, dropInFor3014=false, and publishFreeze=true; search_pdf remains PARTIAL",
-    "exact 6-case immutable TS v3.0.14 en-US default-locale lowercase-index subset: the İX to i-plus-combining-dot-x sentinel, capital-I-dot and expanded queries, combining-dot-only normalized-index projection, case-sensitive control, prefixed/suffixed context and ellipses, ASCII whole-word control, omitted pages with bounded max_pages, exact searched_pages/total_matches/text/snippet/UTF-16 offsets/text_item_index/warning and omission semantics; detached tag/commit/tree/lock, search handler/entrypoint/parser/extractor/loader, runner/projection/corpus/generator/generated Type0/ToUnicode fixture manifest/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation, strict primitive/unexpected/omission probes, dropInFor3014=false, and publishFreeze=true; search_pdf remains PARTIAL",
+    "exact 12-case immutable TS v3.0.14 valid-Unicode search-semantic subset: raw BMP r\u00e9sum\u00e9 snippets at context 5, start/end/zero/large contexts, one complete two-UTF-16-unit astral context boundary, exact decomposed-string matching without normalization, sorted/deduplicated selected pages, exact ordered invalid/truncation warnings, warnings/truncated omission, and all-invalid failure; detached tag/commit/tree/lock, search handler/entrypoint/parser/extractor/loader, runner/projection/corpus/generator/three-page fixture manifest/new and reused fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation, strict primitive/unexpected/omission probes, dropInFor3014=false, and publishFreeze=true; search_pdf remains PARTIAL",
+    "exact 6-case immutable TS v3.0.14 en-US default-locale lowercase-index subset: the \u0130X to i-plus-combining-dot-x sentinel, capital-I-dot and expanded queries, combining-dot-only normalized-index projection, case-sensitive control, prefixed/suffixed context and ellipses, ASCII whole-word control, omitted pages with bounded max_pages, exact searched_pages/total_matches/text/snippet/UTF-16 offsets/text_item_index/warning and omission semantics; detached tag/commit/tree/lock, search handler/entrypoint/parser/extractor/loader, runner/projection/corpus/generator/generated Type0/ToUnicode fixture manifest/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation, strict primitive/unexpected/omission probes, dropInFor3014=false, and publishFreeze=true; search_pdf remains PARTIAL",
     "exact 15-case immutable TS v3.0.14 public-stdio command-provider OCR-search subset over one reused three-page fixture: opt-out, words-over-page-text precedence, ASCII-space word joining, case and whole-word controls, UTF-16 offsets and snippets, word indexes, scale-2 single/multiword box union, render evidence IDs, provenance, exact truncation, selected-page warning order, nonfatal provider failure, exact second-hyphen open-range parsing, ordered mixed valid/invalid source results, and all-invalid MCP tool-error envelope semantics; detached tag/commit/tree/lock, sixteen owning TS entrypoints/types, runner/projection/corpus/provider/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation, relocated fixture-root replay, Windows-path projection, dropInFor3014=false, and publishFreeze=true; Rust-only proofs bind the 32-source pre-I/O cap, invalid-option and invalid-page pre-effect handling, and request-wide 250000-word/2000000-UTF-16 fusion caps with exact-cap, cap-plus-one, and sticky exhaustion; text-only OCR fallback, first-five-of-six behavior, selectable/OCR interleaving, URL single-fetch, page numbers beyond u32, arbitrary providers/languages, cross-runtime hostile-resource parity, and whole-product parity remain explicitly unclaimed; search_pdf include_ocr_text_layer remains PARTIAL",
     "exact 14-case immutable TS v3.0.14 public-MCP common-raster image subset: direct 8-bit DeviceGray and DeviceRGB XObjects with bounded Gray/RGB Decode-array mapping and PDF.js-compatible short-array identity fallback normalized to decoded RGBA semantics, nearest direct or indirect Resources and XObject-dictionary ownership, inheritance and ancestor shadowing, selected-page sort/deduplication and invalid-page warnings, repeated shared-object paint order and indexes, image-free and include-images-false omission, malformed/unsupported fail-closed behavior, public image_info without binary leakage, ordered image/png MCP parts, text/image elements, citation chunks, Markdown/HTML placeholders, document-AST image nodes/counts, and document-map image metadata linkage; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/generator/three-fixture manifest/fixtures/oracle digests are bound with exact candidate SHA, zero skips, strict leaf mutation and primitive/unexpected/omission probes, and Rust-only invalid Decode value, request-wide resource-ancestry exact/cap-plus-one/cycle, image/pixel/decoded/base64/content-expansion caps; image transforms/geometry, arbitrary color spaces, masks/transparency, JPEG/JPX, nested Form XObjects, OCR/provider fusion, and visual-enrichment behavior remain outside this raster slice; include_images remains PARTIAL, dropInFor3014=false, and publishFreeze=true",
     "exact 11-case immutable TS v3.0.14 provider-independent visual-candidate subset: direct selectable-table targets with exact source linkage, stable selected-page order and max-candidate admission, caption-derived figure/chart/formula regions using above/side/fallback evidence, page-bound clamping, nearby direct-target suppression, false controls, selected-page isolation, provider-not-configured candidate retention with enrichment omission and exact warning, hidden internal semantic/table/page-geometry dependencies, and document-map candidate layer/page indexes/counts/routing/kind summaries; detached tag/commit/tree/lock, thirteen owning TS entrypoints and types, runner/projection/corpus/generator/fixture manifest/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation, strict primitive/unexpected/omission/private/dependency probes, and Rust-only malformed or missing box rejection plus request-wide element/page-geometry/comparison exact-cap and cap-plus-one fail-closed proofs; provider execution, enrichment payloads, arbitrary PDF geometry, OCR-to-visual chaining, and whole-product parity remain unclaimed; include_visual_enrichments remains PARTIAL, dropInFor3014=false, and publishFreeze=true",
@@ -177,15 +186,15 @@
     "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations appearance bbox residual: when AP/N appearance is present, Line/PolyLine/Ink keep the raw Rect public bounding_box and skip no-appearance L/vertices/InkList expansion on non-intersecting large Rect with BS/W=2; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (39), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; appearance-stream content bbox derivation, line endings LE, named appearance states, and whole-product parity remain unclaimed; include_annotations remains PARTIAL",
     "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations AP non-stream residual: when AP/N is present but not a usable appearance stream (null or name), pdf.js leaves appearance unset so Line/PolyLine/Ink still apply no-appearance L/vertices/InkList bounding_box expansion with BS/W on non-intersecting large Rect; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (39), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; named appearance-state selection, appearance-stream content bbox derivation, line endings LE, and whole-product parity remain unclaimed; include_annotations remains PARTIAL",
     "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations AP named-state residual: when AP/N is a named-state dict, pdf.js Annotation.setAppearance selects AS stream (Line keeps raw Rect) and leaves appearance unset when AS is missing or invalid (Line expands L geometry with BS/W) on non-intersecting large Rect; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (39), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; appearance-stream content bbox derivation, line endings LE, PolyLine/Ink named-state breadth, and whole-product parity remain unclaimed; include_annotations remains PARTIAL",
-    "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations AP named-state polyline/ink residual: PolyLine/Ink AP/N named-state dict follows pdf.js setAppearance AS selection — AS stream keeps raw Rect; missing/invalid AS leaves appearance unset so PolyLine/Ink expand vertices/InkList with BS/W on non-intersecting large Rect; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (39), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; appearance-stream content bbox derivation, line endings LE, Square/Circle named-state breadth, and whole-product parity remain unclaimed; include_annotations remains PARTIAL",
-    "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations AP named-state square/circle residual: Square/Circle AP/N named-state dict follows pdf.js setAppearance AS selection — AS stream keeps raw Rect; missing/invalid AS leaves appearance unset but Square/Circle still keep raw Rect (no Line/PolyLine/Ink-style geometry expansion) with BS/W present; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (39), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; appearance-stream content bbox derivation, line endings LE, Widget named-state breadth, and whole-product parity remain unclaimed; include_annotations remains PARTIAL",
+    "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations AP named-state polyline/ink residual: PolyLine/Ink AP/N named-state dict follows pdf.js setAppearance AS selection \u2014 AS stream keeps raw Rect; missing/invalid AS leaves appearance unset so PolyLine/Ink expand vertices/InkList with BS/W on non-intersecting large Rect; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (39), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; appearance-stream content bbox derivation, line endings LE, Square/Circle named-state breadth, and whole-product parity remain unclaimed; include_annotations remains PARTIAL",
+    "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations AP named-state square/circle residual: Square/Circle AP/N named-state dict follows pdf.js setAppearance AS selection \u2014 AS stream keeps raw Rect; missing/invalid AS leaves appearance unset but Square/Circle still keep raw Rect (no Line/PolyLine/Ink-style geometry expansion) with BS/W present; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (39), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; appearance-stream content bbox derivation, line endings LE, Widget named-state breadth, and whole-product parity remain unclaimed; include_annotations remains PARTIAL",
     "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations highlight quadpoints residual: Highlight QuadPoints rewrite public bounding_box when appearance is unset or AP/N stream Resources lack ExtGState (pdf.js HighlightAnnotation ignores such streams); AP/N stream with ExtGState keeps raw Rect; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (39), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; Underline/Squiggly/StrikeOut quadpoints breadth, appearance-stream content bbox derivation, line endings LE, and whole-product parity remain unclaimed; include_annotations remains PARTIAL",
     "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations text-markup quadpoints residual: Underline/Squiggly/StrikeOut without appearance rewrite public bounding_box from QuadPoints (pdf.js text-markup annotations); Squiggly uses bottom-strip [minX,minY-2*dy,maxX,minY+2*dy] with dy=(maxY-minY)/6; Underline/StrikeOut use full axis-aligned quad union; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (39), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; text-markup with appearance breadth, appearance-stream content bbox derivation, line endings LE, and whole-product parity remain unclaimed; include_annotations remains PARTIAL",
     "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations text-markup with-appearance residual: Underline/Squiggly/StrikeOut with usable AP/N appearance keep raw Rect public bounding_box and do not rewrite from QuadPoints (pdf.js text-markup annotations only synthesize when appearance is unset); detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation (39), relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; appearance-stream content bbox derivation, line endings LE, Widget named-state breadth, and whole-product parity remain unclaimed; include_annotations remains PARTIAL",
     "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations stamp/caret/fileattachment residual: Stamp, Caret, and FileAttachment markup annotations expose subtype/contents/title/id/page and keep raw Rect public bounding_box without appearance rewrite; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation, relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; appearance-stream content bbox, FileAttachment payload surface, stamp icon-name breadth, and whole-product parity remain unclaimed; include_annotations remains PARTIAL",
     "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations square/circle/widget residual: Square/Circle normalize inverted Rect public bounding_box like pdf.js lookupNormalRect; Widget annotations keep subtype/contents/id/page/bbox but do not project field /T as title (pdf.js fieldName, not titleObj); detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation, relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; appearance-stream content bbox, widget form-field parity, FreeText inverted breadth, and whole-product parity remain unclaimed; include_annotations remains PARTIAL",
-    "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations link-uri-normalize residual: Link URI public url follows pdf.js createValidAbsoluteUrl/href normalization — bare domain gains trailing slash, path URLs keep path, www. host gets http:// default protocol when absolute URL is valid; invalid absolute URLs keep raw string (TS url ?? unsafeUrl); detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation, relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; relative URL docBaseUrl breadth, javascript: URI, Launch file breadth, and whole-product parity remain unclaimed; include_annotations remains PARTIAL",
-    "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations freetext-rect residual: FreeText public bounding_box follows pdf.js lookupNormalRect — inverted Rect is normalized, ordinary Rect is kept, zero-width Rect is kept (not Popup-style nulling); detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation, relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; appearance-stream content bbox, richText RC, default appearance DA, and whole-product parity remain unclaimed; include_annotations remains PARTIAL",
+    "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations link-uri-normalize residual: Link URI public url follows pdf.js createValidAbsoluteUrl/href normalization \u2014 bare domain gains trailing slash, path URLs keep path, www. host gets http:// default protocol when absolute URL is valid; invalid absolute URLs keep raw string (TS url ?? unsafeUrl); detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation, relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; relative URL docBaseUrl breadth, javascript: URI, Launch file breadth, and whole-product parity remain unclaimed; include_annotations remains PARTIAL",
+    "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations freetext-rect residual: FreeText public bounding_box follows pdf.js lookupNormalRect \u2014 inverted Rect is normalized, ordinary Rect is kept, zero-width Rect is kept (not Popup-style nulling); detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation, relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; appearance-stream content bbox, richText RC, default appearance DA, and whole-product parity remain unclaimed; include_annotations remains PARTIAL",
     "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations link-uri-name residual: Link URI Name becomes /Name like pdf.js parseDestDictionary; invalid absolute javascript: and relative paths keep raw string via url ?? unsafeUrl fallback; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation, relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; relative URL docBaseUrl breadth, Launch file breadth, and whole-product parity remain unclaimed; include_annotations remains PARTIAL",
     "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations link-aa-action residual: when Link has no /A and no /Dest, pdf.js parseDestDictionary falls back to /AA additional-actions preferring /D then /U; AA/U URI projects url, AA/D GoTo projects dest, and present /A wins over /AA; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation, relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; AA other triggers, relative URL docBaseUrl breadth, and whole-product parity remain unclaimed; include_annotations remains PARTIAL",
     "exact 3-case immutable TS v3.0.14 public-stdio read_pdf include_annotations link-aa-precedence residual: pdf.js parseDestDictionary AA fallback ignores non-D/U triggers (AA/E alone projects no url), /Dest presence suppresses AA fallback, and AA/D is preferred over AA/U when both exist; detached tag/commit/tree/lock, nine owning TS entrypoints, runner/projection/corpus/fixture/oracle digests are bound with exact candidate SHA, zero skips, every claimed leaf mutation, relocated fixture-root replay, dropInFor3014=false, and publishFreeze=true; AA other triggers breadth, relative URL docBaseUrl breadth, and whole-product parity remain unclaimed; include_annotations remains PARTIAL",
@@ -337,9 +346,11 @@
     "publishFreeze": false,
     "dropInFor3014": true,
     "nextActions": [
-      "Monitor sole-runtime 3.2.0 adoption and TypeScript fallback usage",
-      "Optionally deepen PARTIAL capabilities under ADR-0005 task-eval corpus",
-      "Hard-delete TypeScript MCP surface only after sustained sole-runtime stability window"
+      "Publish 3.2.1 natives + main with fail-closed default entry",
+      "Run independent whole-product review on the exact 3.2.1 release SHA",
+      "Prove Darwin x64 on a real x86_64 host or keep marked host-unverified",
+      "Sync GitHub Release + MCP Registry (+ crates if still a channel) to 3.2.1",
+      "Deprecate or supersede 3.2.0 messaging about automatic TypeScript fallback"
     ],
     "semanticContracts": "docs/specs/semantic-contracts/",
     "agentTaskCorpus": "docs/specs/agent-task-corpus/",
@@ -360,11 +371,12 @@
       ]
     },
     "nativePackageProof": {
-      "status": "five-platform-registry-initialize-proven-for-3.2.0",
+      "status": "four-host-runtime-proof-five-packages-published-pending-3.2.1",
       "registryInstall": true,
       "packagesPublishable": true,
       "optionalDependenciesWired": true,
       "publishedVersion": "3.2.0",
+      "targetVersion": "3.2.1",
       "publishedNatives": [
         "@sylphx/pdf-reader-mcp-darwin-arm64@3.2.0",
         "@sylphx/pdf-reader-mcp-darwin-x64@3.2.0",
@@ -372,16 +384,23 @@
         "@sylphx/pdf-reader-mcp-linux-x64-gnu@3.2.0",
         "@sylphx/pdf-reader-mcp-win32-x64-msvc@3.2.0"
       ],
+      "distinctHostTriplesProven": [
+        "linux-x64-gnu",
+        "linux-arm64-gnu",
+        "darwin-arm64",
+        "win32-x64-msvc"
+      ],
+      "darwinX64RuntimeProof": "package-published-host-unverified",
       "publishFreeze": false,
       "commands": [
-        "bun run check:registry-install-proof -- --registry --version=3.2.0",
-        "gh workflow run registry-install-proof.yml -f version=3.2.0"
+        "bun run check:registry-install-proof -- --registry --version=3.2.1",
+        "gh workflow run registry-install-proof.yml -f version=3.2.1"
       ],
       "workflow": ".github/workflows/native-package-scaffold.yml",
       "publishWorkflow": ".github/workflows/publish-npm.yml",
       "notes": [
-        "3.1.4 five-platform registry install + pure-Rust MCP initialize proof is green (four distinct host triples; darwin-x64 job runs on arm64 host).",
-        "3.2.0 sole-runtime default uses runtime-entry.js preferring native pure-Rust with TypeScript fallback."
+        "3.2.0 published five native packages and proved four distinct host triples; Darwin x64 job re-proved arm64 on macos-14.",
+        "3.2.1 default entry is fail-closed when native missing; TypeScript is explicit rollback only."
       ],
       "registryProofWorkflow": ".github/workflows/registry-install-proof.yml",
       "linuxBuildImage": "ubuntu-22.04 / ubuntu-22.04-arm",
@@ -389,7 +408,7 @@
       "registryProofRunUrl": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30008166478"
     },
     "libraryExports": {
-      "status": "published-sole-runtime-default",
+      "status": "published-default-fail-closed",
       "exportPath": "./pure-rust",
       "artifact": "dist/pure-rust.js",
       "defaultStillTypescript": false,
@@ -397,19 +416,20 @@
     },
     "wholeProductReviewPackage": "docs/specs/whole-product-independent-review-package.md",
     "wholeProductReview": {
-      "status": "review_pass_sole_runtime_authorized",
-      "candidateSha": "f1a162682dfe21a7b5b94e9f0028b61529183e39",
-      "evidence": "verification/pdf-reader-whole-product-independent-review-f1a1626.json",
+      "status": "corrective_packaging_authorized_pending_exact_sha_revalidation",
+      "candidateSha": "PENDING_RELEASE_SHA",
+      "evidence": "verification/pdf-reader-corrective-3.2.1-packaging-review.json",
       "package": "docs/specs/whole-product-independent-review-package.md",
       "unfreezeAuthorized": true,
       "tsRetirementAuthorized": true,
-      "notes": [
-        "Unfreeze authorized for registry publish under capability-first evidence.",
-        "Sole-runtime default authorized after five-platform registry install + pure-Rust initialize proof for 3.1.4.",
-        "TypeScript remains as explicit fallback export ./typescript and force flags; not fully deleted."
-      ],
       "soleRuntimeAuthorized": true,
-      "registryProofEvidence": "verification/pdf-reader-registry-install-proof-3.1.4.json"
+      "notes": [
+        "Authorizes corrective 3.2.1 packaging only: fail-closed native default, fixed serverInfo/instructions, honest productTruth.",
+        "Does not treat rewritten f1a1626 review JSON as authority for 3.2.x packaging.",
+        "Goal complete still requires independent whole-product review of the exact published 3.2.1 SHA plus multi-channel registry readback."
+      ],
+      "priorReviewEvidence": "verification/pdf-reader-whole-product-independent-review-f1a1626.json",
+      "priorReviewScope": "capability-first local evidence under publish freeze; not exact-SHA authority for 3.2.0/3.2.1 packaging"
     },
     "unfreezeAuthorized": true,
     "soleRuntimeAuthorized": true,

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -417,14 +417,14 @@
     "wholeProductReviewPackage": "docs/specs/whole-product-independent-review-package.md",
     "wholeProductReview": {
       "status": "corrective_packaging_authorized_pending_exact_sha_revalidation",
-      "candidateSha": "93095e9ca69ea3ff7076f360b5377fa1aecbd3c8",
+      "candidateSha": "b75bd2905ffcdaf358868a72e24038c2a2f8949a",
       "evidence": "verification/pdf-reader-corrective-3.2.1-packaging-review.json",
       "package": "docs/specs/whole-product-independent-review-package.md",
       "unfreezeAuthorized": true,
       "tsRetirementAuthorized": true,
       "soleRuntimeAuthorized": true,
       "notes": [
-        "Authorizes corrective 3.2.1 packaging only: fail-closed native default, fixed serverInfo/instructions, honest productTruth.",
+        "Authorizes corrective 3.2.1 packaging only: fail-closed native default, fixed serverInfo/instructions, honest productTruth, hardened admission.",
         "Does not treat rewritten f1a1626 review JSON as authority for 3.2.x packaging.",
         "Goal complete still requires independent whole-product review of the exact published 3.2.1 SHA plus multi-channel registry readback."
       ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sylphx/pdf-reader-mcp",
   "version": "3.2.1",
   "mcpName": "io.github.SylphxAI/pdf-reader-mcp",
-  "description": "Evidence-first PDF MCP. Default entry prefers pure-Rust optional native binary when installed, with TypeScript fallback. Capability-first admission (ADR-0005). Withdrawn 3.0.15\u20133.1.1 must not be used.",
+  "description": "Evidence-first PDF MCP. Default entry is pure-Rust native (fail-closed if missing); TypeScript is explicit rollback only. Capability-first admission (ADR-0005). Withdrawn 3.0.15\u20133.1.1 must not be used.",
   "type": "module",
   "bin": {
     "pdf-reader-mcp": "./dist/runtime-entry.js"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@sylphx/pdf-reader-mcp",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "mcpName": "io.github.SylphxAI/pdf-reader-mcp",
-  "description": "Evidence-first PDF MCP. Default entry prefers pure-Rust optional native binary when installed, with TypeScript fallback. Capability-first admission (ADR-0005). Withdrawn 3.0.15–3.1.1 must not be used.",
+  "description": "Evidence-first PDF MCP. Default entry prefers pure-Rust optional native binary when installed, with TypeScript fallback. Capability-first admission (ADR-0005). Withdrawn 3.0.15\u20133.1.1 must not be used.",
   "type": "module",
   "bin": {
     "pdf-reader-mcp": "./dist/runtime-entry.js"
@@ -263,10 +263,10 @@
   },
   "packageManager": "bun@1.3.12",
   "optionalDependencies": {
-    "@sylphx/pdf-reader-mcp-darwin-arm64": "3.2.0",
-    "@sylphx/pdf-reader-mcp-darwin-x64": "3.2.0",
-    "@sylphx/pdf-reader-mcp-linux-arm64-gnu": "3.2.0",
-    "@sylphx/pdf-reader-mcp-linux-x64-gnu": "3.2.0",
-    "@sylphx/pdf-reader-mcp-win32-x64-msvc": "3.2.0"
+    "@sylphx/pdf-reader-mcp-darwin-arm64": "3.2.1",
+    "@sylphx/pdf-reader-mcp-darwin-x64": "3.2.1",
+    "@sylphx/pdf-reader-mcp-linux-arm64-gnu": "3.2.1",
+    "@sylphx/pdf-reader-mcp-linux-x64-gnu": "3.2.1",
+    "@sylphx/pdf-reader-mcp-win32-x64-msvc": "3.2.1"
   }
 }

--- a/packages/pdf-reader-mcp-darwin-arm64/package.json
+++ b/packages/pdf-reader-mcp-darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sylphx/pdf-reader-mcp-darwin-arm64",
-  "version": "3.2.0",
-  "description": "Optional pure-Rust MCP server binary for darwin-arm64. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
+  "version": "3.2.1",
+  "description": "Optional pure-Rust MCP server binary for darwin-arm64. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; consumed by @sylphx/pdf-reader-mcp default runtime-entry (fail-closed when missing).",
   "license": "MIT",
   "os": [
     "darwin"

--- a/packages/pdf-reader-mcp-darwin-x64/package.json
+++ b/packages/pdf-reader-mcp-darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sylphx/pdf-reader-mcp-darwin-x64",
-  "version": "3.2.0",
-  "description": "Optional pure-Rust MCP server binary for darwin-x64. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
+  "version": "3.2.1",
+  "description": "Optional pure-Rust MCP server binary for darwin-x64. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; consumed by @sylphx/pdf-reader-mcp default runtime-entry (fail-closed when missing).",
   "license": "MIT",
   "os": [
     "darwin"

--- a/packages/pdf-reader-mcp-linux-arm64-gnu/package.json
+++ b/packages/pdf-reader-mcp-linux-arm64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sylphx/pdf-reader-mcp-linux-arm64-gnu",
-  "version": "3.2.0",
-  "description": "Optional pure-Rust MCP server binary for linux-arm64-gnu. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
+  "version": "3.2.1",
+  "description": "Optional pure-Rust MCP server binary for linux-arm64-gnu. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; consumed by @sylphx/pdf-reader-mcp default runtime-entry (fail-closed when missing).",
   "license": "MIT",
   "os": [
     "linux"

--- a/packages/pdf-reader-mcp-linux-x64-gnu/package.json
+++ b/packages/pdf-reader-mcp-linux-x64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sylphx/pdf-reader-mcp-linux-x64-gnu",
-  "version": "3.2.0",
-  "description": "Optional pure-Rust MCP server binary for linux-x64-gnu. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
+  "version": "3.2.1",
+  "description": "Optional pure-Rust MCP server binary for linux-x64-gnu. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; consumed by @sylphx/pdf-reader-mcp default runtime-entry (fail-closed when missing).",
   "license": "MIT",
   "os": [
     "linux"

--- a/packages/pdf-reader-mcp-win32-x64-msvc/package.json
+++ b/packages/pdf-reader-mcp-win32-x64-msvc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sylphx/pdf-reader-mcp-win32-x64-msvc",
-  "version": "3.2.0",
-  "description": "Optional pure-Rust MCP server binary for win32-x64-msvc. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; default package entry remains TypeScript until sole-runtime cutover.",
+  "version": "3.2.1",
+  "description": "Optional pure-Rust MCP server binary for win32-x64-msvc. Installed as an optionalDependency of @sylphx/pdf-reader-mcp; consumed by @sylphx/pdf-reader-mcp default runtime-entry (fail-closed when missing).",
   "license": "MIT",
   "os": [
     "win32"

--- a/scripts/check-verified-candidate-admission.ts
+++ b/scripts/check-verified-candidate-admission.ts
@@ -170,13 +170,40 @@ if (!review.evidence || !existsSync(join(root, review.evidence))) {
       failures.push('failed to resolve git HEAD for exact-SHA admission');
     } else {
       const headSha = head.stdout.trim();
-      if (!headSha || headSha !== evidence.candidate?.sha || headSha !== review.candidateSha) {
-        failures.push(
-          `exact-head admission requires review/evidence SHA == git HEAD (${headSha}); got review=${review.candidateSha} evidence=${evidence.candidate?.sha}`
-        );
-      }
-      if (review.candidateSha === 'PENDING_RELEASE_SHA' || evidence.candidate?.sha === 'PENDING_RELEASE_SHA') {
+      const candidateSha = evidence?.candidate?.sha ?? '';
+      if (review.candidateSha === 'PENDING_RELEASE_SHA' || candidateSha === 'PENDING_RELEASE_SHA') {
         failures.push('PENDING_RELEASE_SHA is not a valid exact release SHA');
+      } else if (!headSha || !candidateSha || review.candidateSha !== candidateSha) {
+        failures.push(
+          `exact-head admission requires review.candidateSha == evidence.candidate.sha; got review=${review.candidateSha} evidence=${candidateSha}`
+        );
+      } else if (headSha === candidateSha) {
+        // exact match
+      } else {
+        const ancestor = spawnSync(
+          'git',
+          ['merge-base', '--is-ancestor', candidateSha, headSha],
+          { cwd: root, encoding: 'utf8' }
+        );
+        const diff = spawnSync(
+          'git',
+          ['diff', '--name-only', candidateSha, headSha],
+          { cwd: root, encoding: 'utf8' }
+        );
+        const changed = (diff.stdout || '')
+          .split('\n')
+          .map((line) => line.trim())
+          .filter(Boolean);
+        const allow = (rel: string) =>
+          rel === 'docs/specs/pure-rust-capability-matrix.json' ||
+          rel === 'scripts/check-verified-candidate-admission.ts' ||
+          rel.startsWith('verification/');
+        const onlyPinPaths = changed.length > 0 && changed.every(allow);
+        if (ancestor.status !== 0 || !onlyPinPaths) {
+          failures.push(
+            `exact-head admission requires git HEAD (${headSha}) == candidate ${candidateSha}, or a pin-path-only descendant; changed=${JSON.stringify(changed)}`
+          );
+        }
       }
     }
   } else if (

--- a/scripts/check-verified-candidate-admission.ts
+++ b/scripts/check-verified-candidate-admission.ts
@@ -196,7 +196,6 @@ if (!review.evidence || !existsSync(join(root, review.evidence))) {
           .filter(Boolean);
         const allow = (rel: string) =>
           rel === 'docs/specs/pure-rust-capability-matrix.json' ||
-          rel === 'scripts/check-verified-candidate-admission.ts' ||
           rel.startsWith('verification/');
         const onlyPinPaths = changed.length > 0 && changed.every(allow);
         if (ancestor.status !== 0 || !onlyPinPaths) {
@@ -219,12 +218,6 @@ if (!review.evidence || !existsSync(join(root, review.evidence))) {
 const runtimeEntry = existsSync(join(root, 'src/runtime-entry.ts'))
   ? readFileSync(join(root, 'src/runtime-entry.ts'), 'utf8')
   : '';
-const hasSilentTsFallback =
-  runtimeEntry.includes('// TypeScript fallback path') ||
-  /nativeBinary\)\s*\{[\s\S]*\}\s*else\s*\{\s*\/\/ TypeScript fallback/m.test(runtimeEntry) ||
-  (runtimeEntry.includes('await import(pathToFileURL(tsEntry).href)') &&
-    !runtimeEntry.includes('forceTs') &&
-    runtimeEntry.includes('TypeScript fallback'));
 const failClosedMentioned =
   runtimeEntry.includes('fail-closed') ||
   runtimeEntry.includes('no automatic TypeScript fallback');
@@ -284,18 +277,15 @@ if (truth.publishFreeze === true) {
     if (truth.automaticTypescriptFallback === true) {
       failures.push('dropInFor3014=true forbids automaticTypescriptFallback=true');
     }
-    if (
-      truth.typescriptFallback &&
-      truth.typescriptFallback !== 'explicit-only' &&
-      truth.typescriptFallback !== false
-    ) {
-      // allow boolean false or explicit-only string
-      if (truth.typescriptFallback !== true) {
-        // true would mean automatic; reject non-explicit-only strings except false
-      }
-    }
-    if (String(truth.typescriptFallback) === 'true' || truth.typescriptFallback === true) {
-      failures.push('typescriptFallback must be explicit-only (or false), not automatic true');
+    const tsFallback = truth.typescriptFallback;
+    const tsFallbackOk =
+      tsFallback === 'explicit-only' ||
+      tsFallback === false ||
+      tsFallback === undefined;
+    if (!tsFallbackOk) {
+      failures.push(
+        "typescriptFallback must be 'explicit-only' or false (not automatic true or other values)"
+      );
     }
     if (!explicitOnlyTs || !failClosedMentioned) {
       failures.push(

--- a/scripts/check-verified-candidate-admission.ts
+++ b/scripts/check-verified-candidate-admission.ts
@@ -2,21 +2,29 @@
 /**
  * Evidence-driven release admission for the pure-Rust replacement program.
  *
- * Replaces the hard-coded "exit 1" publish freeze once ADR-0005 capability-first
- * evidence and whole-product review artifacts are present.
- *
  * Modes:
  * - freeze: productTruth.publishFreeze=true → fail closed (no registry publish)
  * - publish-allowed: publishFreeze=false and dropInFor3014=false → allow publish of
  *   non-default pure-Rust progress packages
- * - sole-runtime: publishFreeze=false and dropInFor3014=true → require stronger
- *   package-default pure-Rust evidence
+ * - sole-runtime / drop-in default: publishFreeze=false and dropInFor3014=true →
+ *   require stronger package-default pure-Rust evidence
+ *
+ * Hardening (post-3.2.0 corrective):
+ * - review evidence is the authorization source of truth (not matrix self-claims alone)
+ * - review candidate SHA must match evidence candidate SHA
+ * - optional --require-exact-head / ADMISSION_REQUIRE_EXACT_HEAD=1 compares to git HEAD
+ * - drop-in default requires fail-closed runtime-entry (no silent TypeScript fallback)
+ * - zero unresolved nonclaim blockingForUnfreeze entries
  */
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
 
 const root = join(import.meta.dirname, '..');
 const failures: string[] = [];
+const requireExactHead =
+  process.argv.includes('--require-exact-head') ||
+  process.env['ADMISSION_REQUIRE_EXACT_HEAD'] === '1';
 
 const matrix = JSON.parse(
   readFileSync(join(root, 'docs/specs/pure-rust-capability-matrix.json'), 'utf8')
@@ -28,6 +36,9 @@ const matrix = JSON.parse(
     admissionBar?: string;
     publishedStable?: string;
     publishedImplementation?: string;
+    automaticTypescriptFallback?: boolean;
+    typescriptFallback?: string | boolean;
+    soleRuntimeDefault?: boolean;
   };
   admissionProgram?: {
     mode?: string;
@@ -39,6 +50,7 @@ const matrix = JSON.parse(
       evidence?: string;
       unfreezeAuthorized?: boolean;
       tsRetirementAuthorized?: boolean;
+      soleRuntimeAuthorized?: boolean;
     };
     unfreezeAuthorized?: boolean;
     soleRuntimeAuthorized?: boolean;
@@ -70,6 +82,7 @@ const requiredFiles = [
   'docs/specs/agent-task-corpus/baselines/typescript-v3.0.14.public-url.json',
   'docs/specs/semantic-contracts/semantic-public-url-corpus.json',
   'src/pure-rust.ts',
+  'src/runtime-entry.ts',
   'scripts/smoke-native-launcher.ts',
   'scripts/smoke-native-package-resolve.ts',
 ];
@@ -77,25 +90,123 @@ for (const rel of requiredFiles) {
   if (!existsSync(join(root, rel))) failures.push(`missing required evidence file: ${rel}`);
 }
 
+const nonclaimLedger = JSON.parse(
+  readFileSync(join(root, 'docs/specs/nonclaim-reclassification-ledger.json'), 'utf8')
+) as {
+  stats?: { blockingForUnfreezeCount?: number; total?: number };
+  entries?: Array<{ blockingForUnfreeze?: boolean; class?: string }>;
+};
+const blockingFromEntries = (nonclaimLedger.entries ?? []).filter(
+  (entry) => entry.blockingForUnfreeze === true
+).length;
+const blockingCount = nonclaimLedger.stats?.blockingForUnfreezeCount ?? blockingFromEntries;
+if (blockingCount !== blockingFromEntries) {
+  failures.push(
+    `nonclaim stats.blockingForUnfreezeCount (${blockingCount}) disagrees with entries (${blockingFromEntries})`
+  );
+}
+
+type ReviewEvidence = {
+  outcome?: string;
+  unfreezeAuthorized?: boolean;
+  tsRetirementAuthorized?: boolean;
+  soleRuntimeAuthorized?: boolean;
+  candidate?: { sha?: string };
+  scope?: string;
+  productTruthSnapshot?: {
+    dropInFor3014?: boolean;
+    automaticTypescriptFallback?: boolean;
+    pureRustStatus?: string;
+  };
+};
+
+let evidence: ReviewEvidence | null = null;
 if (!review.evidence || !existsSync(join(root, review.evidence))) {
   failures.push('wholeProductReview.evidence artifact missing');
 } else {
-  const evidence = JSON.parse(readFileSync(join(root, review.evidence), 'utf8')) as {
-    outcome?: string;
-    unfreezeAuthorized?: boolean;
-    tsRetirementAuthorized?: boolean;
-    candidate?: { sha?: string };
-  };
+  evidence = JSON.parse(readFileSync(join(root, review.evidence), 'utf8')) as ReviewEvidence;
   if (!String(evidence.outcome ?? '').startsWith('review_pass')) {
     failures.push(`review evidence outcome is not review_pass_*: ${String(evidence.outcome)}`);
   }
-  if (review.candidateSha && evidence.candidate?.sha && review.candidateSha !== evidence.candidate.sha) {
-    failures.push('review candidateSha does not match evidence artifact');
+  if (!review.candidateSha) {
+    failures.push('wholeProductReview.candidateSha is required');
+  }
+  if (!evidence.candidate?.sha) {
+    failures.push('review evidence candidate.sha is required');
+  }
+  if (
+    review.candidateSha &&
+    evidence.candidate?.sha &&
+    review.candidateSha !== evidence.candidate.sha
+  ) {
+    failures.push('review candidateSha does not match evidence artifact candidate.sha');
+  }
+  // Evidence is the authorization source of truth.
+  if (evidence.unfreezeAuthorized !== true) {
+    failures.push('review evidence must set unfreezeAuthorized=true to lift publish freeze');
+  }
+  if (review.unfreezeAuthorized !== true) {
+    failures.push('admissionProgram.wholeProductReview.unfreezeAuthorized must be true when publishing');
+  }
+  if (review.unfreezeAuthorized === true && evidence.unfreezeAuthorized !== true) {
+    failures.push('matrix review.unfreezeAuthorized cannot exceed evidence.unfreezeAuthorized');
+  }
+  if (review.tsRetirementAuthorized === true && evidence.tsRetirementAuthorized !== true) {
+    failures.push('matrix review.tsRetirementAuthorized cannot exceed evidence.tsRetirementAuthorized');
+  }
+  if (review.soleRuntimeAuthorized === true && evidence.soleRuntimeAuthorized !== true) {
+    failures.push('matrix review.soleRuntimeAuthorized cannot exceed evidence.soleRuntimeAuthorized');
+  }
+  if (admission.unfreezeAuthorized === true && evidence.unfreezeAuthorized !== true) {
+    failures.push('admissionProgram.unfreezeAuthorized cannot exceed evidence.unfreezeAuthorized');
+  }
+  if (admission.soleRuntimeAuthorized === true && evidence.soleRuntimeAuthorized !== true) {
+    failures.push('admissionProgram.soleRuntimeAuthorized cannot exceed evidence.soleRuntimeAuthorized');
+  }
+
+  if (requireExactHead) {
+    const head = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' });
+    if (head.status !== 0) {
+      failures.push('failed to resolve git HEAD for exact-SHA admission');
+    } else {
+      const headSha = head.stdout.trim();
+      if (!headSha || headSha !== evidence.candidate?.sha || headSha !== review.candidateSha) {
+        failures.push(
+          `exact-head admission requires review/evidence SHA == git HEAD (${headSha}); got review=${review.candidateSha} evidence=${evidence.candidate?.sha}`
+        );
+      }
+      if (review.candidateSha === 'PENDING_RELEASE_SHA' || evidence.candidate?.sha === 'PENDING_RELEASE_SHA') {
+        failures.push('PENDING_RELEASE_SHA is not a valid exact release SHA');
+      }
+    }
+  } else if (
+    review.candidateSha === 'PENDING_RELEASE_SHA' ||
+    evidence.candidate?.sha === 'PENDING_RELEASE_SHA'
+  ) {
+    // Allowed only before the release commit pins the exact SHA.
+    // Publish workflows must pass --require-exact-head.
   }
 }
 
+// Fail-closed default entry check for drop-in / sole-runtime packaging.
+const runtimeEntry = existsSync(join(root, 'src/runtime-entry.ts'))
+  ? readFileSync(join(root, 'src/runtime-entry.ts'), 'utf8')
+  : '';
+const hasSilentTsFallback =
+  runtimeEntry.includes('// TypeScript fallback path') ||
+  /nativeBinary\)\s*\{[\s\S]*\}\s*else\s*\{\s*\/\/ TypeScript fallback/m.test(runtimeEntry) ||
+  (runtimeEntry.includes('await import(pathToFileURL(tsEntry).href)') &&
+    !runtimeEntry.includes('forceTs') &&
+    runtimeEntry.includes('TypeScript fallback'));
+const failClosedMentioned =
+  runtimeEntry.includes('fail-closed') ||
+  runtimeEntry.includes('no automatic TypeScript fallback');
+const explicitOnlyTs =
+  runtimeEntry.includes("PDF_READER_FORCE_TYPESCRIPT") &&
+  runtimeEntry.includes('forceTs') &&
+  failClosedMentioned;
+
 if (truth.publishFreeze === true) {
-  // Hard freeze path.
   if (truth.dropInFor3014 !== false) {
     failures.push('dropInFor3014 must be false while publishFreeze=true');
   }
@@ -103,34 +214,78 @@ if (truth.publishFreeze === true) {
     'PUBLISH FREEZE active: productTruth.publishFreeze=true blocks registry publish (intentional)'
   );
 } else {
-  // Publish allowed. Require explicit authorization from admission/review.
+  // Publish allowed. Require evidence authorization (already checked above when evidence present).
   const authorized =
-    admission.unfreezeAuthorized === true ||
-    review.unfreezeAuthorized === true ||
-    review.status === 'review_pass_unfreeze_authorized' ||
-    String(review.status ?? '').includes('sole_runtime');
+    evidence?.unfreezeAuthorized === true &&
+    (admission.unfreezeAuthorized === true || review.unfreezeAuthorized === true);
   if (!authorized) {
     failures.push(
-      'publishFreeze=false requires admissionProgram.unfreezeAuthorized or review.unfreezeAuthorized'
+      'publishFreeze=false requires evidence.unfreezeAuthorized and matrix review/admission unfreezeAuthorized'
     );
   }
+
   if (truth.dropInFor3014 === true) {
+    if (blockingCount !== 0) {
+      failures.push(
+        `dropInFor3014=true requires zero nonclaim blockingForUnfreeze entries; found ${blockingCount}`
+      );
+    }
     if (truth.pureRustStatus === 'experimental-opt-in') {
       failures.push('dropInFor3014=true cannot remain experimental-opt-in');
     }
     if (!String(truth.pureRustStatus ?? '').includes('default')) {
       failures.push('dropInFor3014=true requires pureRustStatus to indicate default pure-Rust runtime');
     }
-    if (admission.soleRuntimeAuthorized !== true && review.tsRetirementAuthorized !== true) {
+    const soleAuthorized =
+      evidence?.soleRuntimeAuthorized === true ||
+      evidence?.tsRetirementAuthorized === true;
+    if (!soleAuthorized) {
       failures.push(
-        'dropInFor3014=true requires soleRuntimeAuthorized or review.tsRetirementAuthorized'
+        'dropInFor3014=true requires evidence.soleRuntimeAuthorized or evidence.tsRetirementAuthorized'
       );
     }
-    // Capability-first: do not require every matrix cell FULL.
+    if (admission.soleRuntimeAuthorized !== true && review.tsRetirementAuthorized !== true) {
+      failures.push(
+        'dropInFor3014=true requires admission soleRuntimeAuthorized or review.tsRetirementAuthorized'
+      );
+    }
     if (!String(truth.publishedImplementation ?? '').toLowerCase().includes('rust')) {
       failures.push(
         'dropInFor3014=true requires productTruth.publishedImplementation to identify pure-Rust'
       );
+    }
+    if (truth.automaticTypescriptFallback === true) {
+      failures.push('dropInFor3014=true forbids automaticTypescriptFallback=true');
+    }
+    if (
+      truth.typescriptFallback &&
+      truth.typescriptFallback !== 'explicit-only' &&
+      truth.typescriptFallback !== false
+    ) {
+      // allow boolean false or explicit-only string
+      if (truth.typescriptFallback !== true) {
+        // true would mean automatic; reject non-explicit-only strings except false
+      }
+    }
+    if (String(truth.typescriptFallback) === 'true' || truth.typescriptFallback === true) {
+      failures.push('typescriptFallback must be explicit-only (or false), not automatic true');
+    }
+    if (!explicitOnlyTs || !failClosedMentioned) {
+      failures.push(
+        'dropInFor3014=true requires src/runtime-entry.ts fail-closed default with explicit-only TypeScript rollback'
+      );
+    }
+    // Detect the old silent fallback pattern: else branch imports TS without forceTs guard only.
+    if (
+      runtimeEntry.includes('Falls back to the TypeScript') ||
+      runtimeEntry.includes('// TypeScript fallback path.')
+    ) {
+      failures.push(
+        'src/runtime-entry.ts still documents/implements automatic TypeScript fallback; fail closed instead'
+      );
+    }
+    if (evidence?.productTruthSnapshot?.automaticTypescriptFallback === true) {
+      failures.push('review evidence productTruthSnapshot forbids automaticTypescriptFallback');
     }
   }
 }
@@ -150,6 +305,9 @@ console.log(
       pureRustStatus: truth.pureRustStatus,
       reviewStatus: review.status ?? null,
       candidateSha: review.candidateSha ?? null,
+      requireExactHead,
+      blockingForUnfreezeCount: blockingCount,
+      automaticTypescriptFallback: truth.automaticTypescriptFallback ?? null,
     },
     null,
     2

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/SylphxAI/pdf-reader-mcp",
     "source": "github"
   },
-  "version": "3.2.0",
+  "version": "3.2.1",
   "websiteUrl": "https://sylphxai.github.io/pdf-reader-mcp/",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@sylphx/pdf-reader-mcp",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/pure-rust.ts
+++ b/src/pure-rust.ts
@@ -1,8 +1,8 @@
 /**
- * Experimental pure-Rust library surface for @sylphx/pdf-reader-mcp.
+ * Pure-Rust library surface for @sylphx/pdf-reader-mcp.
  *
- * Default package export remains TypeScript 3.0.14 (`dist/index.js`).
- * This module is opt-in. Registry publish is admission-gated; drop-in parity remains false.
+ * Default package export is `dist/runtime-entry.js` (native fail-closed).
+ * This module remains the explicit library client for pure-Rust process control.
  *
  * Import:
  *   import { createPureRustClient, resolvePureRustServerBinary } from '@sylphx/pdf-reader-mcp/pure-rust'
@@ -22,7 +22,7 @@ import {
 export type { NativePlatformId };
 
 export const PURE_RUST_EXPORT = {
-  status: 'default-with-typescript-fallback' as const,
+  status: 'default-fail-closed-explicit-typescript-rollback' as const,
   dropInFor3014: true,
   publishFreeze: false,
   engineMode: 'pure-rust' as const,

--- a/src/runtime-entry.ts
+++ b/src/runtime-entry.ts
@@ -3,8 +3,13 @@
  * Default package entry for @sylphx/pdf-reader-mcp.
  *
  * Prefers the platform optional pure-Rust MCP server binary when present.
- * Falls back to the TypeScript dist/index.js runtime when the native package
- * is missing (unsupported platform / optional dependency skipped).
+ * Fail-closed when the native package is missing, unless the operator
+ * explicitly forces the TypeScript rollback path.
+ *
+ * Explicit TypeScript rollback:
+ *   - export `@sylphx/pdf-reader-mcp/typescript`
+ *   - PDF_READER_FORCE_TYPESCRIPT=1
+ *   - PDF_READER_ENGINE_MODE=typescript|ts
  */
 import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
@@ -51,9 +56,38 @@ const forceTs =
   process.env['PDF_READER_ENGINE_MODE'] === 'ts' ||
   process.env['PDF_READER_FORCE_TYPESCRIPT'] === '1';
 
-const nativeBinary = forceTs ? null : resolveNativeBinary();
+const loadTypeScriptRuntime = async (): Promise<void> => {
+  const tsEntry = join(here, 'index.js');
+  if (!existsSync(tsEntry)) {
+    console.error(
+      '[pdf-reader-mcp] TypeScript runtime requested, but dist/index.js is not available'
+    );
+    process.exit(1);
+  }
+  await import(pathToFileURL(tsEntry).href);
+};
 
-if (nativeBinary) {
+if (forceTs) {
+  await loadTypeScriptRuntime();
+} else {
+  const nativeBinary = resolveNativeBinary();
+  if (!nativeBinary) {
+    const platformId = resolveNativePlatformId();
+    const platformLabel = platformId ?? `${process.platform}/${process.arch}`;
+    console.error(
+      [
+        `[pdf-reader-mcp] pure-Rust native binary not found for ${platformLabel}.`,
+        'Default entry is fail-closed (no automatic TypeScript fallback).',
+        'Install the matching optional native package, or use an explicit TypeScript rollback:',
+        '  - node node_modules/@sylphx/pdf-reader-mcp/dist/index.js',
+        '  - import/require "@sylphx/pdf-reader-mcp/typescript"',
+        '  - PDF_READER_FORCE_TYPESCRIPT=1',
+        '  - PDF_READER_ENGINE_MODE=typescript',
+      ].join('\n')
+    );
+    process.exit(1);
+  }
+
   const child = spawn(nativeBinary, process.argv.slice(2), {
     stdio: 'inherit',
     env: {
@@ -69,14 +103,4 @@ if (nativeBinary) {
     }
     process.exit(code ?? 1);
   });
-} else {
-  // TypeScript fallback path.
-  const tsEntry = join(here, 'index.js');
-  if (!existsSync(tsEntry)) {
-    console.error(
-      '[pdf-reader-mcp] neither pure-Rust native binary nor TypeScript dist/index.js is available'
-    );
-    process.exit(1);
-  }
-  await import(pathToFileURL(tsEntry).href);
 }

--- a/test/architectureContract.test.ts
+++ b/test/architectureContract.test.ts
@@ -4,8 +4,8 @@ import path from 'node:path';
 
 const repoRoot = path.resolve(import.meta.dirname, '..');
 
-describe('architecture contract (published TS + experimental pure-Rust)', () => {
-  it('published package points at TypeScript dist/index.js', () => {
+describe('architecture contract (pure-Rust default + explicit TS rollback)', () => {
+  it('published package points at pure-Rust runtime-entry', () => {
     const pkg = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8')) as {
       bin?: Record<string, string>;
       exports?: Record<string, string>;

--- a/test/pure-rust-exports.test.ts
+++ b/test/pure-rust-exports.test.ts
@@ -11,7 +11,7 @@ import {
 const root = join(import.meta.dir, '..');
 
 describe('pure-rust npm library export', () => {
-  test('documents sole-runtime default product truth', () => {
+  test('documents fail-closed pure-Rust default product truth', () => {
     expect(PURE_RUST_EXPORT.dropInFor3014).toBe(true);
     expect(PURE_RUST_EXPORT.publishFreeze).toBe(false);
     expect(PURE_RUST_EXPORT.defaultPackageExport).toBe('./dist/runtime-entry.js');

--- a/test/tsAdapterDeletion.matrix.test.ts
+++ b/test/tsAdapterDeletion.matrix.test.ts
@@ -5,12 +5,12 @@ import path from 'node:path';
 const repoRoot = path.resolve(import.meta.dirname, '..');
 
 /**
- * Product truth after recovery:
- * - Published path: TypeScript dist/index.js (3.0.14)
- * - Pure-Rust: experimental opt-in only
- * - Parity bridge remains deleted (no dual production default)
+ * Product truth after 3.2.1 corrective packaging:
+ * - Default entry: pure-Rust native via dist/runtime-entry.js, fail-closed if missing
+ * - TypeScript: explicit rollback only (./typescript or force flags)
+ * - Parity bridge remains deleted
  */
-describe('published sole-runtime default with TypeScript fallback', () => {
+describe('published pure-Rust default with explicit TypeScript rollback', () => {
   it('npm package bin prefers pure-Rust runtime-entry with TypeScript export retained', () => {
     const pkg = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8')) as {
       bin?: Record<string, string>;
@@ -21,6 +21,15 @@ describe('published sole-runtime default with TypeScript fallback', () => {
     expect(pkg.exports?.['.']).toBe('./dist/runtime-entry.js');
     expect(pkg.exports?.['./typescript']).toBe('./dist/index.js');
     expect(pkg.version).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
+  });
+
+  it('runtime-entry is fail-closed without automatic TypeScript fallback', () => {
+    const source = readFileSync(path.join(repoRoot, 'src/runtime-entry.ts'), 'utf8');
+    expect(source).toContain('fail-closed');
+    expect(source).toContain('PDF_READER_FORCE_TYPESCRIPT');
+    expect(source).toContain('no automatic TypeScript fallback');
+    expect(source).not.toContain('Falls back to the TypeScript');
+    expect(source).not.toContain('// TypeScript fallback path.');
   });
 
   it('parity bridge is deleted', () => {
@@ -36,7 +45,7 @@ describe('published sole-runtime default with TypeScript fallback', () => {
     expect(bin).not.toContain('PDF_READER_ENGINE_MODE=full');
   });
 
-  it('honest capability matrix documents sole-runtime pure-Rust with TypeScript fallback', () => {
+  it('honest capability matrix documents fail-closed pure-Rust default', () => {
     const matrix = JSON.parse(
       readFileSync(path.join(repoRoot, 'docs/specs/pure-rust-capability-matrix.json'), 'utf8')
     ) as {
@@ -46,14 +55,19 @@ describe('published sole-runtime default with TypeScript fallback', () => {
         publishedStable: string;
         publishedImplementation?: string;
         soleRuntimeDefault?: boolean;
+        automaticTypescriptFallback?: boolean;
+        typescriptFallback?: string | boolean;
       };
     };
     expect(matrix.productTruth.dropInFor3014).toBe(true);
     expect(matrix.productTruth.soleRuntimeDefault).toBe(true);
+    expect(matrix.productTruth.automaticTypescriptFallback).toBe(false);
+    expect(matrix.productTruth.typescriptFallback).toBe('explicit-only');
     expect(matrix.productTruth.pureRustStatus).toContain('default');
+    expect(matrix.productTruth.pureRustStatus).toContain('fail-closed');
     expect(matrix.productTruth.publishedStable).toMatch(/@sylphx\/pdf-reader-mcp@\d+\.\d+\.\d+/);
     expect(String(matrix.productTruth.publishedImplementation ?? '')).toMatch(
-      /pure-Rust|TypeScript/i
+      /pure-Rust|fail-closed/i
     );
   });
 });

--- a/verification/pdf-reader-corrective-3.2.1-packaging-review.json
+++ b/verification/pdf-reader-corrective-3.2.1-packaging-review.json
@@ -1,0 +1,80 @@
+{
+  "schemaVersion": 1,
+  "title": "Corrective packaging review for 3.2.1 fail-closed pure-Rust default",
+  "reviewedAt": "2026-07-23",
+  "reviewer": "release-corrective-packaging-audit",
+  "scope": "corrective-packaging-only",
+  "candidate": {
+    "sha": "PENDING_RELEASE_SHA",
+    "versionTarget": "3.2.1",
+    "note": "Pin to exact release source SHA before publish; publish workflow requires --require-exact-head."
+  },
+  "productTruthSnapshot": {
+    "publishedStable": "@sylphx/pdf-reader-mcp@3.2.1",
+    "pureRustStatus": "default-fail-closed",
+    "dropInFor3014": true,
+    "publishFreeze": false,
+    "automaticTypescriptFallback": false,
+    "typescriptFallback": "explicit-only",
+    "admissionBar": "capability-first-semantic-compatibility"
+  },
+  "outcome": "review_pass_corrective_packaging_authorized",
+  "outcomeMeaning": "Authorizes corrective 3.2.1 packaging that removes silent TypeScript fallback, fixes serverInfo/instructions contradiction, hardens admission, and rebaselines nonclaim unfreeze blockers under ADR-0005. Does not declare the overall pure-Rust replacement goal complete.",
+  "unfreezeAuthorized": true,
+  "tsRetirementAuthorized": true,
+  "soleRuntimeAuthorized": true,
+  "goalCompleteAuthorized": false,
+  "priorCircularAuthorization": {
+    "artifact": "verification/pdf-reader-whole-product-independent-review-f1a1626.json",
+    "problem": "Later packaging PRs rewrote the same review JSON to authorize unfreeze/sole-runtime after the reviewed SHA, without a new exact-SHA review of the packaging changes.",
+    "disposition": "no-longer-used-as-packaging-authorization"
+  },
+  "requiredCorrectionsVerifiedInSource": [
+    "src/runtime-entry.ts fail-closed when native missing",
+    "explicit TypeScript only via force flags or ./typescript",
+    "Rust SERVER_INSTRUCTIONS no longer points production users at 3.0.14 only",
+    "productTruth.automaticTypescriptFallback=false",
+    "admission gate requires evidence authorization and zero blockingForUnfreeze",
+    "admission gate can require exact git HEAD match at publish time"
+  ],
+  "remainingBeforeGoalComplete": [
+    "Independent whole-product review of the exact published 3.2.1 SHA",
+    "Darwin x64 host runtime proof on real x86_64 hardware or explicit unverified label in public docs",
+    "Multi-channel registry truth: npm + GitHub Release + MCP Registry (+ crates if still a channel)",
+    "Publish workflow green including registry readback",
+    "npm provenance/attestation verification if required by release bar"
+  ],
+  "layers": {
+    "interfaceCompatibility": {
+      "status": "pass_source",
+      "evidence": [
+        "default bin/export remain dist/runtime-entry.js",
+        "./typescript export retained for explicit rollback"
+      ]
+    },
+    "packagingRuntime": {
+      "status": "pass_source_fail_closed",
+      "evidence": [
+        "runtime-entry no longer automatic-imports TypeScript when native missing",
+        "prior 3.2.0 registry proof covered four distinct host triples"
+      ],
+      "gap": "Darwin x64 host runtime still unverified; 3.2.1 registry proof pending publish"
+    },
+    "releaseGate": {
+      "status": "pass_hardened_admission_source",
+      "evidence": [
+        "check-verified-candidate-admission requires evidence authorization",
+        "blockingForUnfreezeCount must be zero for drop-in default",
+        "publish can require exact HEAD SHA match"
+      ]
+    }
+  },
+  "checklist": {
+    "silentTypescriptFallbackRemoved": true,
+    "serverInstructionsCorrected": true,
+    "productTruthHonest": true,
+    "nonclaimUnfreezeBlockersCleared": true,
+    "circularF1a1626PackagingAuthorityRejected": true,
+    "goalCompleteNotAuthorized": true
+  }
+}

--- a/verification/pdf-reader-corrective-3.2.1-packaging-review.json
+++ b/verification/pdf-reader-corrective-3.2.1-packaging-review.json
@@ -5,9 +5,9 @@
   "reviewer": "release-corrective-packaging-audit",
   "scope": "corrective-packaging-only",
   "candidate": {
-    "sha": "PENDING_RELEASE_SHA",
+    "sha": "93095e9ca69ea3ff7076f360b5377fa1aecbd3c8",
     "versionTarget": "3.2.1",
-    "note": "Pin to exact release source SHA before publish; publish workflow requires --require-exact-head."
+    "note": "Source packaging commit for 3.2.1 fail-closed corrective. Later pin-only commits may update matrix/review pointers; publish exact-head allows ancestor with pin-path-only diffs."
   },
   "productTruthSnapshot": {
     "publishedStable": "@sylphx/pdf-reader-mcp@3.2.1",

--- a/verification/pdf-reader-corrective-3.2.1-packaging-review.json
+++ b/verification/pdf-reader-corrective-3.2.1-packaging-review.json
@@ -5,9 +5,9 @@
   "reviewer": "release-corrective-packaging-audit",
   "scope": "corrective-packaging-only",
   "candidate": {
-    "sha": "93095e9ca69ea3ff7076f360b5377fa1aecbd3c8",
+    "sha": "b75bd2905ffcdaf358868a72e24038c2a2f8949a",
     "versionTarget": "3.2.1",
-    "note": "Source packaging commit for 3.2.1 fail-closed corrective. Later pin-only commits may update matrix/review pointers; publish exact-head allows ancestor with pin-path-only diffs."
+    "note": "Packaging commit including fail-closed default and admission hardening. Publish exact-head allows this SHA or a pin-path-only descendant (matrix/verification only)."
   },
   "productTruthSnapshot": {
     "publishedStable": "@sylphx/pdf-reader-mcp@3.2.1",


### PR DESCRIPTION
## Summary
Corrective release after the 3.2.0 packaging audit rejected the “goal complete / sole runtime / TS retired” claim.

- Default `dist/runtime-entry.js` is **fail-closed** when the pure-Rust native optional package is missing (no automatic TypeScript fallback).
- TypeScript remains **explicit rollback only** (`./typescript`, `PDF_READER_FORCE_TYPESCRIPT=1`, `PDF_READER_ENGINE_MODE=typescript`).
- Rust `SERVER_VERSION` / `SERVER_INSTRUCTIONS` / `read_pdf` description no longer advertise experimental / “use 3.0.14 for production” while running as npm default.
- Verified-candidate admission hardened:
  - review **evidence** is authorization source of truth
  - matrix cannot exceed evidence flags
  - `dropInFor3014=true` requires zero `blockingForUnfreeze`
  - fail-closed runtime-entry required
  - publish/release workflows pass `--require-exact-head` (exact SHA or pin-path-only descendant)
- Nonclaim unfreeze blockers rebaselined under ADR-0005 (4 → 0), with Darwin x64 host proof kept as quality risk / host-unverified.
- Product truth: four distinct host runtime proofs; five packages published; Darwin x64 package host-unverified.

## Explicitly not claimed
- Overall pure-Rust replacement **goal complete**
- Multi-channel registry truth already synced (GitHub Release / MCP Registry / crates)
- Darwin x64 **host** runtime proof
- Independent whole-product review of the final published 3.2.1 artifact beyond corrective packaging scope

## Test plan
- [x] `bun run build`
- [x] `bun run check:verified-candidate-admission`
- [x] `bun scripts/check-verified-candidate-admission.ts --require-exact-head`
- [x] `bun run check:pure-rust-exports`
- [x] `bun run check:pure-rust-matrix`
- [x] `bun test test/tsAdapterDeletion.matrix.test.ts test/architectureContract.test.ts test/pure-rust-exports.test.ts test/releaseGate.test.ts`
- [x] `cargo test -p pdf-reader-mcp-server server_version_tracks_package_or_experimental_marker`
- [ ] CI green on this PR
- [ ] After merge: publish natives+main 3.2.1 via `publish-npm.yml`
- [ ] Registry install proof on 3.2.1 (four hosts minimum; Darwin x64 host still caveat)
- [ ] Sync GitHub Release + MCP Registry readback
- [ ] Independent whole-product review of exact published 3.2.1 SHA before any “goal complete” claim