### PR TITLE
fix(ci): darwin natives on Sylphx self-hosted macOS only

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,11 @@
 self-hosted-runner:
   labels:
     - sylphx-linux-standard
+    - sylphx-linux-control
+    - sylphx-linux-xlarge
+    - sylphx
+    - macos
+    - standard
 paths:
   .github/workflows/release.yml:
     ignore:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.12'
+          bun-version: '1.3.14'
 
       - name: Install dependencies
         run: |
@@ -129,7 +129,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.12'
+          bun-version: '1.3.14'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/native-package-scaffold.yml
+++ b/.github/workflows/native-package-scaffold.yml
@@ -46,7 +46,9 @@ jobs:
           bun-version: 1.3.14
       - id: set
         run: |
-          matrix='[{"platformId":"linux-x64-gnu","runner":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu"},{"platformId":"linux-arm64-gnu","runner":"ubuntu-22.04-arm","target":"aarch64-unknown-linux-gnu"},{"platformId":"darwin-arm64","runner":"macos-14","target":"aarch64-apple-darwin"},{"platformId":"darwin-x64","runner":"macos-14","target":"x86_64-apple-darwin"},{"platformId":"win32-x64-msvc","runner":"windows-latest","target":"x86_64-pc-windows-msvc"}]'
+          # Product CI: darwin uses Sylphx self-hosted macOS only (no GitHub-hosted macos-*).
+          # linux/windows keep fixed GH images for published glibc/ABI and Windows MSVC coverage.
+          matrix='[{"platformId":"linux-x64-gnu","runner":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu"},{"platformId":"linux-arm64-gnu","runner":"ubuntu-22.04-arm","target":"aarch64-unknown-linux-gnu"},{"platformId":"darwin-arm64","runner":["self-hosted","sylphx","macos","standard"],"target":"aarch64-apple-darwin"},{"platformId":"darwin-x64","runner":["self-hosted","sylphx","macos","standard"],"target":"x86_64-apple-darwin"},{"platformId":"win32-x64-msvc","runner":"windows-latest","target":"x86_64-pc-windows-msvc"}]'
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
       - name: Verify package map and Stage B publishable posture
         run: |
@@ -116,7 +118,14 @@ jobs:
           if [[ "$platform" != "win32-x64-msvc" ]]; then
             chmod +x "$staged" "packages/pdf-reader-mcp-${platform}/bin/${bin_name}" "bin/native/${bin_name}"
           fi
-          bun run smoke:native-launcher
-          bun run smoke:native-package-resolve
-          # Assert the matrix target package we staged (may differ from host triple, e.g. darwin-x64 on arm64 runner).
+          # Host execute smoke is only valid when the matrix target matches the runner triple.
+          # Sylphx self-hosted macOS is currently QEMU amd64 (darwin-x64); aarch64-apple-darwin is
+          # still built/asserted here via cross-compile, but must not be executed on the x64 host.
+          host_platform="$(bun -e 'import { resolveNativePlatformId } from "./scripts/native/platform-package-map.ts"; const id=resolveNativePlatformId(); if(!id) process.exit(2); process.stdout.write(id)')"
+          if [[ "$host_platform" == "$platform" ]]; then
+            bun run smoke:native-launcher
+            bun run smoke:native-package-resolve
+          else
+            echo "Skipping host execute smoke for cross-target ${platform} on host ${host_platform}"
+          fi
           bun scripts/native/assert-native-packages-ready.ts --platform=${{ matrix.platformId }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -28,11 +28,12 @@ jobs:
           - platformId: linux-arm64-gnu
             runner: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
+          # Product macOS: Sylphx self-hosted only (no GitHub-hosted macos-*).
           - platformId: darwin-arm64
-            runner: macos-14
+            runner: [self-hosted, sylphx, macos, standard]
             target: aarch64-apple-darwin
           - platformId: darwin-x64
-            runner: macos-14
+            runner: [self-hosted, sylphx, macos, standard]
             target: x86_64-apple-darwin
           - platformId: win32-x64-msvc
             runner: windows-latest

--- a/.github/workflows/registry-install-proof.yml
+++ b/.github/workflows/registry-install-proof.yml
@@ -24,7 +24,9 @@ jobs:
     steps:
       - id: set
         run: |
-          matrix='[{"platformId":"linux-x64-gnu","runner":"ubuntu-22.04"},{"platformId":"linux-arm64-gnu","runner":"ubuntu-22.04-arm"},{"platformId":"darwin-arm64","runner":"macos-14"},{"platformId":"darwin-x64","runner":"macos-14"},{"platformId":"win32-x64-msvc","runner":"windows-latest"}]'
+          # darwin uses Sylphx self-hosted macOS. Host triple decides which optional package npm installs;
+          # both darwin matrix rows therefore prove the runner host package (currently darwin-x64 on QEMU).
+          matrix='[{"platformId":"linux-x64-gnu","runner":"ubuntu-22.04"},{"platformId":"linux-arm64-gnu","runner":"ubuntu-22.04-arm"},{"platformId":"darwin-arm64","runner":["self-hosted","sylphx","macos","standard"]},{"platformId":"darwin-x64","runner":["self-hosted","sylphx","macos","standard"]},{"platformId":"win32-x64-msvc","runner":"windows-latest"}]'
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   proof:
@@ -58,8 +60,8 @@ jobs:
           VERSION="${PROOF_VERSION}"
           test -n "$VERSION"
           echo "Proving @sylphx/pdf-reader-mcp@$VERSION on ${{ matrix.platformId }} / $(uname -s)-$(uname -m)"
-          # darwin-x64 job runs on arm64 runners; still install and prove host native package.
-          # The host triple decides which optional package npm installs.
+          # Host triple decides which optional package npm installs (self-hosted macOS is currently x64).
+          # Matrix platformId is retained for five-platform job coverage / labeling.
           bun scripts/check-registry-install-proof.ts --registry --version="$VERSION"
 
   pass:

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -56,9 +56,12 @@ own ADR/spec and commercial controls.
 ## Delivery
 
 Pull requests use the legacy `Validate Code Quality` context on Sylphx
-self-hosted runners. Package release is Changesets-driven through the repo
-release workflow, which mints a GitHub App token before creating version PRs or
-publishing to npm.
+self-hosted runners. Darwin native package builds and registry proofs use
+`[self-hosted, sylphx, macos, standard]` only — never GitHub-hosted `macos-*`.
+Linux native ABI builds intentionally keep Ubuntu 22.04 images for GLIBC≤2.35;
+Windows natives remain on `windows-latest` until a self-hosted Windows pool exists.
+Package release is Changesets-driven through the repo release workflow, which
+mints a GitHub App token before creating version PRs or publishing to npm.
 
 Control Plane ADR-0014 retired the in-repository GroundAtlas package dogfood
 gate and assigned repository-intelligence ownership to Control Plane Repository

--- a/bun.lock
+++ b/bun.lock
@@ -21,11 +21,11 @@
         "vitepress": "^1.6.4",
       },
       "optionalDependencies": {
-        "@sylphx/pdf-reader-mcp-darwin-arm64": "3.2.0",
-        "@sylphx/pdf-reader-mcp-darwin-x64": "3.2.0",
-        "@sylphx/pdf-reader-mcp-linux-arm64-gnu": "3.2.0",
-        "@sylphx/pdf-reader-mcp-linux-x64-gnu": "3.2.0",
-        "@sylphx/pdf-reader-mcp-win32-x64-msvc": "3.2.0",
+        "@sylphx/pdf-reader-mcp-darwin-arm64": "3.2.2",
+        "@sylphx/pdf-reader-mcp-darwin-x64": "3.2.2",
+        "@sylphx/pdf-reader-mcp-linux-arm64-gnu": "3.2.2",
+        "@sylphx/pdf-reader-mcp-linux-x64-gnu": "3.2.2",
+        "@sylphx/pdf-reader-mcp-win32-x64-msvc": "3.2.2",
       },
     },
   },
@@ -422,6 +422,16 @@
     "@shikijs/types": ["@shikijs/types@2.5.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@sylphx/pdf-reader-mcp-darwin-arm64": ["@sylphx/pdf-reader-mcp-darwin-arm64@3.2.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6mCCM2oa4dznzVi+ZwWP654s9qdtQgaorp922pWeVdnxSrYF9Z7ZFzRI0dTl9ISBZ9k3G3CX+WuKaVtwT2Awqg=="],
+
+    "@sylphx/pdf-reader-mcp-darwin-x64": ["@sylphx/pdf-reader-mcp-darwin-x64@3.2.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-GRtvWOVFw24xwKEQ6dS6V092qjcIqi/AY6xQtrX8Cf+wuvnvkA8xHunTC3bJMuF/BnC0eLwLECbPlZRLprvHiw=="],
+
+    "@sylphx/pdf-reader-mcp-linux-arm64-gnu": ["@sylphx/pdf-reader-mcp-linux-arm64-gnu@3.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-WJt4/bLhTjEJ4S6DTeG74qfVJRnkuEQTColl3pblg8lfWSelwHK8iSgdNlmtbJRitzrx9FWM/1Kc3rNlqyrXPw=="],
+
+    "@sylphx/pdf-reader-mcp-linux-x64-gnu": ["@sylphx/pdf-reader-mcp-linux-x64-gnu@3.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-G+ZXahcCa6yY0dh8rq7uQhDj/1H9xkzL3Hvy8kHjsq88fR0RJriVu0Yd/5X0esP0VxRpwgxuWLd67cuHJU/nTw=="],
+
+    "@sylphx/pdf-reader-mcp-win32-x64-msvc": ["@sylphx/pdf-reader-mcp-win32-x64-msvc@3.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-h0CRQhXa81CbpP68o+7scKP8Zfpjk341x6e05umi4zqOEUc8Lt3gEELBGcTkNDF3xfUpeVsBSHGokOSu1Zk3dA=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 

--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
     "typescript": "^7.0.2",
     "vitepress": "^1.6.4"
   },
-  "packageManager": "bun@1.3.12",
+  "packageManager": "bun@1.3.14",
   "optionalDependencies": {
     "@sylphx/pdf-reader-mcp-darwin-arm64": "3.2.2",
     "@sylphx/pdf-reader-mcp-darwin-x64": "3.2.2",


### PR DESCRIPTION
## Summary
- Product darwin native builds/proofs no longer use GitHub-hosted `macos-14`.
- Route to `[self-hosted, sylphx, macos, standard]` for scaffold, publish, and registry proof.
- Host execute smoke runs only when matrix target matches runner triple so QEMU amd64 can still cross-build `aarch64-apple-darwin`.
- Linux Ubuntu 22.04 ABI images and Windows MSVC stay as intentional non-mac exceptions.

## Why
Self-hosted macOS JIT is healthy again (canary + Cubeage product jobs). Using GitHub-hosted macOS for product natives is a regression and is not acceptable.

## Evidence to collect after merge/admission
- Native package scaffold darwin jobs assigned to Sylphx runners (not `GitHub Actions` runner group).
- Pickup latency and successful cargo build for both darwin targets.