### PR TITLE
docs(release): sole-Rust 4.0.0 multi-channel closeout

### DIFF
--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -3,8 +3,8 @@
   "title": "Pure-Rust capability matrix (capability-first semantic admission SSOT)",
   "updated": "2026-07-24",
   "productTruth": {
-    "publishedStable": "@sylphx/pdf-reader-mcp@3.2.2",
-    "publishedImplementation": "3.2.2 transitional Rust-default with bundled TypeScript rollback (not Sole Rust)",
+    "publishedStable": "@sylphx/pdf-reader-mcp@4.0.0",
+    "publishedImplementation": "4.0.0 sole-Rust production (thin launcher + optional natives; no TypeScript PDF runtime)",
     "pureRustStatus": "sole-rust-production-default",
     "optIn": "native optional package required; PDF_READER_MCP_RUST_BIN override allowed; no TS production path",
     "dropInFor3014": true,
@@ -26,30 +26,32 @@
       "linux-x64-gnu",
       "linux-arm64-gnu",
       "darwin-arm64",
+      "darwin-x64",
       "win32-x64-msvc"
     ],
-    "darwinX64RuntimeProof": "package-published-host-unverified",
+    "darwinX64RuntimeProof": "registry-install-proven-real-x86_64",
     "correctiveRelease": "3.2.2-serverinfo-and-channel-push",
-    "githubRelease": "v3.2.2",
-    "mcpRegistryStatus": "3.2.2-latest-active",
+    "githubRelease": "v4.0.0",
+    "mcpRegistryStatus": "4.0.0-latest-active",
     "cratesStatus": "not-admitted-product-channel",
-    "npmIntegrity": "sha512-xcxeg4O/7lGQvI4s3vdT8iUOAGRYVqUIxV6LoDYfQ2GtLTVY4UjHULVvCCEzxEh4T6u2sHhJq3MHc1PFxqxJHg==",
+    "npmIntegrity": "sha512-NdAP8urPJz3/uRhGW55TUTPGmUB2RhaO3eQY+Ki/cu0QHPxxQ8OlhtrjAaGThIP9wFmJdVB7PTiVf5LX18hfsA==",
     "npmSignaturesPresent": true,
     "npmProvenanceAttestationPresent": false,
-    "registryProofEvidence": "verification/pdf-reader-registry-install-proof-3.2.2.json",
+    "registryProofEvidence": "verification/pdf-reader-registry-install-proof-4.0.0.json",
     "mcpRegistryReadback": {
       "name": "io.github.SylphxAI/pdf-reader-mcp",
-      "latestVersion": "3.2.2",
+      "latestVersion": "4.0.0",
       "isLatest": true,
       "status": "active",
-      "updatedAt": "2026-07-23T22:58:15.206376Z",
-      "workflowRunUrl": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30051674578",
+      "updatedAt": "2026-07-24T05:46:00.292865Z",
+      "workflowRunUrl": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30070317979",
       "staleActiveVersionsStillListed": [
         "3.0.15",
         "3.0.16",
         "3.0.17",
         "3.0.18",
-        "3.1.0"
+        "3.1.0",
+        "3.2.2"
       ]
     },
     "candidateVersion": "4.0.0",
@@ -60,7 +62,7 @@
     "historicalTypescriptLkg": "@sylphx/pdf-reader-mcp@3.0.14",
     "semverTarget": "4.0.0",
     "cratesAuthority": "docs/adr/0006-sole-rust-production-and-channel-authority.md",
-    "transitionalNote": "Live latest remains 3.2.2 until 4.0.0 is published. 4.0.0 is sole-Rust production candidate re-authorized for freeze-lifted publication by independent review f9a3154 (goal complete still false until multi-channel readback).",
+    "transitionalNote": "Live latest is sole-Rust 4.0.0. Historical TS LKG remains @sylphx/pdf-reader-mcp@3.0.14 external only. 3.2.2 remains available as transitional Rust-default+bundled-TS history and is not Sole Rust. Performance marketing claims remain withheld.",
     "candidateHostRuntimeProof": {
       "status": "five-distinct-host-triples-proven-for-4.0.0-candidate",
       "candidateSha": "f9a31541c7083eda6efe3fc828a6223a8c476342",
@@ -81,7 +83,19 @@
       "boundary": "local-pack install/runtime proofs; not npm registry readback"
     },
     "performanceClaimsAuthorized": false,
-    "performanceClaimsPolicy": "docs/specs/performance/4.0.0-performance-claims-policy.md"
+    "performanceClaimsPolicy": "docs/specs/performance/4.0.0-performance-claims-policy.md",
+    "publishedGitHead": "8063e4b78c3d77116fa6430f1804f0967984daf8",
+    "implementationCandidateSha": "f9a31541c7083eda6efe3fc828a6223a8c476342",
+    "mainLandedSha": "096b0259e599b0a16e3c7ba2a3403cee974a4617",
+    "channelCloseout": {
+      "npmLatest": "4.0.0",
+      "githubRelease": "v4.0.0",
+      "mcpRegistryLatest": "4.0.0",
+      "crates": "not-admitted-product-channel",
+      "fiveHostRegistryProof": true,
+      "tsProductionAbsent": true,
+      "performanceClaims": "withheld"
+    }
   },
   "legend": {
     "FULL": "Production-usable capability for agent tasks in this slice under the capability-first semantic contract (not exact PDF.js JSON equality)",
@@ -533,6 +547,8 @@
         "rosettaTranslated": false,
         "runner": "self-hosted x86_64-apple-darwin"
       }
-    }
+    },
+    "publishedGitHead": "8063e4b78c3d77116fa6430f1804f0967984daf8",
+    "channelCloseoutEvidence": "verification/pdf-reader-registry-install-proof-4.0.0.json"
   }
 }

--- a/docs/specs/release-closeout-4.0.0.md
+++ b/docs/specs/release-closeout-4.0.0.md
@@ -1,0 +1,34 @@
+# Release closeout — @sylphx/pdf-reader-mcp@4.0.0
+
+Date: 2026-07-24  
+Status: **channels live; performance claims withheld**
+
+## Exact identities
+
+| Surface | Value |
+| --- | --- |
+| npm latest | `4.0.0` |
+| npm gitHead | `8063e4b78c3d77116fa6430f1804f0967984daf8` |
+| implementation candidate | `f9a31541c7083eda6efe3fc828a6223a8c476342` |
+| independent review | `verification/pdf-reader-whole-product-independent-review-4.0.0-f9a3154.json` |
+| main land (squash) | `096b0259e599b0a16e3c7ba2a3403cee974a4617` |
+| GitHub Release | [v4.0.0](https://github.com/SylphxAI/pdf-reader-mcp/releases/tag/v4.0.0) |
+| MCP Registry | `io.github.SylphxAI/pdf-reader-mcp@4.0.0` active + `isLatest=true` |
+| five-host registry proof | [run 30070323043](https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30070323043) |
+
+## Sole Rust truth
+
+- Production package ships thin launcher only (`dist/runtime-entry.js`, `dist/pure-rust.js`)
+- No `./typescript` export; force-TS fails closed
+- No TS/PDF.js production payload in npm tarball (14 files)
+- Missing native package fails closed with external LKG guidance for `@3.0.14`
+
+## Performance
+
+Marketing speedups remain **withheld**. See
+`docs/specs/performance/4.0.0-performance-claims-policy.md`.
+
+## Rollback
+
+- Historical TS production: `@sylphx/pdf-reader-mcp@3.0.14`
+- Transitional Rust-default+bundled-TS history: `3.2.2` (not Sole Rust)

--- a/verification/pdf-reader-registry-install-proof-4.0.0.json
+++ b/verification/pdf-reader-registry-install-proof-4.0.0.json
@@ -1,0 +1,24 @@
+{
+  "profile": "registry_install_proof_aggregate",
+  "version": "4.0.0",
+  "mode": "registry",
+  "workflowRunUrl": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30070323043",
+  "workflowConclusion": "success",
+  "publishedGitHead": "8063e4b78c3d77116fa6430f1804f0967984daf8",
+  "implementationCandidateSha": "f9a31541c7083eda6efe3fc828a6223a8c476342",
+  "independentReview": "verification/pdf-reader-whole-product-independent-review-4.0.0-f9a3154.json",
+  "distinctHostTriplesProven": [
+    "darwin-arm64",
+    "darwin-x64",
+    "linux-arm64-gnu",
+    "linux-x64-gnu",
+    "win32-x64-msvc"
+  ],
+  "notes": [
+    "Five-host registry install + pure-Rust MCP initialize for published @sylphx/pdf-reader-mcp@4.0.0",
+    "darwin-x64 executed on real self-hosted x86_64 (not arm64 Rosetta substitute)",
+    "Performance marketing claims remain withheld"
+  ],
+  "pass": true,
+  "recordedAt": "2026-07-24T05:58:00Z"
+}


### PR DESCRIPTION
## Summary
- Record live `@sylphx/pdf-reader-mcp@4.0.0` channel identities after authorized publish from pin SHA `8063e4b`.
- Attach five-host registry install proof run 30070323043.
- Keep performance marketing claims withheld.

## Test plan
- [x] npm latest = 4.0.0
- [x] GitHub Release v4.0.0
- [x] MCP Registry 4.0.0 isLatest
- [x] five-host registry install proof success