### PR TITLE
fix(ci): remove residual GitHub-hosted macos from Darwin proofs

### DIFF
--- a/.github/workflows/candidate-host-runtime-proof.yml
+++ b/.github/workflows/candidate-host-runtime-proof.yml
@@ -29,13 +29,14 @@ jobs:
     steps:
       - id: set
         run: |
-          # Runtime proofs require matching host arch (PROOF_REQUIRE_PLATFORM_ID).
-          # darwin-arm64: GitHub macos-14 (real arm64). darwin-x64: Sylphx self-hosted x86_64.
-          # linux/windows: GitHub-hosted.
+          # Product policy: never GitHub-hosted macos-*. Darwin uses Sylphx self-hosted only.
+          # Current fleet is QEMU amd64 (darwin-x64). darwin-arm64 is cross-built there;
+          # host-execute proof is only claimed when runner arch matches (fail-closed).
+          # linux/windows: GitHub-hosted until self-hosted pools exist.
           matrix='[
             {"platformId":"linux-x64-gnu","runner":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu"},
             {"platformId":"linux-arm64-gnu","runner":"ubuntu-22.04-arm","target":"aarch64-unknown-linux-gnu"},
-            {"platformId":"darwin-arm64","runner":"macos-14","target":"aarch64-apple-darwin"},
+            {"platformId":"darwin-arm64","runner":["self-hosted","sylphx","macos","standard"],"target":"aarch64-apple-darwin"},
             {"platformId":"darwin-x64","runner":["self-hosted","sylphx","macos","standard"],"target":"x86_64-apple-darwin"},
             {"platformId":"win32-x64-msvc","runner":"windows-latest","target":"x86_64-pc-windows-msvc"}
           ]'
@@ -96,7 +97,38 @@ jobs:
           PROOF_REQUIRE_PLATFORM_ID: ${{ matrix.platformId }}
         run: |
           set -euo pipefail
-          bun scripts/check-registry-install-proof.ts --local-pack | tee "host-proof-${{ matrix.platformId }}.json"
+          required="${{ matrix.platformId }}"
+          host_id="$(bun -e 'import { resolveNativePlatformId } from "./scripts/native/platform-package-map.ts"; const id=resolveNativePlatformId(); if(!id) process.exit(2); process.stdout.write(id)')"
+          echo "host_id=${host_id} required=${required}"
+          if [[ "${host_id}" == "${required}" ]]; then
+            bun scripts/check-registry-install-proof.ts --local-pack | tee "host-proof-${required}.json"
+          else
+            # Cross-build already staged above. Do not use GitHub-hosted macos-* for arm64 host proof.
+            # Record explicit non-host-proof so aggregate stays honest.
+            python3 -c "
+import json, platform, subprocess, sys
+required = sys.argv[1]
+host_id = sys.argv[2]
+uname = subprocess.check_output(['uname','-m'], text=True).strip()
+report = {
+  'profile': 'candidate_host_runtime_proof_leg',
+  'pass': True,
+  'runtimeProofValid': False,
+  'requiredPlatformId': required,
+  'hostPlatformId': host_id,
+  'host': {
+    'nodePlatform': sys.platform,
+    'nodeArch': platform.machine(),
+    'unameMachine': uname,
+  },
+  'crossBuiltOnly': True,
+  'note': f'Cross-built on host {host_id}; host runtime proof deferred until matching self-hosted capacity (no GitHub-hosted macos-*).',
+}
+path = f'host-proof-{required}.json'
+open(path,'w').write(json.dumps(report, indent=2)+'\n')
+print(json.dumps(report, indent=2))
+" "${required}" "${host_id}"
+          fi
 
       - name: Upload host proof JSON
         if: always()
@@ -127,37 +159,48 @@ jobs:
           legs = []
           proven = []
           failed = []
+          cross_ok = []
           for f in files:
               data = json.loads(f.read_text())
-              platform = data.get('hostPlatformId') or data.get('requiredPlatformId') or f.stem
+              platform = data.get('requiredPlatformId') or data.get('hostPlatformId') or f.stem
               valid = bool(data.get('runtimeProofValid') and data.get('pass'))
               legs.append({
                   'file': f.name,
                   'platformId': platform,
                   'pass': data.get('pass'),
                   'runtimeProofValid': data.get('runtimeProofValid'),
+                  'crossBuiltOnly': data.get('crossBuiltOnly'),
                   'host': data.get('host'),
                   'initialize': data.get('initialize'),
               })
               if valid:
                   proven.append(platform)
+              elif data.get('crossBuiltOnly') and data.get('pass'):
+                  cross_ok.append(platform)
               else:
                   failed.append(platform)
-          required = [
+          # Host-proven required now (self-hosted darwin-x64 + GH linux/windows).
+          required_host = [
               'linux-x64-gnu',
               'linux-arm64-gnu',
-              'darwin-arm64',
               'darwin-x64',
               'win32-x64-msvc',
           ]
-          missing = [p for p in required if p not in proven]
+          # darwin-arm64 host proof needs Apple Silicon self-hosted; QEMU x64 may only cross-build.
+          required_cross_or_host = ['darwin-arm64']
+          missing_host = [x for x in required_host if x not in proven]
+          missing_cross = [x for x in required_cross_or_host if x not in proven and x not in cross_ok]
+          missing = missing_host + missing_cross
           report = {
               'profile': 'candidate_host_runtime_proof_aggregate',
-              'requiredPlatforms': required,
+              'requiredHostProven': required_host,
+              'requiredCrossOrHost': required_cross_or_host,
               'distinctHostTriplesProven': sorted(set(proven)),
+              'crossBuiltOnly': sorted(set(cross_ok)),
               'failedOrMissing': missing + failed,
               'legs': legs,
-              'pass': len(missing) == 0 and len(failed) == 0 and len(proven) == 5,
+              'pass': len(missing) == 0 and len(failed) == 0,
+              'policy': 'no-github-hosted-macos; darwin-arm64 host proof deferred without AS self-hosted capacity',
           }
           pathlib.Path('candidate-host-runtime-proof-aggregate.json').write_text(json.dumps(report, indent=2) + '\n')
           print(json.dumps(report, indent=2))

--- a/.github/workflows/registry-install-proof.yml
+++ b/.github/workflows/registry-install-proof.yml
@@ -24,9 +24,10 @@ jobs:
     steps:
       - id: set
         run: |
-          # Runtime proofs require matching host arch (PROOF_REQUIRE_PLATFORM_ID).
-          # darwin-arm64: GitHub macos-14 arm64. darwin-x64: Sylphx self-hosted x86_64.
-          matrix='[{"platformId":"linux-x64-gnu","runner":"ubuntu-22.04"},{"platformId":"linux-arm64-gnu","runner":"ubuntu-22.04-arm"},{"platformId":"darwin-arm64","runner":"macos-14"},{"platformId":"darwin-x64","runner":["self-hosted","sylphx","macos","standard"]},{"platformId":"win32-x64-msvc","runner":"windows-latest"}]'
+          # Product policy: never GitHub-hosted macos-*. Darwin uses Sylphx self-hosted only.
+          # Current fleet is QEMU amd64: darwin-x64 is host-proven; darwin-arm64 is scheduled on
+          # the same self-hosted labels and fails closed unless matching arch is available.
+          matrix='[{"platformId":"linux-x64-gnu","runner":"ubuntu-22.04"},{"platformId":"linux-arm64-gnu","runner":"ubuntu-22.04-arm"},{"platformId":"darwin-arm64","runner":["self-hosted","sylphx","macos","standard"]},{"platformId":"darwin-x64","runner":["self-hosted","sylphx","macos","standard"]},{"platformId":"win32-x64-msvc","runner":"windows-latest"}]'
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   proof:
@@ -59,8 +60,39 @@ jobs:
           set -euo pipefail
           VERSION="${PROOF_VERSION}"
           test -n "$VERSION"
-          echo "Proving @sylphx/pdf-reader-mcp@$VERSION on required=${{ matrix.platformId }} host=$(uname -s)-$(uname -m) node=$(node -p 'process.arch')"
-          export PROOF_REQUIRE_PLATFORM_ID="${{ matrix.platformId }}"
+          required="${{ matrix.platformId }}"
+          host_id="$(bun -e 'import { resolveNativePlatformId } from "./scripts/native/platform-package-map.ts"; const id=resolveNativePlatformId(); if(!id) process.exit(2); process.stdout.write(id)')"
+          echo "Proving @sylphx/pdf-reader-mcp@$VERSION required=${required} host_id=${host_id} host=$(uname -s)-$(uname -m) node=$(node -p 'process.arch')"
+          if [[ "${host_id}" != "${required}" ]]; then
+            echo "Host ${host_id} cannot provide registry host-runtime proof for ${required}."
+            echo "Policy forbids GitHub-hosted macos-*; Apple Silicon self-hosted capacity is required for darwin-arm64 host proof."
+            # Soft-skip only the known QEMU x64 vs darwin-arm64 gap; all other mismatches fail closed.
+            if [[ "${required}" == "darwin-arm64" && "${host_id}" == "darwin-x64" ]]; then
+              echo "Recording deferred darwin-arm64 host proof (cross-fleet gap)."
+              mkdir -p verification
+              python3 -c "
+import json, platform, subprocess, sys
+required, host_id, version = sys.argv[1:4]
+uname = subprocess.check_output(['uname','-m'], text=True).strip()
+report = {
+  'profile': 'registry_install_proof_leg',
+  'pass': True,
+  'runtimeProofValid': False,
+  'deferred': True,
+  'requiredPlatformId': required,
+  'hostPlatformId': host_id,
+  'version': version,
+  'host': {'nodePlatform': sys.platform, 'nodeArch': platform.machine(), 'unameMachine': uname},
+  'note': 'Deferred: no Apple Silicon self-hosted capacity; GitHub-hosted macos-* forbidden by product policy.',
+}
+open(f'registry-proof-{required}.json','w').write(json.dumps(report, indent=2)+'\n')
+print(json.dumps(report, indent=2))
+" "${required}" "${host_id}" "${VERSION}"
+              exit 0
+            fi
+            exit 1
+          fi
+          export PROOF_REQUIRE_PLATFORM_ID="${required}"
           bun scripts/check-registry-install-proof.ts --registry --version="$VERSION"
 
   pass:
@@ -75,7 +107,7 @@ jobs:
           echo "proof result=${{ needs.proof.result }}"
           if [[ "${{ needs.proof.result }}" != "success" ]]; then
             echo "One or more host runtime proof legs failed or were host-unverified."
-            echo "Darwin x64 requires a real x86_64 macOS runner (see docs/specs/host-runtime-proof-contract.md)."
+            echo "Darwin proofs require Sylphx self-hosted macOS (see docs/specs/host-runtime-proof-contract.md). darwin-arm64 host proof needs Apple Silicon self-hosted capacity; do not use GitHub-hosted macos-*."
             exit 1
           fi
           echo "All configured host runtime proof legs passed with matching host architecture."

--- a/docs/specs/host-runtime-proof-contract.md
+++ b/docs/specs/host-runtime-proof-contract.md
@@ -39,3 +39,11 @@ gh workflow run candidate-host-runtime-proof.yml
 ```
 
 This builds/stages natives per platform, local-packs the sole-Rust candidate, installs the tarballs, and runs MCP initialize with `PROOF_REQUIRE_PLATFORM_ID`.
+
+## Self-hosted macOS policy
+
+- Product Darwin CI must use Sylphx self-hosted labels `[self-hosted, sylphx, macos, standard]` only.
+- GitHub-hosted `macos-*` runners are forbidden for product Darwin build and host proof.
+- Current Sylphx macOS fleet is QEMU x86_64 (`darwin-x64`). That host proves `darwin-x64` only.
+- `darwin-arm64` host runtime proof requires Apple Silicon self-hosted capacity. Until then, cross-build on the x64 fleet is allowed as **build evidence only** and must not be claimed as host runtime proof.
+


### PR DESCRIPTION
## Summary
- Removes residual `macos-14` from `candidate-host-runtime-proof` and `registry-install-proof` (missed by #575).
- All product Darwin legs use `[self-hosted, sylphx, macos, standard]` only.
- Honest QEMU x86_64 gap: `darwin-x64` host-proven; `darwin-arm64` cross-build + deferred host proof until Apple Silicon self-hosted capacity exists. **No GitHub-hosted workaround.**

## Why
Live main still scheduled darwin-arm64 on GitHub-hosted `macos-14` while PROJECT.md and #575 policy require self-hosted only. That is an unacceptable regression path.

## Test plan
- [ ] PR CI / workflow validation
- [ ] Dispatch `candidate-host-runtime-proof` on self-hosted darwin legs
- [ ] Confirm no `macos-14` / `macos-latest` in product Darwin workflows
- [ ] Confirm aggregate accepts cross-build-only for darwin-arm64 without claiming host runtime proof