### PR TITLE
docs(review): pin independent whole-product review for 4.0.2 afb1aa3

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm install -g @sylphx/pdf-reader-mcp
 Or pin a version:
 
 ```bash
-npm install -g @sylphx/pdf-reader-mcp@4.0.1
+npm install -g @sylphx/pdf-reader-mcp@4.0.2
 ```
 
 Supported native packages (installed automatically when available):

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -60,8 +60,9 @@
     "cratesAuthority": "docs/adr/0006-sole-rust-production-and-channel-authority.md",
     "transitionalNote": "4.0.1 removed production TS/PDF.js dependencies and is MCP/GitHub published, but @sylphx/pdf-reader-mcp-linux-x64-gnu@4.0.1 registry tarball returns 404 despite metadata. 4.0.2 is an emergency republish of all natives+main so Linux x64 installs resolve. Performance claims remain withheld. Goal complete remains false until five-host registry proof on a fully installable release and admissible performance evidence.",
     "candidateHostRuntimeProof": {
-      "status": "five-distinct-host-triples-proven-for-4.0.0-candidate",
-      "candidateSha": "f9a31541c7083eda6efe3fc828a6223a8c476342",
+      "status": "five-distinct-host-triples-proven-for-4.0.2-candidate",
+      "candidateSha": "afb1aa3387dc3b4e10b9415d31dfea8844b3a89a",
+      "ciHeadSha": "af51476359575ff4f51b0e83b1bfe98c4a8d488c",
       "distinctHostTriplesProven": [
         "darwin-arm64",
         "darwin-x64",
@@ -69,8 +70,8 @@
         "linux-x64-gnu",
         "win32-x64-msvc"
       ],
-      "evidence": "verification/pdf-reader-candidate-host-runtime-proof-4.0.0-aggregate.json",
-      "workflowRunUrl": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30067554747",
+      "evidence": "verification/pdf-reader-candidate-host-runtime-proof-4.0.2-aggregate.json",
+      "workflowRunUrl": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30087577283",
       "darwinX64": {
         "unameMachine": "x86_64",
         "rosettaTranslated": false,
@@ -95,7 +96,14 @@
     "independentReviewEvidence": "verification/pdf-reader-whole-product-independent-review-4.0.1-d6780a3.json",
     "independentReviewCandidateSha": "d6780a3bd17919b5f9b67e078422778d2a4b0c5f",
     "independentReviewOutcome": "review_pass_unfreeze_authorized_goal_incomplete",
-    "goalCompleteAuthorized": false
+    "goalCompleteAuthorized": false,
+    "independentWholeProductReview": {
+      "artifact": "verification/pdf-reader-whole-product-independent-review-4.0.2-afb1aa3.json",
+      "outcome": "review_pass_unfreeze_authorized_goal_incomplete",
+      "candidateSha": "afb1aa3387dc3b4e10b9415d31dfea8844b3a89a",
+      "performanceClaimsAuthorized": false,
+      "goalCompleteAuthorized": false
+    }
   },
   "legend": {
     "FULL": "Production-usable capability for agent tasks in this slice under the capability-first semantic contract (not exact PDF.js JSON equality)",
@@ -412,9 +420,9 @@
     "publishFreeze": false,
     "dropInFor3014": true,
     "nextActions": [
-      "Publish 4.0.2 natives+main after independent exact-SHA review",
-      "Five-host registry install proof on published 4.0.2",
-      "Deprecate or document 4.0.1 linux-x64-gnu tarball defect",
+      "Publish 4.0.2 natives+main from exact reviewed SHA afb1aa3 or pin-path-only descendant via verified-candidate path",
+      "Five-host registry install proof on published 4.0.2 including installable linux-x64-gnu tarball",
+      "Document 4.0.1 linux-x64-gnu tarball defect / tombstone for operators",
       "Complete admissible same-host performance A/B before marketing claims",
       "Goal complete only after multi-channel readback + performance evidence if required"
     ],
@@ -437,12 +445,12 @@
       ]
     },
     "nativePackageProof": {
-      "status": "five-host-candidate-local-pack-proven-for-4.0.1-pending-registry-publish",
+      "status": "five-host-candidate-local-pack-proven-for-4.0.2-pending-registry-publish",
       "registryInstall": true,
       "packagesPublishable": true,
       "optionalDependenciesWired": true,
       "publishedVersion": "4.0.0",
-      "targetVersion": "4.0.1",
+      "targetVersion": "4.0.2",
       "publishedNatives": [
         "@sylphx/pdf-reader-mcp-darwin-arm64@4.0.0",
         "@sylphx/pdf-reader-mcp-darwin-x64@4.0.0",
@@ -469,14 +477,17 @@
         "4.0.0 natives+main published with five-host registry proof.",
         "4.0.1 candidate removes production pdfjs-dist/MCP SDK/pngjs/zod install closure.",
         "PR #578 five-host local-pack initialize proofs green (incl. macos-14 darwin-arm64 and real darwin-x64).",
-        "Registry install proof for published 4.0.1 remains pending after publish."
+        "Registry install proof for published 4.0.1 remains pending after publish.",
+        "4.0.1 main published but linux-x64-gnu@4.0.1 tarball tombstoned (404); cannot republish that native version.",
+        "PR #581 five-host local-pack initialize proofs green for 4.0.2 (incl. macos-14 darwin-arm64 and real darwin-x64).",
+        "Registry install proof for published 4.0.2 remains pending after publish."
       ],
       "registryProofWorkflow": ".github/workflows/registry-install-proof.yml",
       "registryProofEvidence": "verification/pdf-reader-registry-install-proof-4.0.0.json",
       "registryProofRunUrl": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30070323043",
-      "candidateVersion": "4.0.1",
-      "candidateHostProofWorkflowRunUrl": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30078550923",
-      "candidateHostProofEvidence": "verification/pdf-reader-candidate-host-runtime-proof-4.0.1-aggregate.json"
+      "candidateVersion": "4.0.2",
+      "candidateHostProofWorkflowRunUrl": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30087577283",
+      "candidateHostProofEvidence": "verification/pdf-reader-candidate-host-runtime-proof-4.0.2-aggregate.json"
     },
     "libraryExports": {
       "status": "published-default-fail-closed",
@@ -487,27 +498,22 @@
     },
     "wholeProductReviewPackage": "docs/specs/whole-product-independent-review-package-4.0.0-sole-rust.md",
     "wholeProductReview": {
-      "status": "review_pass_unfreeze_authorized_goal_incomplete",
-      "candidateSha": "d6780a3bd17919b5f9b67e078422778d2a4b0c5f",
-      "evidence": "verification/pdf-reader-whole-product-independent-review-4.0.1-d6780a3.json",
-      "package": "docs/specs/whole-product-independent-review-package-4.0.0-sole-rust.md",
-      "runtimeEvidenceSha": "d6780a3bd17919b5f9b67e078422778d2a4b0c5f",
-      "runtimeEvidenceRelationship": "exact-reviewed-implementation-candidate-tree-identical-to-pr-head-f4fdcf4",
-      "hostProofWorkflowRunUrl": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30078550923",
+      "status": "independent-review-pass-unfreeze-authorized-goal-incomplete",
+      "candidateVersion": "4.0.2",
+      "candidateSha": "afb1aa3387dc3b4e10b9415d31dfea8844b3a89a",
+      "artifact": "verification/pdf-reader-whole-product-independent-review-4.0.2-afb1aa3.json",
+      "outcome": "review_pass_unfreeze_authorized_goal_incomplete",
       "unfreezeAuthorized": true,
-      "tsRetirementAuthorized": true,
       "soleRuntimeAuthorized": true,
+      "tsRetirementAuthorized": true,
       "performanceClaimsAuthorized": false,
       "goalCompleteAuthorized": false,
-      "notes": [
-        "Independent whole-product review of exact tip d6780a3 (PR #578 squash; tree-identical to CI head f4fdcf4).",
-        "Production dependency closure empty; TS/PDF.js only via devDependencies + build:oracle-ts.",
-        "Local gates: prod-dependency-closure, ts-production-absence, production-contract, sole-rust-core, package-smoke all PASS.",
-        "Five-host host-proof workflow 30078550923 green including darwin-arm64 macos-14 and real darwin-x64 x86_64 Rosetta=false.",
-        "Matrix remains 1 FULL + 44 PARTIAL; nonclaim ledger 109/109 with zero blockingForUnfreeze.",
-        "Performance marketing claims remain withheld; same-host A/B status=measured_draft_not_admissible.",
-        "Goal complete unauthorized: 4.0.1 unpublished; live npm latest remains 4.0.0."
-      ]
+      "hostProofWorkflowRunUrl": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30087577283",
+      "hostProofEvidence": "verification/pdf-reader-candidate-host-runtime-proof-4.0.2-aggregate.json",
+      "reviewedAt": "2026-07-24T11:12:39Z",
+      "priorReview": "verification/pdf-reader-whole-product-independent-review-4.0.1-d6780a3.json",
+      "note": "Emergency 4.0.2 republish authorized after linux-x64-gnu@4.0.1 tarball tombstone. Publish multi-channel readback still required before goal complete.",
+      "evidence": "verification/pdf-reader-whole-product-independent-review-4.0.2-afb1aa3.json"
     },
     "unfreezeAuthorized": true,
     "soleRuntimeAuthorized": true,

--- a/docs/specs/whole-product-independent-review-package-4.0.0-sole-rust.md
+++ b/docs/specs/whole-product-independent-review-package-4.0.0-sole-rust.md
@@ -122,10 +122,12 @@ Local result: PASS
 
 ## Latest independent review binding
 
-- **Candidate SHA:** `f9a31541c7083eda6efe3fc828a6223a8c476342`
-- **Evidence:** `verification/pdf-reader-whole-product-independent-review-4.0.0-f9a3154.json`
+- **Candidate SHA:** `afb1aa3387dc3b4e10b9415d31dfea8844b3a89a`
+- **Version:** `4.0.2` (unpublished emergency republish)
+- **Evidence:** `verification/pdf-reader-whole-product-independent-review-4.0.2-afb1aa3.json`
 - **Outcome:** `review_pass_unfreeze_authorized_goal_incomplete`
-- **Host proof run:** https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30067554747
+- **Host proof run:** https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30087577283
 - **Authorizations:** unfreeze=true; soleRuntime=true; tsRetirement=true; performanceClaims=false; goalComplete=false
-- **Note:** Pin-path-only descendants may bind matrix/verification docs. Any non-pin-path delta requires successor review. Goal complete remains blocked on multi-channel publish/readback.
+- **Defect repaired:** linux-x64-gnu@4.0.1 registry tarball tombstone / 404; full multi-platform republish required at 4.0.2
+- **Note:** Pin-path-only descendants may bind matrix/verification docs. Any non-pin-path delta requires successor review. Goal complete remains blocked on multi-channel publish/readback + install proofs; performance remains open.
 

--- a/verification/pdf-reader-candidate-host-runtime-proof-4.0.2-aggregate.json
+++ b/verification/pdf-reader-candidate-host-runtime-proof-4.0.2-aggregate.json
@@ -1,0 +1,117 @@
+{
+  "profile": "candidate_host_runtime_proof_aggregate",
+  "requiredPlatforms": [
+    "linux-x64-gnu",
+    "linux-arm64-gnu",
+    "darwin-arm64",
+    "darwin-x64",
+    "win32-x64-msvc"
+  ],
+  "distinctHostTriplesProven": [
+    "darwin-arm64",
+    "darwin-x64",
+    "linux-arm64-gnu",
+    "linux-x64-gnu",
+    "win32-x64-msvc"
+  ],
+  "failedOrMissing": [],
+  "legs": [
+    {
+      "file": "host-proof-darwin-arm64.json",
+      "platformId": "darwin-arm64",
+      "pass": true,
+      "runtimeProofValid": true,
+      "crossBuiltOnly": null,
+      "deferred": null,
+      "host": {
+        "nodePlatform": "darwin",
+        "nodeArch": "arm64",
+        "unameMachine": "arm64",
+        "rosettaTranslated": false,
+        "resolvedPlatformId": "darwin-arm64"
+      },
+      "initialize": {
+        "serverName": "pdf-reader-mcp",
+        "serverVersion": "4.0.2"
+      }
+    },
+    {
+      "file": "host-proof-darwin-x64.json",
+      "platformId": "darwin-x64",
+      "pass": true,
+      "runtimeProofValid": true,
+      "crossBuiltOnly": null,
+      "deferred": null,
+      "host": {
+        "nodePlatform": "darwin",
+        "nodeArch": "x64",
+        "unameMachine": "x86_64",
+        "rosettaTranslated": false,
+        "resolvedPlatformId": "darwin-x64"
+      },
+      "initialize": {
+        "serverName": "pdf-reader-mcp",
+        "serverVersion": "4.0.2"
+      }
+    },
+    {
+      "file": "host-proof-linux-arm64-gnu.json",
+      "platformId": "linux-arm64-gnu",
+      "pass": true,
+      "runtimeProofValid": true,
+      "crossBuiltOnly": null,
+      "deferred": null,
+      "host": {
+        "nodePlatform": "linux",
+        "nodeArch": "arm64",
+        "unameMachine": "aarch64",
+        "rosettaTranslated": null,
+        "resolvedPlatformId": "linux-arm64-gnu"
+      },
+      "initialize": {
+        "serverName": "pdf-reader-mcp",
+        "serverVersion": "4.0.2"
+      }
+    },
+    {
+      "file": "host-proof-linux-x64-gnu.json",
+      "platformId": "linux-x64-gnu",
+      "pass": true,
+      "runtimeProofValid": true,
+      "crossBuiltOnly": null,
+      "deferred": null,
+      "host": {
+        "nodePlatform": "linux",
+        "nodeArch": "x64",
+        "unameMachine": "x86_64",
+        "rosettaTranslated": null,
+        "resolvedPlatformId": "linux-x64-gnu"
+      },
+      "initialize": {
+        "serverName": "pdf-reader-mcp",
+        "serverVersion": "4.0.2"
+      }
+    },
+    {
+      "file": "host-proof-win32-x64-msvc.json",
+      "platformId": "win32-x64-msvc",
+      "pass": true,
+      "runtimeProofValid": true,
+      "crossBuiltOnly": null,
+      "deferred": null,
+      "host": {
+        "nodePlatform": "win32",
+        "nodeArch": "x64",
+        "unameMachine": "x86_64",
+        "rosettaTranslated": null,
+        "resolvedPlatformId": "win32-x64-msvc"
+      },
+      "initialize": {
+        "serverName": "pdf-reader-mcp",
+        "serverVersion": "4.0.2"
+      }
+    }
+  ],
+  "pass": true,
+  "policy": "all five platforms require real matching-arch host runtime proof; cross-build/deferred never pass"
+}

--- a/verification/pdf-reader-host-proof-4.0.2-darwin-arm64.json
+++ b/verification/pdf-reader-host-proof-4.0.2-darwin-arm64.json
@@ -1,0 +1,45 @@
+{
+  "profile": "registry_install_proof",
+  "mode": "local-pack",
+  "hostPlatformId": "darwin-arm64",
+  "host": {
+    "nodePlatform": "darwin",
+    "nodeArch": "arm64",
+    "unameMachine": "arm64",
+    "rosettaTranslated": false,
+    "resolvedPlatformId": "darwin-arm64"
+  },
+  "hostMatchesResolvedPlatformId": true,
+  "requiredPlatforms": [
+    "darwin-arm64",
+    "darwin-x64",
+    "linux-arm64-gnu",
+    "linux-x64-gnu",
+    "win32-x64-msvc"
+  ],
+  "soleRuntimePrerequisite": [
+    "productTruth.dropInFor3014=true",
+    "native optional packages published with platform binaries",
+    "npm install @sylphx/pdf-reader-mcp@<version> resolves optional native package",
+    "MCP initialize succeeds with pure-Rust native binary on each platform"
+  ],
+  "commands": {
+    "plan": "bun scripts/check-registry-install-proof.ts",
+    "localPack": "bun scripts/check-registry-install-proof.ts --local-pack",
+    "registry": "bun scripts/check-registry-install-proof.ts --registry --version=<published>",
+    "registryInstallOnly": "bun scripts/check-registry-install-proof.ts --registry --install-only --version=<published>"
+  },
+  "stagedBinary": "/Users/runner/work/pdf-reader-mcp/pdf-reader-mcp/packages/pdf-reader-mcp-darwin-arm64/bin/pdf-reader-mcp-server",
+  "tarballs": [
+    "sylphx-pdf-reader-mcp-4.0.2.tgz",
+    "sylphx-pdf-reader-mcp-darwin-arm64-4.0.2.tgz"
+  ],
+  "nativeBinary": "/var/folders/g3/pffjr_y96bq06blnkf72x_hw0000gn/T/pdf-reader-local-install-8H3YTp/node_modules/@sylphx/pdf-reader-mcp-darwin-arm64/bin/pdf-reader-mcp-server",
+  "initialize": {
+    "serverName": "pdf-reader-mcp",
+    "serverVersion": "4.0.2"
+  },
+  "runtimeProofValid": true,
+  "note": "Local pack + install + pure-Rust MCP initialize on matching host. Not npm registry readback.",
+  "pass": true
+}

--- a/verification/pdf-reader-host-proof-4.0.2-darwin-x64.json
+++ b/verification/pdf-reader-host-proof-4.0.2-darwin-x64.json
@@ -1,0 +1,45 @@
+{
+  "profile": "registry_install_proof",
+  "mode": "local-pack",
+  "hostPlatformId": "darwin-x64",
+  "host": {
+    "nodePlatform": "darwin",
+    "nodeArch": "x64",
+    "unameMachine": "x86_64",
+    "rosettaTranslated": false,
+    "resolvedPlatformId": "darwin-x64"
+  },
+  "hostMatchesResolvedPlatformId": true,
+  "requiredPlatforms": [
+    "darwin-arm64",
+    "darwin-x64",
+    "linux-arm64-gnu",
+    "linux-x64-gnu",
+    "win32-x64-msvc"
+  ],
+  "soleRuntimePrerequisite": [
+    "productTruth.dropInFor3014=true",
+    "native optional packages published with platform binaries",
+    "npm install @sylphx/pdf-reader-mcp@<version> resolves optional native package",
+    "MCP initialize succeeds with pure-Rust native binary on each platform"
+  ],
+  "commands": {
+    "plan": "bun scripts/check-registry-install-proof.ts",
+    "localPack": "bun scripts/check-registry-install-proof.ts --local-pack",
+    "registry": "bun scripts/check-registry-install-proof.ts --registry --version=<published>",
+    "registryInstallOnly": "bun scripts/check-registry-install-proof.ts --registry --install-only --version=<published>"
+  },
+  "stagedBinary": "/Users/sylphx/actions-runner/_work/pdf-reader-mcp/pdf-reader-mcp/packages/pdf-reader-mcp-darwin-x64/bin/pdf-reader-mcp-server",
+  "tarballs": [
+    "sylphx-pdf-reader-mcp-4.0.2.tgz",
+    "sylphx-pdf-reader-mcp-darwin-x64-4.0.2.tgz"
+  ],
+  "nativeBinary": "/var/folders/0h/217ygk_d11jcgw6fthbjsz640000gp/T/pdf-reader-local-install-OFsKqf/node_modules/@sylphx/pdf-reader-mcp-darwin-x64/bin/pdf-reader-mcp-server",
+  "initialize": {
+    "serverName": "pdf-reader-mcp",
+    "serverVersion": "4.0.2"
+  },
+  "runtimeProofValid": true,
+  "note": "Local pack + install + pure-Rust MCP initialize on matching host. Not npm registry readback.",
+  "pass": true
+}

--- a/verification/pdf-reader-host-proof-4.0.2-linux-arm64-gnu.json
+++ b/verification/pdf-reader-host-proof-4.0.2-linux-arm64-gnu.json
@@ -1,0 +1,45 @@
+{
+  "profile": "registry_install_proof",
+  "mode": "local-pack",
+  "hostPlatformId": "linux-arm64-gnu",
+  "host": {
+    "nodePlatform": "linux",
+    "nodeArch": "arm64",
+    "unameMachine": "aarch64",
+    "rosettaTranslated": null,
+    "resolvedPlatformId": "linux-arm64-gnu"
+  },
+  "hostMatchesResolvedPlatformId": true,
+  "requiredPlatforms": [
+    "darwin-arm64",
+    "darwin-x64",
+    "linux-arm64-gnu",
+    "linux-x64-gnu",
+    "win32-x64-msvc"
+  ],
+  "soleRuntimePrerequisite": [
+    "productTruth.dropInFor3014=true",
+    "native optional packages published with platform binaries",
+    "npm install @sylphx/pdf-reader-mcp@<version> resolves optional native package",
+    "MCP initialize succeeds with pure-Rust native binary on each platform"
+  ],
+  "commands": {
+    "plan": "bun scripts/check-registry-install-proof.ts",
+    "localPack": "bun scripts/check-registry-install-proof.ts --local-pack",
+    "registry": "bun scripts/check-registry-install-proof.ts --registry --version=<published>",
+    "registryInstallOnly": "bun scripts/check-registry-install-proof.ts --registry --install-only --version=<published>"
+  },
+  "stagedBinary": "/home/runner/work/pdf-reader-mcp/pdf-reader-mcp/packages/pdf-reader-mcp-linux-arm64-gnu/bin/pdf-reader-mcp-server",
+  "tarballs": [
+    "sylphx-pdf-reader-mcp-4.0.2.tgz",
+    "sylphx-pdf-reader-mcp-linux-arm64-gnu-4.0.2.tgz"
+  ],
+  "nativeBinary": "/tmp/pdf-reader-local-install-kdACky/node_modules/@sylphx/pdf-reader-mcp-linux-arm64-gnu/bin/pdf-reader-mcp-server",
+  "initialize": {
+    "serverName": "pdf-reader-mcp",
+    "serverVersion": "4.0.2"
+  },
+  "runtimeProofValid": true,
+  "note": "Local pack + install + pure-Rust MCP initialize on matching host. Not npm registry readback.",
+  "pass": true
+}

--- a/verification/pdf-reader-host-proof-4.0.2-linux-x64-gnu.json
+++ b/verification/pdf-reader-host-proof-4.0.2-linux-x64-gnu.json
@@ -1,0 +1,45 @@
+{
+  "profile": "registry_install_proof",
+  "mode": "local-pack",
+  "hostPlatformId": "linux-x64-gnu",
+  "host": {
+    "nodePlatform": "linux",
+    "nodeArch": "x64",
+    "unameMachine": "x86_64",
+    "rosettaTranslated": null,
+    "resolvedPlatformId": "linux-x64-gnu"
+  },
+  "hostMatchesResolvedPlatformId": true,
+  "requiredPlatforms": [
+    "darwin-arm64",
+    "darwin-x64",
+    "linux-arm64-gnu",
+    "linux-x64-gnu",
+    "win32-x64-msvc"
+  ],
+  "soleRuntimePrerequisite": [
+    "productTruth.dropInFor3014=true",
+    "native optional packages published with platform binaries",
+    "npm install @sylphx/pdf-reader-mcp@<version> resolves optional native package",
+    "MCP initialize succeeds with pure-Rust native binary on each platform"
+  ],
+  "commands": {
+    "plan": "bun scripts/check-registry-install-proof.ts",
+    "localPack": "bun scripts/check-registry-install-proof.ts --local-pack",
+    "registry": "bun scripts/check-registry-install-proof.ts --registry --version=<published>",
+    "registryInstallOnly": "bun scripts/check-registry-install-proof.ts --registry --install-only --version=<published>"
+  },
+  "stagedBinary": "/home/runner/work/pdf-reader-mcp/pdf-reader-mcp/packages/pdf-reader-mcp-linux-x64-gnu/bin/pdf-reader-mcp-server",
+  "tarballs": [
+    "sylphx-pdf-reader-mcp-4.0.2.tgz",
+    "sylphx-pdf-reader-mcp-linux-x64-gnu-4.0.2.tgz"
+  ],
+  "nativeBinary": "/tmp/pdf-reader-local-install-wpHf1p/node_modules/@sylphx/pdf-reader-mcp-linux-x64-gnu/bin/pdf-reader-mcp-server",
+  "initialize": {
+    "serverName": "pdf-reader-mcp",
+    "serverVersion": "4.0.2"
+  },
+  "runtimeProofValid": true,
+  "note": "Local pack + install + pure-Rust MCP initialize on matching host. Not npm registry readback.",
+  "pass": true
+}

--- a/verification/pdf-reader-host-proof-4.0.2-win32-x64-msvc.json
+++ b/verification/pdf-reader-host-proof-4.0.2-win32-x64-msvc.json
@@ -1,0 +1,45 @@
+{
+  "profile": "registry_install_proof",
+  "mode": "local-pack",
+  "hostPlatformId": "win32-x64-msvc",
+  "host": {
+    "nodePlatform": "win32",
+    "nodeArch": "x64",
+    "unameMachine": "x86_64",
+    "rosettaTranslated": null,
+    "resolvedPlatformId": "win32-x64-msvc"
+  },
+  "hostMatchesResolvedPlatformId": true,
+  "requiredPlatforms": [
+    "darwin-arm64",
+    "darwin-x64",
+    "linux-arm64-gnu",
+    "linux-x64-gnu",
+    "win32-x64-msvc"
+  ],
+  "soleRuntimePrerequisite": [
+    "productTruth.dropInFor3014=true",
+    "native optional packages published with platform binaries",
+    "npm install @sylphx/pdf-reader-mcp@<version> resolves optional native package",
+    "MCP initialize succeeds with pure-Rust native binary on each platform"
+  ],
+  "commands": {
+    "plan": "bun scripts/check-registry-install-proof.ts",
+    "localPack": "bun scripts/check-registry-install-proof.ts --local-pack",
+    "registry": "bun scripts/check-registry-install-proof.ts --registry --version=<published>",
+    "registryInstallOnly": "bun scripts/check-registry-install-proof.ts --registry --install-only --version=<published>"
+  },
+  "stagedBinary": "D:\\a\\pdf-reader-mcp\\pdf-reader-mcp\\packages\\pdf-reader-mcp-win32-x64-msvc\\bin\\pdf-reader-mcp-server.exe",
+  "tarballs": [
+    "sylphx-pdf-reader-mcp-4.0.2.tgz",
+    "sylphx-pdf-reader-mcp-win32-x64-msvc-4.0.2.tgz"
+  ],
+  "nativeBinary": "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\pdf-reader-local-install-aTRZWH\\node_modules\\@sylphx\\pdf-reader-mcp-win32-x64-msvc\\bin\\pdf-reader-mcp-server.exe",
+  "initialize": {
+    "serverName": "pdf-reader-mcp",
+    "serverVersion": "4.0.2"
+  },
+  "runtimeProofValid": true,
+  "note": "Local pack + install + pure-Rust MCP initialize on matching host. Not npm registry readback.",
+  "pass": true
+}

--- a/verification/pdf-reader-whole-product-independent-review-4.0.2-afb1aa3.json
+++ b/verification/pdf-reader-whole-product-independent-review-4.0.2-afb1aa3.json
@@ -1,0 +1,448 @@
+{
+  "schemaVersion": 1,
+  "profile": "pdf_reader_whole_product_independent_review_sole_rust_4_0_2",
+  "authority": [
+    "docs/adr/0005-capability-first-semantic-compatibility.md",
+    "docs/adr/0006-sole-rust-production-and-channel-authority.md",
+    "docs/specs/capability-first-admission-contract.md",
+    "docs/specs/host-runtime-proof-contract.md",
+    "docs/specs/performance/4.0.0-performance-claims-policy.md",
+    "docs/specs/whole-product-independent-review-package-4.0.0-sole-rust.md"
+  ],
+  "reviewPackage": "docs/specs/whole-product-independent-review-package-4.0.0-sole-rust.md",
+  "reviewer": {
+    "identity": "independent-whole-product-reviewer-agent",
+    "mode": "emergency-republish-candidate-independent-review",
+    "independence": "Does not inherit prior 4.0.0/4.0.1 authorizations as automatic truth for 4.0.2. Re-evaluates exact main tip afb1aa3 from repository state, local packaging/fail-closed gates, PR #581 CI, host-proof artifacts, live npm tombstone/readback, matrix/nonclaim honesty, and performance-claim status only.",
+    "reviewedAt": "2026-07-24T11:12:39Z"
+  },
+  "candidate": {
+    "repository": "SylphxAI/pdf-reader-mcp",
+    "branch": "main",
+    "pullRequest": 581,
+    "sha": "afb1aa3387dc3b4e10b9415d31dfea8844b3a89a",
+    "shortSha": "afb1aa3",
+    "tree": "00f82c6a05b8aa41187ac4e783bc47904983198a",
+    "prHeadSha": "af51476359575ff4f51b0e83b1bfe98c4a8d488c",
+    "prHeadTree": "6c13c533607d1f4919e3fc3a90d5267673108d02",
+    "prHeadTreeIdentical": false,
+    "prHeadProductPathsIdenticalExcludingGithubWorkflows": true,
+    "prHeadTreeDeltaNote": "Full trees differ only in .github/workflows/* Dependabot actions/* version bumps that were already on main before squash-merge of #581. Product packaging/source paths are identical between CI head af51476 and merge tip afb1aa3.",
+    "version": "4.0.2",
+    "title": "fix(release): 4.0.2 emergency linux-x64-gnu tarball repair (#581)",
+    "published": false,
+    "liveNpmLatest": "4.0.1",
+    "liveLinuxX64GnuLatest": "4.0.0",
+    "linuxX64Gnu401Status": "tombstoned_or_unpublished_tarball_404",
+    "reviewedAt": "2026-07-24T11:12:39Z",
+    "trackedTreeCleanAtReview": true,
+    "worktreeNote": "Detached HEAD at afb1aa3 with clean tracked tree before review mutation. Pre-existing untracked benchmark-artifacts/same-host-ab preserved and not part of package allowlist or this pin-path commit.",
+    "correctiveOf": {
+      "version": "4.0.1",
+      "defect": "Main package and four natives published at 4.0.1, but @sylphx/pdf-reader-mcp-linux-x64-gnu@4.0.1 registry tarball 404/tombstone after failed tarball repair/unpublish; cannot republish that native version. Linux x64 optional installs fail closed despite main@4.0.1 existing."
+    },
+    "contentRelationshipTo401": "Version-bump emergency republish of sole-Rust packaging with empty production dependency closure; product packaging content identical in intent to 4.0.1 dependency-closure release."
+  },
+  "runtimeEvidenceCandidate": {
+    "sha": "afb1aa3387dc3b4e10b9415d31dfea8844b3a89a",
+    "prHeadSha": "af51476359575ff4f51b0e83b1bfe98c4a8d488c",
+    "relationshipToReviewedSha": "squash_merge_of_pr_581_product_paths_identical_to_ci_head_workflow_actions_bumps_only",
+    "tree": "00f82c6a05b8aa41187ac4e783bc47904983198a",
+    "hostProofWorkflowRunUrl": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30087577283",
+    "hostProofWorkflowConclusion": "success",
+    "hostProofHeadSha": "af51476359575ff4f51b0e83b1bfe98c4a8d488c",
+    "hostProofArtifactsBoundInPinCommit": [
+      "verification/pdf-reader-candidate-host-runtime-proof-4.0.2-aggregate.json",
+      "verification/pdf-reader-host-proof-4.0.2-darwin-arm64.json",
+      "verification/pdf-reader-host-proof-4.0.2-darwin-x64.json",
+      "verification/pdf-reader-host-proof-4.0.2-linux-arm64-gnu.json",
+      "verification/pdf-reader-host-proof-4.0.2-linux-x64-gnu.json",
+      "verification/pdf-reader-host-proof-4.0.2-win32-x64-msvc.json"
+    ],
+    "initializeServerVersionObserved": "4.0.2",
+    "darwinX64": {
+      "unameMachine": "x86_64",
+      "rosettaTranslated": false,
+      "runtimeProofValid": true
+    }
+  },
+  "priorReview": {
+    "artifact": "verification/pdf-reader-whole-product-independent-review-4.0.1-d6780a3.json",
+    "candidateSha": "d6780a3bd17919b5f9b67e078422778d2a4b0c5f",
+    "outcome": "review_pass_unfreeze_authorized_goal_incomplete",
+    "note": "4.0.1 unfreeze authorized packaging/publish of dependency-closure sole-Rust release. Post-publish linux-x64-gnu@4.0.1 tarball defect forced 4.0.2 emergency republish. This review re-opens exact-SHA admission for 4.0.2 only."
+  },
+  "productTruthSnapshot": {
+    "publishedStable": "@sylphx/pdf-reader-mcp@4.0.1",
+    "candidateVersion": "4.0.2",
+    "pureRustStatus": "sole-rust-production-default",
+    "soleRustProduction": true,
+    "typescriptProductionShipped": false,
+    "typescriptExportRemoved": true,
+    "automaticTypescriptFallback": false,
+    "productionDependencies": {},
+    "optionalNativeDependenciesOnly": true,
+    "oracleTsOnlyVia": [
+      "devDependencies",
+      "build:oracle-ts"
+    ],
+    "defaultBuild": "build:package (launcher-only)",
+    "dropInFor3014": true,
+    "publishFreeze": false,
+    "registryPublishAuthorized": true,
+    "performanceClaimsWithheld": true,
+    "matrixFull": 1,
+    "matrixPartial": 44,
+    "nonclaimEntries": 109,
+    "nonclaimBlockingForUnfreeze": 0,
+    "sameHostAbStatus": "measured_draft_not_admissible",
+    "linuxX64Gnu401Tarball": "HTTP 404 / version not installable",
+    "liveMainLatest": "4.0.1",
+    "liveLinuxX64GnuLatest": "4.0.0"
+  },
+  "outcome": "review_pass_unfreeze_authorized_goal_incomplete",
+  "outcomeMeaning": "Exact 4.0.2 candidate is authorized for verified-candidate multi-platform publish (main + five natives) as emergency repair of linux-x64-gnu@4.0.1 tarball tombstone. Performance claims remain unauthorized. Goal complete remains false until published multi-channel readback + five-host registry install proofs (and performance still open if product goal requires it).",
+  "unfreezeAuthorized": true,
+  "soleRuntimeAuthorized": true,
+  "tsRetirementAuthorized": true,
+  "performanceClaimsAuthorized": false,
+  "goalCompleteAuthorized": false,
+  "unfreezeScope": {
+    "exactCandidate": "afb1aa3387dc3b4e10b9415d31dfea8844b3a89a",
+    "version": "4.0.2",
+    "channels": [
+      "npm @sylphx/pdf-reader-mcp@4.0.2",
+      "npm five optional native packages@4.0.2",
+      "MCP registry io.github.SylphxAI/pdf-reader-mcp@4.0.2",
+      "GitHub Release v4.0.2 notes"
+    ],
+    "notAuthorized": [
+      "performance marketing claims",
+      "goal-complete declaration",
+      "reclassify PARTIAL matrix cells as FULL",
+      "republish linux-x64-gnu@4.0.1 (tombstoned)"
+    ]
+  },
+  "layers": {
+    "productionDependencyClosure": {
+      "status": "pass",
+      "evidence": [
+        "package.json dependencies == {}",
+        "optionalDependencies are only the five @sylphx/pdf-reader-mcp-<platform>@4.0.2 natives",
+        "bun run check:prod-dependency-closure PASS",
+        "omit-optional local pack install lock packages only main; banned pdfjs-dist/@modelcontextprotocol/sdk/pngjs/zod absent"
+      ]
+    },
+    "tsPdfjsAbsence": {
+      "status": "pass",
+      "evidence": [
+        "bun run check:ts-production-absence PASS",
+        "bun run package:smoke PASS",
+        "npm pack tarball 14 files: launcher + pure-rust helper + examples/corpus/README/LICENSE only; no pdfjs/worker/typescript/legacy payloads"
+      ]
+    },
+    "soleRustLauncherFailClosed": {
+      "status": "pass",
+      "evidence": [
+        "src/runtime-entry.ts force-TS / engine-mode=typescript exit 2",
+        "omit-optional install missing native exit 1",
+        "SERVER_VERSION const in crates/pdf-reader-mcp-server/src/lib.rs is 4.0.2; CI initialize serverVersion=4.0.2"
+      ]
+    },
+    "partialHonesty": {
+      "status": "pass",
+      "evidence": [
+        "docs/specs/pure-rust-capability-matrix.json tools status counts FULL=1 PARTIAL=44",
+        "nonclaim ledger stats.blockingForUnfreezeCount=0; 109 reviewed entries"
+      ]
+    },
+    "fiveHostRealArchProofs": {
+      "status": "pass",
+      "evidence": [
+        "PR #581 Candidate host runtime proof run 30087577283 success on CI head af51476",
+        "5/5 legs pass with matching arch incl. darwin-x64 unameMachine=x86_64 rosettaTranslated=false",
+        "aggregate pass bound as verification/pdf-reader-candidate-host-runtime-proof-4.0.2-aggregate.json",
+        "product paths identical between CI head and reviewed merge tip afb1aa3"
+      ]
+    },
+    "performanceClaims": {
+      "status": "withheld",
+      "evidence": [
+        "verification/pdf-reader-same-host-ab-suite-draft.json status=measured_draft_not_admissible",
+        "no admissible A/B successor authorization"
+      ]
+    },
+    "goalComplete": {
+      "status": "not_authorized",
+      "evidence": [
+        "4.0.2 unpublished; npm view @sylphx/pdf-reader-mcp@4.0.2 => 404",
+        "live latest main=4.0.1 with broken linux-x64-gnu@4.0.1 channel",
+        "no multi-channel 4.0.2 registry/MCP/GitHub Release readback",
+        "performance still not admissible if required by product goal"
+      ]
+    }
+  },
+  "findings": [
+    {
+      "id": "F1-prod-dependency-closure-empty",
+      "severity": "info",
+      "status": "pass",
+      "summary": "Production dependency object is empty; only platform native optionalDependencies@4.0.2 remain; banned install-graph packages absent.",
+      "evidence": [
+        "package.json dependencies={}",
+        "check:prod-dependency-closure PASS",
+        "package:smoke PASS",
+        "omit-optional install banned_count=0"
+      ]
+    },
+    {
+      "id": "F2-ts-pdfjs-not-published",
+      "severity": "info",
+      "status": "pass",
+      "summary": "TS/PDF.js runtime is not in published package files; oracle remains devDependency only.",
+      "evidence": [
+        "files allowlist launcher-only",
+        "build=build:package",
+        "check:ts-production-absence PASS",
+        "tarball paths exclude pdfjs/typescript/legacy"
+      ]
+    },
+    {
+      "id": "F3-runtime-fail-closed",
+      "severity": "info",
+      "status": "pass",
+      "summary": "Runtime fails closed on force-TS and missing native; no silent TS engine switch.",
+      "evidence": [
+        "src/runtime-entry.ts exit 2 / exit 1 paths",
+        "local FORCE_TS exit 2 and omit-optional missing-native exit 1 probes on packed 4.0.2"
+      ]
+    },
+    {
+      "id": "F4-partial-honesty",
+      "severity": "info",
+      "status": "pass",
+      "summary": "Capability matrix still reports 44 PARTIAL + 1 FULL; residuals not reclassified as FULL.",
+      "evidence": [
+        "docs/specs/pure-rust-capability-matrix.json status counts",
+        "nonclaim ledger blockingForUnfreeze=0"
+      ]
+    },
+    {
+      "id": "F5-five-host-real-arch-proofs",
+      "severity": "info",
+      "status": "pass",
+      "summary": "PR #581 five-host candidate proofs green including macos-14 darwin-arm64 and real darwin-x64 x86_64; initialize serverVersion=4.0.2.",
+      "evidence": [
+        "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30087577283",
+        "verification/pdf-reader-candidate-host-runtime-proof-4.0.2-aggregate.json",
+        "product-path identity af51476 <-> afb1aa3"
+      ]
+    },
+    {
+      "id": "F6-emergency-401-linux-x64-tombstone",
+      "severity": "info",
+      "status": "pass",
+      "summary": "Live channel defect confirmed: main@4.0.1 exists, linux-x64-gnu@4.0.1 not installable (npm view 404 / tarball 404); latest linux-x64-gnu remains 4.0.0. 4.0.2 version bump is the correct republish vehicle.",
+      "evidence": [
+        "npm view @sylphx/pdf-reader-mcp version => 4.0.1",
+        "npm view @sylphx/pdf-reader-mcp-linux-x64-gnu dist-tags.latest => 4.0.0",
+        "npm view @sylphx/pdf-reader-mcp-linux-x64-gnu@4.0.1 => 404",
+        "HEAD tarball URL for linux-x64-gnu-4.0.1.tgz => HTTP 404"
+      ]
+    },
+    {
+      "id": "F7-performance-unauthorized",
+      "severity": "blocker_for_claims_only",
+      "status": "withheld",
+      "summary": "No admissible same-host A/B; performance marketing claims remain unauthorized.",
+      "evidence": [
+        "verification/pdf-reader-same-host-ab-suite-draft.json status=measured_draft_not_admissible",
+        "docs/specs/performance/4.0.0-performance-claims-policy.md"
+      ]
+    },
+    {
+      "id": "F8-goal-incomplete-unpublished",
+      "severity": "blocker_for_goal_complete",
+      "status": "open",
+      "summary": "4.0.2 is not published; live main latest is broken-channel 4.0.1. Goal complete cannot be authorized.",
+      "evidence": [
+        "npm view @sylphx/pdf-reader-mcp@4.0.2 => 404",
+        "no multi-channel 4.0.2 readback"
+      ]
+    },
+    {
+      "id": "F9-local-stale-binary-note",
+      "severity": "info",
+      "status": "noted",
+      "summary": "Local worktree staged native binary still embedded prior 4.0.1 server version string; not a candidate source defect. CI rebuilt natives advertise 4.0.2. Local check:production-contract version assert failed for this environmental reason only.",
+      "evidence": [
+        "crates/pdf-reader-mcp-server/src/lib.rs SERVER_VERSION=\"4.0.2\"",
+        "CI host-proof initialize.serverVersion=4.0.2",
+        "local packages/.../bin/pdf-reader-mcp-server strings still show 4.0.1 until rebuild"
+      ]
+    }
+  ],
+  "commandsExecuted": [
+    {
+      "cmd": "git rev-parse afb1aa3 / afb1aa3^{tree} / af51476^{tree}",
+      "result": "afb1aa3; trees 00f82c6a vs 6c13c533"
+    },
+    {
+      "cmd": "git diff --stat af51476 afb1aa3",
+      "result": "12 workflow files only (actions/* bumps)"
+    },
+    {
+      "cmd": "bun run check:prod-dependency-closure",
+      "result": "PASS version 4.0.2 dependencies={}"
+    },
+    {
+      "cmd": "bun run check:ts-production-absence",
+      "result": "PASS"
+    },
+    {
+      "cmd": "bun run package:smoke",
+      "result": "PASS"
+    },
+    {
+      "cmd": "bun run check:pure-rust-matrix",
+      "result": "PASS"
+    },
+    {
+      "cmd": "bun run check:pure-rust-exports",
+      "result": "PASS"
+    },
+    {
+      "cmd": "bun run build:package && npm pack",
+      "result": "14-file launcher-only tarball; no pdfjs"
+    },
+    {
+      "cmd": "npm install --omit=optional <local 4.0.2 tarball>",
+      "result": "only @sylphx/pdf-reader-mcp; banned deps absent; missing native exit 1; FORCE_TS exit 2"
+    },
+    {
+      "cmd": "npm view @sylphx/pdf-reader-mcp version / @4.0.2",
+      "result": "latest 4.0.1; 4.0.2 404"
+    },
+    {
+      "cmd": "npm view @sylphx/pdf-reader-mcp-linux-x64-gnu dist-tags / @4.0.1",
+      "result": "latest 4.0.0; 4.0.1 404"
+    },
+    {
+      "cmd": "HEAD registry tarball linux-x64-gnu-4.0.1.tgz",
+      "result": "HTTP 404"
+    },
+    {
+      "cmd": "gh pr checks 581",
+      "result": "all listed checks pass including five host proofs + aggregate"
+    },
+    {
+      "cmd": "gh run download 30087577283 host proofs",
+      "result": "5/5 legs pass + aggregate pass; serverVersion 4.0.2"
+    }
+  ],
+  "remainingBeforeGoalComplete": [
+    "Publish @sylphx/pdf-reader-mcp@4.0.2 and all five native optional packages@4.0.2 from exact reviewed SHA or pin-path-only descendant via verified-candidate release path",
+    "Five-host registry install proof on published 4.0.2 (not only local-pack candidate proof)",
+    "npm latest / dist-tag / integrity / provenance readback for 4.0.2 including installable linux-x64-gnu@4.0.2 tarball",
+    "MCP registry readback for io.github.SylphxAI/pdf-reader-mcp@4.0.2 (latest/active as intended)",
+    "GitHub Release v4.0.2 notes consistent with user-facing honesty (no performance overclaim); document 4.0.1 linux-x64-gnu tombstone",
+    "If product goal still requires performance marketing evidence: admissible same-host TS 3.0.14 vs Rust A/B with status=admissible_pass + successor authorization (currently absent; keep withheld)"
+  ],
+  "blockers": {
+    "forPublishAdmission": [],
+    "forPerformanceClaims": [
+      "same-host A/B remains measured_draft_not_admissible",
+      "performanceClaimsAuthorized=false"
+    ],
+    "forGoalComplete": [
+      "4.0.2 unpublished; live npm latest=4.0.1 with linux-x64-gnu@4.0.1 install channel broken",
+      "no multi-channel 4.0.2 registry/MCP/GitHub Release readback",
+      "performance evidence still not admissible if required by product goal"
+    ]
+  },
+  "contradictionsChecked": [
+    {
+      "claim": "4.0.1 already completed sole-Rust dependency-closure production goal",
+      "resolution": "Partially false for multi-platform installability. Main@4.0.1 and non-linux-x64 natives exist, but linux-x64-gnu@4.0.1 tarball is 404/tombstoned so full multi-platform install graph is broken. Goal complete remains false; 4.0.2 is emergency republish."
+    },
+    {
+      "claim": "4.0.2 changes product behavior beyond version bump",
+      "resolution": "Unsupported for packaging intent. Diff vs 4.0.1 is version/metadata/matrix productTruth emergency notes + SERVER_VERSION 4.0.2; empty production deps retained. PR CI head vs merge tip differs only in Dependabot workflow action versions."
+    },
+    {
+      "claim": "Clean install no longer downloads PDF.js",
+      "resolution": "Supported for 4.0.2 candidate package/tarball (empty production deps; omit-optional install has no pdfjs). Not yet live until publish of 4.0.2."
+    },
+    {
+      "claim": "Performance is Nx faster",
+      "resolution": "Unauthorized. Draft A/B not admissible; claims withheld."
+    },
+    {
+      "claim": "PARTIAL capabilities are now FULL",
+      "resolution": "False. Matrix still 44 PARTIAL + 1 FULL."
+    },
+    {
+      "claim": "linux-x64-gnu@4.0.1 can be repaired in-place",
+      "resolution": "Rejected by registry reality: version not re-publishable after unpublish/tombstone. 4.0.2 is required."
+    }
+  ],
+  "publicationAdmissionReadiness": {
+    "readyForVerifiedCandidatePublish": true,
+    "requireExactHead": "afb1aa3387dc3b4e10b9415d31dfea8844b3a89a",
+    "requirePinPathOnlyIfDescendant": true,
+    "prepublishGates": [
+      "bun run prepublishOnly",
+      "verified-candidate admission path",
+      "native packages 4.0.2 co-published with installable tarballs for all five hosts including linux-x64-gnu"
+    ]
+  },
+  "allowedDescendants": {
+    "exact": "afb1aa3387dc3b4e10b9415d31dfea8844b3a89a",
+    "pinPathOnly": [
+      "docs/specs/**",
+      "verification/**",
+      "admission-allowlisted pin paths (matrix, README/CHANGELOG, pure-rust constants, admission scripts)"
+    ],
+    "note": "Non-pin-path deltas require successor independent review before publish."
+  },
+  "evidencePaths": [
+    "verification/pdf-reader-whole-product-independent-review-4.0.2-afb1aa3.json",
+    "verification/pdf-reader-candidate-host-runtime-proof-4.0.2-aggregate.json",
+    "verification/pdf-reader-host-proof-4.0.2-darwin-arm64.json",
+    "verification/pdf-reader-host-proof-4.0.2-darwin-x64.json",
+    "verification/pdf-reader-host-proof-4.0.2-linux-arm64-gnu.json",
+    "verification/pdf-reader-host-proof-4.0.2-linux-x64-gnu.json",
+    "verification/pdf-reader-host-proof-4.0.2-win32-x64-msvc.json",
+    "verification/pdf-reader-whole-product-independent-review-4.0.1-d6780a3.json",
+    "verification/pdf-reader-same-host-ab-suite-draft.json",
+    "docs/specs/pure-rust-capability-matrix.json",
+    "docs/specs/nonclaim-reclassification-ledger.json",
+    "docs/specs/performance/4.0.0-performance-claims-policy.md",
+    "package.json",
+    "README.md",
+    "src/runtime-entry.ts",
+    "crates/pdf-reader-mcp-server/src/lib.rs"
+  ],
+  "ci": {
+    "pullRequest": 581,
+    "url": "https://github.com/SylphxAI/pdf-reader-mcp/pull/581",
+    "mergedAt": "2026-07-24T11:04:52Z",
+    "mergeCommit": "afb1aa3387dc3b4e10b9415d31dfea8844b3a89a",
+    "hostProofRun": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/30087577283",
+    "hostProofHeadSha": "af51476359575ff4f51b0e83b1bfe98c4a8d488c",
+    "checks": {
+      "Validate Code Quality": "pass",
+      "Release Evidence Gate": "pass",
+      "security:secrets": "pass",
+      "Analyze (javascript-typescript)": "pass",
+      "proof darwin-arm64 macos-14": "pass",
+      "proof darwin-x64 real x86_64": "pass",
+      "proof linux-x64-gnu": "pass",
+      "proof linux-arm64-gnu": "pass",
+      "proof win32-x64-msvc": "pass",
+      "native package scaffold five hosts": "pass",
+      "rust-parity-differential": "pass",
+      "host-proof aggregate": "pass"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Independent whole-product review pin for emergency sole-Rust **4.0.2** at exact SHA `afb1aa3387dc3b4e10b9415d31dfea8844b3a89a` (main tip after #581).

### Authorizations
- `outcome`: `review_pass_unfreeze_authorized_goal_incomplete`
- `unfreezeAuthorized`: true
- `soleRuntimeAuthorized`: true
- `tsRetirementAuthorized`: true
- `performanceClaimsAuthorized`: **false**
- `goalCompleteAuthorized`: **false**

### Evidence
- Empty production dependency closure; no pdfjs-dist install graph on packed 4.0.2
- Sole-Rust launcher fail-closed (FORCE_TS exit 2; omit-optional missing native exit 1)
- PR #581 five-host real-arch local-pack proofs green (incl. macos-14 darwin-arm64 + real darwin-x64); initialize `serverVersion=4.0.2`
- PARTIAL honesty retained (44 PARTIAL + 1 FULL)
- Live: main latest=4.0.1; linux-x64-gnu@4.0.1 tombstoned/404; 4.0.2 unpublished

### Pin paths only
- `verification/**` review + host-proof artifacts
- `docs/specs/pure-rust-capability-matrix.json` wholeProductReview pointer
- `docs/specs/whole-product-independent-review-package-4.0.0-sole-rust.md` latest binding
- `README.md` install pin example → `@4.0.2`

Does **not** publish.

### Publish vs goal complete
- **Publish admission:** ready for verified-candidate multi-platform 4.0.2 publish from exact `afb1aa3` or pin-path-only descendant
- **Goal complete blocked on:** 4.0.2 multi-channel readback + five-host registry install proofs; performance still open if required