### PR TITLE
docs(product): public truth reset + honest install footprint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,17 @@ repository = "https://github.com/SylphxAI/pdf-reader-mcp"
 homepage = "https://github.com/SylphxAI/pdf-reader-mcp"
 authors = ["Sylphx <contact@sylphx.com>"]
 readme = "README.md"
+
+# Production binaries: smaller artifacts without requiring runtime downloads.
+# Keep debuginfo available via separate tooling/dSYM workflows in CI when needed.
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = "symbols"
+panic = "abort"
+
+[profile.release-with-debug]
+inherits = "release"
+strip = "none"
+debug = true
+

--- a/README.md
+++ b/README.md
@@ -2,46 +2,47 @@
 
 # PDF Reader MCP
 
-**Evidence-first PDF intelligence for AI agents**
+### Give your AI agent eyes for PDFs.
 
-Read PDFs with page citations, tables, structure, OCR, and trust signals — not a plain text dump.
+Turn PDFs into **structured text, tables, OCR, visual evidence, and page-level citations** — locally, with one MCP server.
+
+Plain-text PDF tools make agents guess. **PDF Reader MCP gives them evidence.**
 
 [![npm version](https://img.shields.io/npm/v/@sylphx/pdf-reader-mcp?style=flat-square)](https://www.npmjs.com/package/@sylphx/pdf-reader-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat-square)](https://opensource.org/licenses/MIT)
 [![CI](https://img.shields.io/github/actions/workflow/status/SylphxAI/pdf-reader-mcp/ci.yml?style=flat-square&label=CI)](https://github.com/SylphxAI/pdf-reader-mcp/actions/workflows/ci.yml)
+[![stars](https://img.shields.io/github/stars/SylphxAI/pdf-reader-mcp?style=flat-square)](https://github.com/SylphxAI/pdf-reader-mcp/stargazers)
 
 </div>
 
-## What it does
+## Why this exists
 
-`@sylphx/pdf-reader-mcp` turns PDFs into agent-usable evidence:
+Most PDF tools dump text. Agents then invent page numbers, miss tables, and cite the wrong cell.
 
-- Text and structure with page numbers and locations
-- Tables with cells and geometry
-- Search with snippets and page hits
-- Document map / AST for headings, lists, figures, reading order
-- OCR for scanned pages
-- Forms, annotations, attachments
-- Trust / accessibility signals when requested
-- Crops and renders for visual verification
+PDF Reader MCP returns an **Agent Document Twin**: markdown + structure + geometry + provenance your agent can actually trust.
 
-Version 4 uses a **native Rust engine** on supported platforms, launched by a thin Node wrapper.
+| Without evidence | With PDF Reader MCP |
+| --- | --- |
+| “The revenue was about $12M” | “Page 14, Table 3, cell (row 4, col 2) = `$12.4M`” |
+| Lost table structure | Rows, columns, cells, bounding boxes |
+| Scanned PDF becomes noise | OCR path with page-linked evidence |
+| Hidden text / prompt injection ignored | Trust signals when requested |
 
-## Install
+## Install (30 seconds)
 
 ```bash
 npm install -g @sylphx/pdf-reader-mcp
 ```
 
-Pin a version:
+Or pin the current release:
 
 ```bash
 npm install -g @sylphx/pdf-reader-mcp@4.0.2
 ```
 
-Optional native packages install automatically when available:
+One native binary is installed for **your** platform only (not all five).
 
-| Platform | Package |
+| Platform | Native package (auto optionalDependency) |
 | --- | --- |
 | macOS arm64 | `@sylphx/pdf-reader-mcp-darwin-arm64` |
 | macOS x64 | `@sylphx/pdf-reader-mcp-darwin-x64` |
@@ -49,35 +50,47 @@ Optional native packages install automatically when available:
 | Linux arm64 | `@sylphx/pdf-reader-mcp-linux-arm64-gnu` |
 | Windows x64 | `@sylphx/pdf-reader-mcp-win32-x64-msvc` |
 
-If the matching native package is missing, the server fails closed.
+Missing native package → **fail closed** (no silent engine switch).
 
 ## Quick start
+
+**Claude Code**
 
 ```bash
 claude mcp add pdf-reader -- npx @sylphx/pdf-reader-mcp
 ```
 
-Stdio:
+**Claude Desktop / Cursor / VS Code / any MCP client**
+
+```json
+{
+  "mcpServers": {
+    "pdf-reader": {
+      "command": "npx",
+      "args": ["@sylphx/pdf-reader-mcp"]
+    }
+  }
+}
+```
+
+**Stdio / HTTP**
 
 ```bash
 pdf-reader-mcp
-```
-
-HTTP:
-
-```bash
 MCP_TRANSPORT=http pdf-reader-mcp
 ```
 
-## Tools
+## What you get
 
-| Tool | Purpose |
+Three tools. One product surface.
+
+| Tool | What agents use it for |
 | --- | --- |
-| `read_pdf` | Read pages/regions: markdown, tables, OCR, structure, evidence |
-| `search_pdf` | Find matches with page + snippet context |
-| `pdf_evidence` | Inspect evidence, crops, renders, related operations |
+| `read_pdf` | Smart default: markdown, tables, structure, OCR, citations |
+| `search_pdf` | Find page + snippet matches before deep reading |
+| `pdf_evidence` | Crops, renders, inspect, focused evidence ops |
 
-Minimal `read_pdf` call:
+Minimal call:
 
 ```json
 {
@@ -85,30 +98,52 @@ Minimal `read_pdf` call:
 }
 ```
 
-## Performance
+### Flagship use cases
 
-Current published measurements are **startup-inclusive end-to-end** (spawn server + initialize + one `read_pdf`), not steady-state latency of an already-running server.
+1. **Financial reports** — extract table cells agents can cite by page and geometry  
+2. **Research papers** — headings, reading order, page-level quotes  
+3. **Scanned documents** — OCR path with evidence, not a text soup  
 
-On a controlled same-host **linux-x64** run versus `@sylphx/pdf-reader-mcp@3.0.14` for page-1 `include_full_text`:
+## Install footprint (honest product comparison)
 
-- Preliminary suite reported large speedups on local fixtures
-- Formal product performance admission is being rebuilt with:
-  - separate startup vs persistent-server timings
-  - stronger semantic outcome checks
-  - capability-specific tasks (table/structure/search/geometry)
-  - registry-installed exact binaries and durable raw samples
+Compare **full clean installs**, not “JS wrapper tarball vs native executable”:
 
-Until that re-admission lands, treat public speed numbers as **preliminary**, not a universal product guarantee.
+| Metric (measured clean install, **linux-x64**) | Historical TS `3.0.14` | Sole-Rust `4.0.2` |
+| --- | ---: | ---: |
+| Main package on disk | ~403 KB | ~77 KB |
+| Full `node_modules` | ~82.3 MiB | **~24.4 MiB** (~3.4× smaller) |
+| Installed files | 4,101 | **20** (~205× fewer) |
+| Production npm dependency graph | PDF.js + MCP TS SDK + more | `{}` + **one** platform native |
 
-Details: [performance report](docs/specs/performance/4.0.2-same-host-performance-report.md) · [claims policy](docs/specs/performance/4.0.2-performance-claims-policy.md)
+The native binary is multi-megabyte because it **is** the PDF intelligence engine (parser, server, rendering/table/OCR routing). That is expected and still yields a **cleaner, smaller install** than shipping PDF.js + a JS dependency tree.
+
+Details: [installed footprint comparison](docs/specs/performance/installed-footprint-comparison.md)
+
+## Performance (bounded honesty)
+
+- Startup-inclusive measurements (spawn + initialize + task) show large gains on local fixtures vs TS `3.0.14`.
+- Steady-state warm `tools/call` performance is **being re-admitted** under a dual-mode harness (`startup_inclusive` vs `persistent_warm`).
+- Until that re-admission + independent authorization, **do not treat any single “Nx faster” number as a universal product guarantee**.
+
+## Engine note
+
+Version 4 runs a **native Rust engine** on supported platforms via a thin Node launcher.
+
+> Local-first. Five platforms. One clean install.
+
+Engineering history, recovery pins, and ADRs live under [docs/migration.md](docs/migration.md) — not the product pitch.
 
 ## Docs
 
-- [Comparison / capability overview](docs/comparison/index.md)
-- [Capability matrix](docs/specs/pure-rust-capability-matrix.json)
-- [Migration / recovery notes](docs/migration.md)
-- [ADR-0005](docs/adr/0005-capability-first-semantic-compatibility.md) · [ADR-0006](docs/adr/0006-sole-rust-production-and-channel-authority.md)
+- [Website / guide](https://sylphxai.github.io/pdf-reader-mcp/)
+- [Installation](docs/guide/installation.md)
+- [Comparison](docs/comparison/index.md)
+- [Migration / recovery (secondary)](docs/migration.md)
 
 ## License
 
 MIT
+
+---
+
+If this saves your agents from PDF hallucinations, **star the repo** and share a demo with your team.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   cleanUrls: true,
   title: 'PDF Reader MCP',
   description:
-    'The most-starred PDF MCP server. Stop agent hallucinations on PDFs with evidence-first Agent Document Twin extraction, tables, trust reports, and source proof for Claude, Cursor, and any MCP client.',
+    'Give your AI agent eyes for PDFs. Structured text, tables, OCR, visual evidence, and page-level citations — local-first native engine for Claude, Cursor, VS Code, and any MCP client.',
 
   appearance: 'dark',
   lastUpdated: true,
@@ -20,7 +20,7 @@ export default defineConfig({
     ['meta', { property: 'og:type', content: 'website' }],
     [
       'meta',
-      { property: 'og:title', content: 'PDF Reader MCP - Stop PDF Hallucinations for AI Agents' },
+      { property: 'og:title', content: 'PDF Reader MCP — Give your AI agent eyes for PDFs' },
     ],
     [
       'meta',

--- a/docs/comparison/index.md
+++ b/docs/comparison/index.md
@@ -64,6 +64,6 @@ PDF Reader MCP exposes that as a compact V3 tool surface:
 ## Boundaries
 
 PDF Reader MCP does not bundle heavy OCR, vision, formula, or layout model
-weights. The default package stays TypeScript-first and local-first; advanced
+weights. The production package is sole-Rust and local-first; advanced
 OCR and visual understanding are enabled through explicit local providers and
 validated through provider benchmarks.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -6,7 +6,7 @@ Twin: text layers, semantic structure, source visuals, region crops, OCR
 provenance, tables, citations, trust signals, accessibility signals, and
 provider-backed visual enrichments linked through stable IDs.
 
-The default package stays TypeScript-first and local-first. Selectable-text
+The production package is **sole-Rust** and local-first. Selectable-text
 PDFs, smart routing, search, rendering, crops, document maps, trust reports,
 accessibility reports, Markdown/HTML/JSON extraction, and safety signals work
 without heavy model downloads. Scanned OCR and visual table/chart/formula/figure

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,21 +1,35 @@
 # Installation
 
-## Published stable (required for production)
+## Published stable
 
-Install from **npm**. Published stable is **TypeScript `@sylphx/pdf-reader-mcp@3.0.14`**.
+Install from **npm**. Current production is **`@sylphx/pdf-reader-mcp@4.0.2`** — a **sole-Rust** MCP server launched by a thin Node entrypoint.
 
-Pure-Rust cutover packages (`3.0.15`–`3.1.1`) are **withdrawn/deprecated**. Do not use them.
+```bash
+npm install -g @sylphx/pdf-reader-mcp
+# or pin
+npm install -g @sylphx/pdf-reader-mcp@4.0.2
+```
+
+npm installs:
+
+1. The thin launcher package
+2. **One** platform native package as an optional dependency (when available)
+
+There is **no** TypeScript PDF runtime in the production package. If the matching native binary is missing, the server **fails closed**.
 
 ## Requirements
 
-- **Node.js >= 22.13.0**
-- The published package runs the TypeScript MCP server at `dist/index.js`
-- Optional OCR / visual providers are opt-in (not required for core text + twin path)
+- **Node.js >= 22.13.0** (launcher only)
+- Supported platform for the native binary:
+  - macOS arm64 / x64
+  - Linux x64 gnu / arm64 gnu
+  - Windows x64
+- Optional OCR / visual providers are opt-in (not required for core text paths)
 
 ## Claude Code
 
 ```bash
-claude mcp add pdf-reader -- npx @sylphx/pdf-reader-mcp@3.0.14
+claude mcp add pdf-reader -- npx @sylphx/pdf-reader-mcp
 ```
 
 ## Claude Desktop
@@ -27,7 +41,7 @@ Add to your `claude_desktop_config.json`:
   "mcpServers": {
     "pdf-reader": {
       "command": "npx",
-      "args": ["@sylphx/pdf-reader-mcp@3.0.14"]
+      "args": ["@sylphx/pdf-reader-mcp"]
     }
   }
 }
@@ -37,42 +51,53 @@ Add to your `claude_desktop_config.json`:
 
 - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+- **Linux**: `~/.config/Claude/claude_desktop_config.json`
 
-## Cursor
+## Cursor / VS Code / other MCP clients
+
+Use the same stdio command shape:
 
 ```json
 {
   "mcpServers": {
     "pdf-reader": {
       "command": "npx",
-      "args": ["@sylphx/pdf-reader-mcp@3.0.14"]
+      "args": ["@sylphx/pdf-reader-mcp"]
     }
   }
 }
 ```
 
-## Other MCP clients
+## Run directly
 
 ```bash
-npx @sylphx/pdf-reader-mcp@3.0.14
+npx @sylphx/pdf-reader-mcp
+# or after global install
+pdf-reader-mcp
 ```
 
-## Experimental pure-Rust (developers only)
-
-Not a production install path. Build from source in this repository:
+HTTP transport:
 
 ```bash
-bun run build:rust
-PDF_READER_ENGINE_MODE=pure-rust ./bin/pdf-reader-mcp
+MCP_TRANSPORT=http pdf-reader-mcp
 ```
 
-Honest capability status: [`docs/specs/pure-rust-capability-matrix.json`](../specs/pure-rust-capability-matrix.json).
+## Platforms
 
-## Optional OCR Provider
+| Platform | Native package |
+| --- | --- |
+| macOS arm64 | `@sylphx/pdf-reader-mcp-darwin-arm64` |
+| macOS x64 | `@sylphx/pdf-reader-mcp-darwin-x64` |
+| Linux x64 | `@sylphx/pdf-reader-mcp-linux-x64-gnu` |
+| Linux arm64 | `@sylphx/pdf-reader-mcp-linux-arm64-gnu` |
+| Windows x64 | `@sylphx/pdf-reader-mcp-win32-x64-msvc` |
 
-`pdf_evidence` operation `ocr_pages` and `read_pdf` OCR fusion are disabled
-until a local OCR command or preset is configured. Set
-`MCP_PDF_OCR_PRESET=tesseract` for the plain-text Tesseract command template,
-or `MCP_PDF_OCR_PRESET=tesseract-tsv` when agents need normalized Tesseract
-word boxes and confidence. You can also set `MCP_PDF_OCR_COMMAND` to the OCR
-executable or wrapper you want the server to run.
+## Historical TypeScript baseline (not production)
+
+Immutable external comparison/recovery pin only:
+
+```bash
+npm install -g @sylphx/pdf-reader-mcp@3.0.14
+```
+
+See [Migration / recovery notes](/migration) for engine history. Do not use withdrawn intermediate cutover packages as production.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,15 +3,15 @@ layout: home
 
 hero:
   name: PDF Reader MCP
-  text: Stop PDF Hallucinations. Prove Every Answer.
-  tagline: "The most-starred PDF MCP server on GitHub. One read_pdf call turns any PDF into an Agent Document Twin — markdown, tables, trust signals, and source evidence with page numbers and bounding boxes. Local-first. Benchmark-gated. Works with Claude, Cursor, VS Code, and any MCP client."
+  text: Give your AI agent eyes for PDFs.
+  tagline: "Turn PDFs into structured text, tables, OCR, visual evidence, and page-level citations — locally, with one MCP server. Plain-text tools make agents guess. PDF Reader MCP gives them evidence."
   image:
     src: /logo.svg
     alt: PDF Reader MCP Logo
   actions:
     - theme: brand
-      text: Get Started in 30s
-      link: /guide/getting-started
+      text: Install in 30s
+      link: /guide/installation
     - theme: alt
       text: Star on GitHub
       link: https://github.com/SylphxAI/pdf-reader-mcp
@@ -21,46 +21,33 @@ hero:
     - theme: alt
       text: Benchmark Proof
       link: /benchmark
-      
 
 features:
+  - icon: "\U0001F441\uFE0F"
+    title: Evidence, not text dumps
+    details: Page numbers, bounding boxes, table cells, and provenance so agents can cite instead of invent.
+  - icon: "\U0001F4CA"
+    title: Tables agents can trust
+    details: Rows, cells, geometry, and confidence for financial reports and structured PDFs.
+  - icon: "\U0001F50E"
+    title: Search then verify
+    details: Find snippets with page context before deep reading, cropping, or citing.
   - icon: "\U0001F4C4"
     title: Agent Document Twin
-    details: Return one linked document map with pages, elements, text-layer coverage, chunks, layout diagnostics, trust routing, accessibility routing, visual routing, OCR evidence, and page geometry.
-  - icon: "\U0001F50E"
-    title: Evidence-First Search
-    details: Locate literal text matches with snippets, match offsets, character-derived, text-item, or opt-in OCR-word boxes, and provenance before reading, rendering, cropping, or citing.
-  - icon: "\u26A1"
-    title: Performance-Bounded Local Execution
-    details: Built on pdfjs-dist with concurrent processing, bounded rendering, page limits, pixel budgets, package smoke checks, and reproducible benchmark artifacts.
-  - icon: "\U0001F50C"
-    title: V3 Smart Tool Surface
-    details: Start with read_pdf for automatic Agent Document Twin extraction, use search_pdf for cheap literal evidence, and use pdf_evidence for focused inspect, render, crop, OCR, or visual-analysis operations.
+    details: One linked document map — structure, chunks, layout, trust and accessibility routing when requested.
   - icon: "\U0001F5BC\uFE0F"
-    title: Visual Evidence and Crops
-    details: Render source pages and crop PDF-coordinate regions into bounded image evidence for tables, figures, charts, formulas, annotations, and citations.
-  - icon: "\U0001F9FE"
-    title: Text Layer Fidelity
-    details: Expose direction-aware run, line, word, and character records with page-level ranges, estimated bounding boxes, provenance, and metadata coverage diagnostics for citation and extraction workflows.
-  - icon: "\U0001F5BC\uFE0F"
-    title: Visual Provider Enrichment
-    details: Normalize table, formula, chart, figure, diagram, and image-description evidence from configured command, HTTP, Ollama, OpenAI-compatible, LM Studio, or llama.cpp providers.
-  - icon: "\U0001F50D"
-    title: Table Intelligence
-    details: Extract selectable-text and OCR-derived tables with rows, cells, geometry, confidence, quality metrics, inferred spans, warnings, and continuation candidates.
+    title: Visual evidence
+    details: Render pages and crop regions for tables, figures, charts, and citations.
   - icon: "\U0001F524"
-    title: Scanned PDF OCR Path
-    details: Route selected rendered pages through configured OCR providers, keep OCR separate from selectable text, and link OCR words and tables back to source-render evidence.
-  - icon: "\U0001F9ED"
-    title: Semantic AST and Layout Confidence
-    details: Traverse sections, paragraphs, lists, captions, tables, images, charts, formulas, and figures while preserving reading-order diagnostics and caption-to-evidence links.
+    title: Scanned PDF OCR path
+    details: Route selected pages through configured OCR providers and keep OCR separate from selectable text.
   - icon: "\U0001F6E1\uFE0F"
-    title: Trust Report
-    details: Surface deterministic prompt-injection, hidden-text, tiny/off-page, overlapping, visual-spoofing, unsafe-link, layout, table-quality, redaction, and page-risk signals.
-  - icon: "\u267F"
-    title: Accessibility Report
-    details: Summarize tagged-PDF coverage, tag-to-visible-content coverage, structure trees, headings, image alt-text verifiability, form labels, link labels, accessibility permissions, issue types, severities, page grades, and document-map routing without claiming PDF/UA certification.
-  - icon: "\U0001F9EA"
-    title: Benchmark-Gated Releases
-    details: Release evidence includes performance, deterministic quality, corpus, installed-provider, provider-manifest crop/scoring, package-smoke, and SOTA release-gate artifacts.
+    title: Trust signals
+    details: Surface hidden-text, prompt-injection, overlapping, and related risk signals when requested.
+  - icon: "\u26A1"
+    title: Native local engine
+    details: Sole-Rust production on five platforms via a thin Node launcher. Clean install. Fail closed if the native binary is missing.
+  - icon: "\U0001F50C"
+    title: Three tools, one surface
+    details: read_pdf for smart extraction, search_pdf for cheap evidence, pdf_evidence for focused inspect/render/crop/OCR ops.
 ---

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,5 +1,7 @@
 # Migration and recovery notes
 
+This page is **secondary engineering history**. Product install docs live on the README and Installation guide.
+
 This page holds historical engine-transition details. The main product page is the repository [README](https://github.com/SylphxAI/pdf-reader-mcp#readme) / docs [home](/).
 
 ## Current production

--- a/docs/performance/why-rust.md
+++ b/docs/performance/why-rust.md
@@ -1,39 +1,53 @@
 ---
 layout: doc
-title: Why pure Rust + open gaps
+title: Why a native Rust engine
 ---
 
-# Why pure Rust + open gaps
+# Why a native Rust engine
 
+> **Product status:** `@sylphx/pdf-reader-mcp@4.0.2` is **sole-Rust production** on supported platforms (thin Node launcher + one platform native binary).  
+> Users should not need to “opt in” to Rust. Missing natives fail closed.  
+> Engineering residual catalogs below are **maintainer history**, not the product pitch.
+
+## User-facing reason
+
+PDF Reader MCP is a public MCP that agents call heavily. The right product is **one local engine** that returns evidence — not a migration story.
+
+Native Rust is a **second-layer proof point**:
+
+- Local-first execution
+- Five supported platforms
+- Clean install (empty production npm dependency graph)
+- Fail-closed behavior when the platform binary is absent
+
+Primary product promise remains:
+
+> Give your AI agent eyes for PDFs.
+
+See the [README](https://github.com/SylphxAI/pdf-reader-mcp#readme) and [installation guide](/guide/installation).
 
 ## Capability-first admission (ADR-0005)
 
-As of 2026-07-22, pure-Rust admission is **capability-first semantic
-compatibility**, not whole-product exact PDF.js output parity.
+Pure-Rust admission is **capability-first semantic compatibility**, not whole-product exact PDF.js output parity.
 
 - Interface/schema/transport/error contracts remain exact.
-- Semantic capability equivalence and calibrated agent-task quality are the
-  release standards.
-- Frozen TS v3.0.14 differential families below remain valuable regression and
-  coverage evidence.
-- Do **not** expand exact residual families for representation-only PDF.js
-  quirks unless classified as contract break, semantic regression, or
-  security/resource fail-closed gap.
-- `dropInFor3014=false` and publish freeze remain until the ADR-0005 bar is met.
+- Semantic capability equivalence and calibrated agent-task quality are the release standards.
+- Frozen TS v3.0.14 differentials remain valuable regression/coverage evidence.
+- Exact residual families expand only for contract breaks, semantic regressions, or security/resource fail-closed gaps.
 
 See `docs/adr/0005-capability-first-semantic-compatibility.md` and
 `docs/specs/capability-first-admission-contract.md`.
 
-Executable scaffolds now live under `docs/specs/semantic-contracts/` and
-`docs/specs/agent-task-corpus/`, with `bun run check:semantic-contracts`,
-`bun run check:agent-task-corpus`, and `bun run test:agent-task-smoke`.
+## Engineering archive
 
+The sections after this banner preserve historical residual notes and migration
+context for maintainers. They are **not** acquisition copy. Live product install
+truth is sole-Rust 4.0.2 — see [migration notes](/migration).
 
-> **Status:** pure-Rust fail-closed default at `@sylphx/pdf-reader-mcp@3.2.1` (capability-first; explicit TypeScript rollback only).
-> TypeScript production default is retired; TypeScript remains fallback-only.
+---
 
+## Historical product decision notes
 
-## The product decision
 
 `@sylphx/pdf-reader-mcp` is a **starred public MCP**. Agents call it thousands of
 times. The right end state is not “half TypeScript, half Rust, please wait while
@@ -154,278 +168,278 @@ paths fail closed; this is not TS 3.0.14 parity.
 
 ## Install
 
-Production: pin `@sylphx/pdf-reader-mcp@3.2.1` (pure-Rust fail-closed default; explicit TypeScript rollback only).  
+Production: pin `@sylphx/pdf-reader-mcp@4.0.2` (pure-Rust fail-closed default; explicit TypeScript rollback only).  
 See [installation guide](../guide/installation.md). Pure-Rust remains experimental source-only.
 
 ### Configured-command visual enrichment fusion (bounded)
 
-A frozen five-case configured-command `read_pdf` visual-enrichment payload and Document Map fusion subset is admitted through the exact-SHA differential harness. It covers direct table fusion, page sort/dedup/invalid + max-one admission, ordered two-caption analyses, fail-closed second-provider failure, and ready/no-candidate zero invocation. Pure-Rust also implements analyze_regions HTTP URL and ollama/openai-compatible/lmstudio/llamacpp presets with local mock proof. `include_visual_enrichments` remains `PARTIAL` while public remote-provider fidelity and whole-product parity stay unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen five-case configured-command `read_pdf` visual-enrichment payload and Document Map fusion subset is admitted through the exact-SHA differential harness. It covers direct table fusion, page sort/dedup/invalid + max-one admission, ordered two-caption analyses, fail-closed second-provider failure, and ready/no-candidate zero invocation. Pure-Rust also implements analyze_regions HTTP URL and ollama/openai-compatible/lmstudio/llamacpp presets with local mock proof. `include_visual_enrichments` remains `PARTIAL` while public remote-provider fidelity and whole-product parity stay unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### Document AST visual enrichment fusion (bounded)
 
-A frozen five-case configured-command `read_pdf` visual-enrichment Document AST fusion subset is admitted through the exact-SHA differential harness. Direct table attachment, caption-derived orphan figure/chart nodes, fail-closed provider failure, and ready/no-candidate zero invocation are proven. `include_document_ast` and `include_visual_enrichments` remain `PARTIAL`; `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen five-case configured-command `read_pdf` visual-enrichment Document AST fusion subset is admitted through the exact-SHA differential harness. Direct table attachment, caption-derived orphan figure/chart nodes, fail-closed provider failure, and ready/no-candidate zero invocation are proven. `include_document_ast` and `include_visual_enrichments` remain `PARTIAL`; Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf include_ocr_text_layer public-stdio fusion (bounded)
 
-A frozen six-case public-stdio `read_pdf` `include_ocr_text_layer` subset is admitted through the exact-SHA differential harness. It covers opt-out, page-1 success with Document Map OCR fields, page-3 multiword boxes, invalid page-selection warning with page-1 OCR retained, provider-failure soft warning without layer, and not-configured soft warning without layer. Leaf-mutation count is frozen at 143 with relocated fixture-root replay. `include_ocr_text_layer` remains `PARTIAL`; tesseract-tsv, text-only fallback, selectable/OCR table continuation, URL single-fetch, first-five-of-six page boundary, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen six-case public-stdio `read_pdf` `include_ocr_text_layer` subset is admitted through the exact-SHA differential harness. It covers opt-out, page-1 success with Document Map OCR fields, page-3 multiword boxes, invalid page-selection warning with page-1 OCR retained, provider-failure soft warning without layer, and not-configured soft warning without layer. Leaf-mutation count is frozen at 143 with relocated fixture-root replay. `include_ocr_text_layer` remains `PARTIAL`; tesseract-tsv, text-only fallback, selectable/OCR table continuation, URL single-fetch, first-five-of-six page boundary, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf OCR residual public-stdio subset (bounded)
 
-A frozen three-case public-stdio residual for `read_pdf` `include_ocr_text_layer` is admitted: plain-text provider stdout without words, JSON text-only without words, and default `max_pages` first-five-of-six truncation with exact warning and five applied OCR pages. Leaf-mutation count is frozen at 154 with relocated fixture-root replay. Document Map `needs_ocr_pages` remains layout-derived and is not overwritten by OCR candidates. `include_ocr_text_layer` remains `PARTIAL`; tesseract-tsv, selectable/OCR table continuation, URL single-fetch, mixed interleaving, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio residual for `read_pdf` `include_ocr_text_layer` is admitted: plain-text provider stdout without words, JSON text-only without words, and default `max_pages` first-five-of-six truncation with exact warning and five applied OCR pages. Leaf-mutation count is frozen at 154 with relocated fixture-root replay. Document Map `needs_ocr_pages` remains layout-derived and is not overwritten by OCR candidates. `include_ocr_text_layer` remains `PARTIAL`; tesseract-tsv, selectable/OCR table continuation, URL single-fetch, mixed interleaving, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf tesseract-tsv public-stdio subset (bounded)
 
-A frozen two-case public-stdio `MCP_PDF_OCR_PRESET=tesseract-tsv` subset is admitted: valid TSV level-5 words with image-to-PDF box conversion, and malformed TSV soft raw fallback with exact warning. Leaf-mutation count is frozen at 66. Real tesseract binary health checks remain unclaimed. `include_ocr_text_layer` remains `PARTIAL`; `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `MCP_PDF_OCR_PRESET=tesseract-tsv` subset is admitted: valid TSV level-5 words with image-to-PDF box conversion, and malformed TSV soft raw fallback with exact warning. Leaf-mutation count is frozen at 66. Real tesseract binary health checks remain unclaimed. `include_ocr_text_layer` remains `PARTIAL`; Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### mixed selectable/OCR table merge public-stdio subset (bounded)
 
-A frozen three-case public-stdio mixed selectable/OCR table merge subset is admitted: distinct non-overlapping OCR tables are reindexed after selectable tables, overlapping OCR tables are suppressed at the 0.6 IoU duplicate threshold, and OCR-only pages without selectable tables still project table_info. Leaf-mutation count is frozen at 76. `include_tables` and `include_ocr_text_layer` remain `PARTIAL`; `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio mixed selectable/OCR table merge subset is admitted: distinct non-overlapping OCR tables are reindexed after selectable tables, overlapping OCR tables are suppressed at the 0.6 IoU duplicate threshold, and OCR-only pages without selectable tables still project table_info. Leaf-mutation count is frozen at 76. `include_tables` and `include_ocr_text_layer` remain `PARTIAL`; Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### OCR-search residual public-stdio subset (bounded)
 
-A frozen four-case public-stdio residual for `search_pdf` `include_ocr_text_layer` is admitted: plain-text OCR fallback without match geometry, JSON text-only without words/geometry, words control with `ocr_word` geometry, and `max_pages` first-five-of-six truncation with exact warning. Leaf-mutation count is frozen at 133. `include_ocr_text_layer` remains `PARTIAL`; selectable/OCR interleaving and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen four-case public-stdio residual for `search_pdf` `include_ocr_text_layer` is admitted: plain-text OCR fallback without match geometry, JSON text-only without words/geometry, words control with `ocr_word` geometry, and `max_pages` first-five-of-six truncation with exact warning. Leaf-mutation count is frozen at 133. `include_ocr_text_layer` remains `PARTIAL`; selectable/OCR interleaving and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### selectable/OCR search interleaving public-stdio subset (bounded)
 
-A frozen four-case public-stdio selectable/OCR search interleaving subset is admitted: selectable matches append before OCR matches, exact `max_matches` admits one OCR match, a full selectable cap skips OCR without a truncation flag, and unique OCR-only tokens append as sole matches. Leaf-mutation count is frozen at 149. `include_ocr_text_layer` remains `PARTIAL`; `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen four-case public-stdio selectable/OCR search interleaving subset is admitted: selectable matches append before OCR matches, exact `max_matches` admits one OCR match, a full selectable cap skips OCR without a truncation flag, and unique OCR-only tokens append as sole matches. Leaf-mutation count is frozen at 149. `include_ocr_text_layer` remains `PARTIAL`; Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### URL source single-fetch public-stdio subset (bounded)
 
-A frozen two-case public-stdio URL source single-fetch subset is admitted for `read_pdf` over a local fixture HTTP server with `MCP_PDF_ALLOW_PRIVATE_IPS=true`: no-OCR single fetch and OCR-with-document-map single fetch that reuses materialized bytes. Leaf-mutation count is frozen at 16 with relocated fixture-root replay. `url_ssrf` remains `PARTIAL`; `search_pdf` URL+OCR single-fetch (TS double-fetch residual), resolver timeout, TLS-SNI fixtures, public-internet fetch, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio URL source single-fetch subset is admitted for `read_pdf` over a local fixture HTTP server with `MCP_PDF_ALLOW_PRIVATE_IPS=true`: no-OCR single fetch and OCR-with-document-map single fetch that reuses materialized bytes. Leaf-mutation count is frozen at 16 with relocated fixture-root replay. `url_ssrf` remains `PARTIAL`; `search_pdf` URL+OCR single-fetch (TS double-fetch residual), resolver timeout, TLS-SNI fixtures, public-internet fetch, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### search_pdf prefer_speed route (post-3.0.14 surface)
 
-Pure-Rust `search_pdf` now accepts `prefer_speed` and, when OCR is off, matches the current TypeScript speed route: match geometry is omitted, provenance uses `rust-text-index`/`text-content`, and the speed-route warning is emitted. This is a current-surface parity fix, not a frozen detached TS v3.0.14 differential claim. `prefer_speed` remains `PARTIAL` in the capability matrix; `dropInFor3014` stays false and publish freeze remains enabled.
+Pure-Rust `search_pdf` now accepts `prefer_speed` and, when OCR is off, matches the current TypeScript speed route: match geometry is omitted, provenance uses `rust-text-index`/`text-content`, and the speed-route warning is emitted. This is a current-surface parity fix, not a frozen detached TS v3.0.14 differential claim. `prefer_speed` remains `PARTIAL` in the capability matrix; Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### search_pdf multiword selectable geometry residual (bounded)
 
-A frozen three-case public-stdio `search_pdf` multiword selectable-text geometry residual is admitted over `v3014-behavior-v1.pdf`: start-item multiword box union, mid-line multiword union, and case-insensitive multiword, all at `char_estimated` level with float-normalized boxes. Leaf-mutation count is frozen at 48 with relocated fixture-root replay. `bounding_box` remains `PARTIAL`; glyph-perfect boxes, RTL/vertical writing, OCR fusion, prefer_speed, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `search_pdf` multiword selectable-text geometry residual is admitted over `v3014-behavior-v1.pdf`: start-item multiword box union, mid-line multiword union, and case-insensitive multiword, all at `char_estimated` level with float-normalized boxes. Leaf-mutation count is frozen at 48 with relocated fixture-root replay. `bounding_box` remains `PARTIAL`; glyph-perfect boxes, RTL/vertical writing, OCR fusion, prefer_speed, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf form residual public-stdio subset (bounded)
 
-A frozen two-case public-stdio `read_pdf` `include_form_fields` residual is admitted: radiobutton/pushbutton/signature kinds (signature omits box and editable), and pdf.js-compatible value coercion for numeric text, missing text defaults, bool button checkbox Off, and choice array first-string selection. Leaf-mutation count is frozen at 90 with relocated fixture-root replay. `include_form_fields` remains `PARTIAL`; radio group kids, broader button-array coercion, malformed-field breadth, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_form_fields` residual is admitted: radiobutton/pushbutton/signature kinds (signature omits box and editable), and pdf.js-compatible value coercion for numeric text, missing text defaults, bool button checkbox Off, and choice array first-string selection. Leaf-mutation count is frozen at 90 with relocated fixture-root replay. `include_form_fields` remains `PARTIAL`; radio group kids, broader button-array coercion, malformed-field breadth, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf form radio-group residual (bounded)
 
-A frozen two-case public-stdio `read_pdf` `include_form_fields` radio-group residual is admitted: parent stub plus radiobutton kids inheriting `V` (with sibling checkbox control), and a three-option radio group inheriting value `Silver` and default `Bronze`. Leaf-mutation count is frozen at 78 with relocated fixture-root replay. `include_form_fields` remains `PARTIAL`; broader button-array coercion, malformed-field breadth, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_form_fields` radio-group residual is admitted: parent stub plus radiobutton kids inheriting `V` (with sibling checkbox control), and a three-option radio group inheriting value `Silver` and default `Bronze`. Leaf-mutation count is frozen at 78 with relocated fixture-root replay. `include_form_fields` remains `PARTIAL`; broader button-array coercion, malformed-field breadth, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf attachment residual public-stdio subset (bounded)
 
-A frozen two-case public-stdio `read_pdf` `include_attachments` residual is admitted: EmbeddedFiles name-tree `Kids` win over sibling `Names`, trailing-slash `UF` becomes `unnamed`, and Windows-path `UF` basenames. Leaf-mutation count is frozen at 17 with relocated fixture-root replay. `include_attachments` remains `PARTIAL`; malformed name-tree breadth, duplicate-kids fail-closed, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_attachments` residual is admitted: EmbeddedFiles name-tree `Kids` win over sibling `Names`, trailing-slash `UF` becomes `unnamed`, and Windows-path `UF` basenames. Leaf-mutation count is frozen at 17 with relocated fixture-root replay. `include_attachments` remains `PARTIAL`; malformed name-tree breadth, duplicate-kids fail-closed, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf mark_info residual public-stdio subset (bounded)
 
-A frozen three-case public-stdio catalog `mark_info` residual is admitted: non-boolean `Suspects` defaults to false with missing `UserProperties` false, all-true MarkInfo, and empty MarkInfo all-false. Leaf-mutation count is frozen at 30 with relocated fixture-root replay. Catalog surfaces remain `PARTIAL`; permissions encryption, outline beyond behavior, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio catalog `mark_info` residual is admitted: non-boolean `Suspects` defaults to false with missing `UserProperties` false, all-true MarkInfo, and empty MarkInfo all-false. Leaf-mutation count is frozen at 30 with relocated fixture-root replay. Catalog surfaces remain `PARTIAL`; permissions encryption, outline beyond behavior, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf form parent/child residual (bounded)
 
-A frozen two-case public-stdio `include_form_fields` parent/child residual is admitted: skip top-level and Kids direct dicts with parent stub plus dotted spaced child name and DV-as-value, and readonly parent `Ff` inheritance making child non-editable. Leaf-mutation count is frozen at 34 with relocated fixture-root replay. `include_form_fields` remains `PARTIAL`; malformed-field breadth, broader button-array coercion, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `include_form_fields` parent/child residual is admitted: skip top-level and Kids direct dicts with parent stub plus dotted spaced child name and DV-as-value, and readonly parent `Ff` inheritance making child non-editable. Leaf-mutation count is frozen at 34 with relocated fixture-root replay. `include_form_fields` remains `PARTIAL`; malformed-field breadth, broader button-array coercion, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf annotation residual public-stdio subset (bounded)
 
-A frozen two-case public-stdio `read_pdf` `include_annotations` residual is admitted: FreeText and Link URI keep full `/Rect` boxes including multi-page FreeText, while Text sticky notes claim contents/title only without bounding boxes (pdf.js icon-box geometry remains unclaimed). Leaf-mutation count is frozen at 44 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; dest-only Link page-ref shape, glyph-perfect boxes, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_annotations` residual is admitted: FreeText and Link URI keep full `/Rect` boxes including multi-page FreeText, while Text sticky notes claim contents/title only without bounding boxes (pdf.js icon-box geometry remains unclaimed). Leaf-mutation count is frozen at 44 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; dest-only Link page-ref shape, glyph-perfect boxes, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf annotation dest residual public-stdio subset (bounded)
 
-A frozen two-case public-stdio `read_pdf` `include_annotations` dest residual is admitted: dest-only Link keeps pdf.js page-ref `{num,gen}` plus name token `{name}` for `/Fit` and `/XYZ` coordinate destinations with full `/Rect` boxes. Leaf-mutation count is frozen at 33 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; named dest string lookup, GoTo action dest, Text icon/box geometry, glyph-perfect boxes, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_annotations` dest residual is admitted: dest-only Link keeps pdf.js page-ref `{num,gen}` plus name token `{name}` for `/Fit` and `/XYZ` coordinate destinations with full `/Rect` boxes. Leaf-mutation count is frozen at 33 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; named dest string lookup, GoTo action dest, Text icon/box geometry, glyph-perfect boxes, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf annotation action/named dest residual public-stdio subset (bounded)
 
-A frozen two-case public-stdio `read_pdf` `include_annotations` action/named dest residual is admitted: named `/Dest` string is preserved, and GoTo action `/D` is exposed as pdf.js `dest` with page-ref `{num,gen}`, name token `FitH`, and coordinate, with full `/Rect` boxes. Leaf-mutation count is frozen at 29 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; named dest resolution to array, remote GoToR, URI action beyond url, Text icon/box geometry, glyph-perfect boxes, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_annotations` action/named dest residual is admitted: named `/Dest` string is preserved, and GoTo action `/D` is exposed as pdf.js `dest` with page-ref `{num,gen}`, name token `FitH`, and coordinate, with full `/Rect` boxes. Leaf-mutation count is frozen at 29 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; named dest resolution to array, remote GoToR, URI action beyond url, Text icon/box geometry, glyph-perfect boxes, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf annotation action-precedence residual public-stdio subset (bounded)
 
-A frozen three-case public-stdio `read_pdf` `include_annotations` action-precedence residual is admitted: GoTo action dest wins over explicit `/Dest` (`FitH` + coordinate), URI action exposes `url` and suppresses `/Dest`, and Launch file maps to `url` with no dest, all with full `/Rect` boxes. Leaf-mutation count is frozen at 42 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; named dest resolution to array, remote GoToR, Launch file-dict variants, Text icon/box geometry, glyph-perfect boxes, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_annotations` action-precedence residual is admitted: GoTo action dest wins over explicit `/Dest` (`FitH` + coordinate), URI action exposes `url` and suppresses `/Dest`, and Launch file maps to `url` with no dest, all with full `/Rect` boxes. Leaf-mutation count is frozen at 42 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; named dest resolution to array, remote GoToR, Launch file-dict variants, Text icon/box geometry, glyph-perfect boxes, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf info flags residual public-stdio subset (bounded)
 
-A frozen two-case public-stdio `read_pdf` `include_metadata` info residual is admitted: pdf.js info flags (`Language`, `EncryptFilterName`, `IsLinearized`, `IsAcroFormPresent`, `IsXFAPresent`, `IsCollectionPresent`, `IsSignaturesPresent`) plus document info fields for AcroForm+Lang and plain catalogs. Leaf-mutation count is frozen at 33 with relocated fixture-root replay. `include_metadata` remains `PARTIAL`; XMP metadata payload, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_metadata` info residual is admitted: pdf.js info flags (`Language`, `EncryptFilterName`, `IsLinearized`, `IsAcroFormPresent`, `IsXFAPresent`, `IsCollectionPresent`, `IsSignaturesPresent`) plus document info fields for AcroForm+Lang and plain catalogs. Leaf-mutation count is frozen at 33 with relocated fixture-root replay. `include_metadata` remains `PARTIAL`; XMP metadata payload, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf page_geometry residual public-stdio subset (bounded)
 
-A frozen three-case public-stdio `read_pdf` `include_page_geometry` residual is admitted: Rotate+UserUnit+CropBox dimensions, default MediaBox identity geometry, and inverted MediaBox normalization with `view_box`. Leaf-mutation count is frozen at 39 with relocated fixture-root replay. `include_page_geometry` remains `PARTIAL`; Bleed/Trim/Art boxes, non-right-angle rotation, inherited MediaBox breadth, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_page_geometry` residual is admitted: Rotate+UserUnit+CropBox dimensions, default MediaBox identity geometry, and inverted MediaBox normalization with `view_box`. Leaf-mutation count is frozen at 39 with relocated fixture-root replay. `include_page_geometry` remains `PARTIAL`; Bleed/Trim/Art boxes, non-right-angle rotation, inherited MediaBox breadth, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 
 ### read_pdf include_page_geometry inheritance residual (frozen TS v3.0.14)
 
-A frozen three-case public-stdio `read_pdf` `include_page_geometry` inheritance residual is admitted: pdf.js inherits `MediaBox`/`Rotate` from `Pages`, intersects page `CropBox` with inherited `MediaBox` for `view_box`, and normalizes negative right-angle `Rotate` (`-90` → `270`) with width/height swap. Leaf-mutation count is frozen at 39 with relocated fixture-root replay. Bleed/Trim/Art boxes, non-right-angle rotation beyond clamp, deeper Pages inheritance breadth, and whole-product parity remain unclaimed; `include_page_geometry` remains `PARTIAL`. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_page_geometry` inheritance residual is admitted: pdf.js inherits `MediaBox`/`Rotate` from `Pages`, intersects page `CropBox` with inherited `MediaBox` for `view_box`, and normalizes negative right-angle `Rotate` (`-90` → `270`) with width/height swap. Leaf-mutation count is frozen at 39 with relocated fixture-root replay. Bleed/Trim/Art boxes, non-right-angle rotation beyond clamp, deeper Pages inheritance breadth, and whole-product parity remain unclaimed; `include_page_geometry` remains `PARTIAL`. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf include_page_geometry depth-clamp residual (frozen TS v3.0.14)
 
-A frozen three-case public-stdio `read_pdf` `include_page_geometry` depth-clamp residual is admitted: pdf.js deeper Pages `MediaBox`/`CropBox` inheritance across an intermediate Pages node, non-right-angle `Rotate` `45` clamps to `0`, and partial `MediaBox`/`CropBox` intersection projects the clipped `view_box`. Leaf-mutation count is frozen at 39 with relocated fixture-root replay. Bleed/Trim/Art boxes, UserUnit Pages inheritance, multi-page geometry breadth, and whole-product parity remain unclaimed; `include_page_geometry` remains `PARTIAL`. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_page_geometry` depth-clamp residual is admitted: pdf.js deeper Pages `MediaBox`/`CropBox` inheritance across an intermediate Pages node, non-right-angle `Rotate` `45` clamps to `0`, and partial `MediaBox`/`CropBox` intersection projects the clipped `view_box`. Leaf-mutation count is frozen at 39 with relocated fixture-root replay. Bleed/Trim/Art boxes, UserUnit Pages inheritance, multi-page geometry breadth, and whole-product parity remain unclaimed; `include_page_geometry` remains `PARTIAL`. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf include_page_geometry userunit-multipage residual (frozen TS v3.0.14)
 
-A frozen three-case public-stdio `read_pdf` `include_page_geometry` userunit-multipage residual is admitted: pdf.js does not inherit Pages `UserUnit` onto page geometry, multi-page selected geometry projects per-page `MediaBox`/`Rotate` (including 90-degree width/height swap), and Bleed/Trim/Art boxes do not replace `MediaBox` `view_box`. Leaf-mutation count is frozen at 48 with relocated fixture-root replay. Bleed/Trim/Art as alternate view source, page-level UserUnit override breadth beyond the frozen fixtures, large multi-page breadth, and whole-product parity remain unclaimed; `include_page_geometry` remains `PARTIAL`. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_page_geometry` userunit-multipage residual is admitted: pdf.js does not inherit Pages `UserUnit` onto page geometry, multi-page selected geometry projects per-page `MediaBox`/`Rotate` (including 90-degree width/height swap), and Bleed/Trim/Art boxes do not replace `MediaBox` `view_box`. Leaf-mutation count is frozen at 48 with relocated fixture-root replay. Bleed/Trim/Art as alternate view source, page-level UserUnit override breadth beyond the frozen fixtures, large multi-page breadth, and whole-product parity remain unclaimed; `include_page_geometry` remains `PARTIAL`. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### read_pdf page_labels residual public-stdio subset (bounded)
 
-A frozen three-case public-stdio `read_pdf` `include_page_labels` residual is admitted: multi-style PageLabels (prefix roman, decimal start, alpha), prefix+start decimal sequence, and absent labels omitted. Leaf-mutation count is frozen at 17 with relocated fixture-root replay. `include_page_labels` remains `PARTIAL`; number-tree Kids breadth, hostile label overflow, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_page_labels` residual is admitted: multi-style PageLabels (prefix roman, decimal start, alpha), prefix+start decimal sequence, and absent labels omitted. Leaf-mutation count is frozen at 17 with relocated fixture-root replay. `include_page_labels` remains `PARTIAL`; number-tree Kids breadth, hostile label overflow, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf outline residual public-stdio subset (bounded)
 
-A frozen three-case public-stdio `read_pdf` `include_outline` residual is admitted: URI outline with bold/italic/color and child Fit dest (`dest` null on URI parent), FitH dest with coordinate, and absent outline omitted. Leaf-mutation count is frozen at 39 with relocated fixture-root replay. `include_outline` remains `PARTIAL`; outline cycle suppression beyond behavior, named dest string lookup, remote GoToR, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_outline` residual is admitted: URI outline with bold/italic/color and child Fit dest (`dest` null on URI parent), FitH dest with coordinate, and absent outline omitted. Leaf-mutation count is frozen at 39 with relocated fixture-root replay. `include_outline` remains `PARTIAL`; outline cycle suppression beyond behavior, named dest string lookup, remote GoToR, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf permissions residual public-stdio subset (bounded)
 
-A frozen four-case public-stdio `read_pdf` `include_permissions` residual is admitted: empty-user-password encrypted PDFs expose pdf.js permission labels for print/copy/fill/a11y, modify/annotate/assemble, and print+print_high_quality; unencrypted PDFs omit permissions. Leaf-mutation count is frozen at 25 with relocated fixture-root replay. `include_permissions` remains `PARTIAL`; non-empty user password, owner-only unlock, unknown permission bits, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen four-case public-stdio `read_pdf` `include_permissions` residual is admitted: empty-user-password encrypted PDFs expose pdf.js permission labels for print/copy/fill/a11y, modify/annotate/assemble, and print+print_high_quality; unencrypted PDFs omit permissions. Leaf-mutation count is frozen at 25 with relocated fixture-root replay. `include_permissions` remains `PARTIAL`; non-empty user password, owner-only unlock, unknown permission bits, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf metadata presence residual public-stdio subset (bounded)
 
-A frozen two-case public-stdio `read_pdf` `include_metadata` presence residual is admitted: catalog without `/Metadata` omits `data.metadata`; catalog with `/Metadata` stream emits an empty metadata object matching pdfjs-dist Node presence (no synthetic info wrapper). Leaf-mutation count is frozen at 12 with relocated fixture-root replay. `include_metadata` remains `PARTIAL`; XMP key/value parsing, rich getAll payloads, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_metadata` presence residual is admitted: catalog without `/Metadata` omits `data.metadata`; catalog with `/Metadata` stream emits an empty metadata object matching pdfjs-dist Node presence (no synthetic info wrapper). Leaf-mutation count is frozen at 12 with relocated fixture-root replay. `include_metadata` remains `PARTIAL`; XMP key/value parsing, rich getAll payloads, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### read_pdf include_metadata info-extras residual (frozen TS v3.0.14)
 
-A frozen two-case public-stdio `read_pdf` `include_metadata` info-extras residual is admitted: `data.info` key sets match pdf.js `getMetadata().info` with no rust-only extras (`text_chars`, nested `route`, nested `num_pages`) for AcroForm+Lang and plain catalogs, while top-level `num_pages` remains separate. Leaf-mutation count is frozen at 60 with relocated fixture-root replay. `include_metadata` remains `PARTIAL`; XMP key/value parsing, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_metadata` info-extras residual is admitted: `data.info` key sets match pdf.js `getMetadata().info` with no rust-only extras (`text_chars`, nested `route`, nested `num_pages`) for AcroForm+Lang and plain catalogs, while top-level `num_pages` remains separate. Leaf-mutation count is frozen at 60 with relocated fixture-root replay. `include_metadata` remains `PARTIAL`; XMP key/value parsing, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf include_metadata info trapped-custom residual (frozen TS v3.0.14)
 
-A frozen three-case public-stdio `read_pdf` `include_metadata` info trapped-custom residual is admitted: pdf.js `getMetadata().info` projects `Trapped` Name as `{name}` and non-standard Info keys under `Custom` (string/number/boolean/Name). Leaf-mutation count is frozen at 48 with relocated fixture-root replay. XMP key/value parsing, keywords array coercion, info beyond Trapped/Custom breadth, and whole-product parity remain unclaimed; `include_metadata` remains `PARTIAL`. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_metadata` info trapped-custom residual is admitted: pdf.js `getMetadata().info` projects `Trapped` Name as `{name}` and non-standard Info keys under `Custom` (string/number/boolean/Name). Leaf-mutation count is frozen at 48 with relocated fixture-root replay. XMP key/value parsing, keywords array coercion, info beyond Trapped/Custom breadth, and whole-product parity remain unclaimed; `include_metadata` remains `PARTIAL`. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### read_pdf include_metadata encrypt-filter residual (frozen TS v3.0.14)
 
-A frozen two-case public-stdio `read_pdf` `include_metadata` encrypt-filter residual is admitted: empty-user-password Standard-encrypted PDFs expose `EncryptFilterName=Standard`, and unencrypted PDFs keep `EncryptFilterName` null, matching pdf.js `getMetadata().info`. Leaf-mutation count is frozen at 18 with relocated fixture-root replay. `include_metadata` remains `PARTIAL`; non-Standard security handlers, non-empty user password, linearized-true, signatures-true, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_metadata` encrypt-filter residual is admitted: empty-user-password Standard-encrypted PDFs expose `EncryptFilterName=Standard`, and unencrypted PDFs keep `EncryptFilterName` null, matching pdf.js `getMetadata().info`. Leaf-mutation count is frozen at 18 with relocated fixture-root replay. `include_metadata` remains `PARTIAL`; non-Standard security handlers, non-empty user password, linearized-true, signatures-true, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### read_pdf include_metadata linearized residual (frozen TS v3.0.14)
 
-A frozen three-case public-stdio `read_pdf` `include_metadata` linearized residual is admitted: pdf.js `IsLinearized` matches `Linearization.create` over exact source bytes — valid first-object linearization dictionaries are true; spurious `Linearized` dictionaries (bad `L`/`H`) and absent linearization are false. Leaf-mutation count is frozen at 27 with relocated fixture-root replay. `include_metadata` remains `PARTIAL`; four-entry hint arrays, pageFirst optional variants, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_metadata` linearized residual is admitted: pdf.js `IsLinearized` matches `Linearization.create` over exact source bytes — valid first-object linearization dictionaries are true; spurious `Linearized` dictionaries (bad `L`/`H`) and absent linearization are false. Leaf-mutation count is frozen at 27 with relocated fixture-root replay. `include_metadata` remains `PARTIAL`; four-entry hint arrays, pageFirst optional variants, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### read_pdf include_metadata form-flags residual (frozen TS v3.0.14)
 
-A frozen four-case public-stdio `read_pdf` `include_metadata` form-flags residual is admitted matching pdf.js `formInfo`: XFA-only AcroForm yields `IsAcroFormPresent=false` + `IsXFAPresent=true`; Collection catalogs set `IsCollectionPresent=true`; visible Sig fields set `IsSignaturesPresent=true` + `IsAcroFormPresent=true`; invisible-only document signatures set `IsSignaturesPresent=true` + `IsAcroFormPresent=false`. Leaf-mutation count is frozen at 36 with relocated fixture-root replay. `include_metadata` remains `PARTIAL`; nested Kids signature-only breadth, empty XFA stream edge cases, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen four-case public-stdio `read_pdf` `include_metadata` form-flags residual is admitted matching pdf.js `formInfo`: XFA-only AcroForm yields `IsAcroFormPresent=false` + `IsXFAPresent=true`; Collection catalogs set `IsCollectionPresent=true`; visible Sig fields set `IsSignaturesPresent=true` + `IsAcroFormPresent=true`; invisible-only document signatures set `IsSignaturesPresent=true` + `IsAcroFormPresent=false`. Leaf-mutation count is frozen at 36 with relocated fixture-root replay. `include_metadata` remains `PARTIAL`; nested Kids signature-only breadth, empty XFA stream edge cases, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### read_pdf include_annotations text-annotation residual (frozen TS v3.0.14)
 
-A frozen two-case public-stdio `read_pdf` `include_annotations` text-annotation residual is admitted: Text annotations without appearance use pdf.js 22×22 icon boxes (`bottom = top - 22`, `right = left + 22`); FreeText keeps raw `/Rect` geometry. Leaf-mutation count is frozen at 27 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; Text with appearance stream, Name field, glyph-perfect boxes, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_annotations` text-annotation residual is admitted: Text annotations without appearance use pdf.js 22×22 icon boxes (`bottom = top - 22`, `right = left + 22`); FreeText keeps raw `/Rect` geometry. Leaf-mutation count is frozen at 27 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; Text with appearance stream, Name field, glyph-perfect boxes, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### read_pdf include_annotations remote-action residual (frozen TS v3.0.14)
 
-A frozen three-case public-stdio `read_pdf` `include_annotations` remote-action residual is admitted: Launch string files map to `url`; Launch file dictionaries prefer `UF` over `F`; GoToR builds remote `url` as `file#` + JSON explicit dest and suppresses `dest`. Leaf-mutation count is frozen at 42 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; GoToE attachments, `newWindow`, named remote dest string variants, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_annotations` remote-action residual is admitted: Launch string files map to `url`; Launch file dictionaries prefer `UF` over `F`; GoToR builds remote `url` as `file#` + JSON explicit dest and suppresses `dest`. Leaf-mutation count is frozen at 42 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; GoToE attachments, `newWindow`, named remote dest string variants, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### read_pdf include_annotations popup-annotation residual (frozen TS v3.0.14)
 
-A frozen two-case public-stdio `read_pdf` `include_annotations` popup residual is admitted: Popup inherits parent Text `title`/`contents` (pdf.js PopupAnnotation parent projection); parent Text keeps no-appearance 22×22 icon box; FreeText control keeps raw `/Rect` without parent inheritance. Leaf-mutation count is frozen at 36 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; Popup Group/IRT chain, zero-size rect nulling, richText RC, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_annotations` popup residual is admitted: Popup inherits parent Text `title`/`contents` (pdf.js PopupAnnotation parent projection); parent Text keeps no-appearance 22×22 icon box; FreeText control keeps raw `/Rect` without parent inheritance. Leaf-mutation count is frozen at 36 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; Popup Group/IRT chain, zero-size rect nulling, richText RC, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### read_pdf include_annotations popup-zero-size residual (frozen TS v3.0.14)
 
-A frozen two-case public-stdio `read_pdf` `include_annotations` popup zero-size residual is admitted: Popup with zero width or height nulls `rect` (omits `bounding_box`) like pdf.js `PopupAnnotation`; nonzero Popup keeps its `bounding_box`; zero-size Popup still inherits parent Text `title`/`contents`. Leaf-mutation count is frozen at 42 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; Popup Group/IRT chain, richText RC, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_annotations` popup zero-size residual is admitted: Popup with zero width or height nulls `rect` (omits `bounding_box`) like pdf.js `PopupAnnotation`; nonzero Popup keeps its `bounding_box`; zero-size Popup still inherits parent Text `title`/`contents`. Leaf-mutation count is frozen at 42 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; Popup Group/IRT chain, richText RC, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### read_pdf include_annotations popup-group-irt residual (frozen TS v3.0.14)
 
-A frozen two-case public-stdio `read_pdf` `include_annotations` popup group/IRT residual is admitted: Markup Text with `RT=Group` inherits `title`/`contents` from the `IRT` root (pdf.js MarkupAnnotation overwrite); Popup whose Parent has `RT=Group` also projects the IRT root `title`/`contents`; non-group Popup control keeps parent Text inheritance. Leaf-mutation count is frozen at 64 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; richText RC, group color/flags, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_annotations` popup group/IRT residual is admitted: Markup Text with `RT=Group` inherits `title`/`contents` from the `IRT` root (pdf.js MarkupAnnotation overwrite); Popup whose Parent has `RT=Group` also projects the IRT root `title`/`contents`; non-group Popup control keeps parent Text inheritance. Leaf-mutation count is frozen at 64 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; richText RC, group color/flags, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### read_pdf include_annotations text-appearance residual (frozen TS v3.0.14)
 
-A frozen two-case public-stdio `read_pdf` `include_annotations` text-appearance residual is admitted: Text annotations with `AP/N` stream keep raw `/Rect` geometry (pdf.js `hasAppearance`); empty appearance streams still count as appearance and do not force the 22×22 icon box. Leaf-mutation count is frozen at 28 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; Name field, glyph-perfect boxes, named appearance-state selection, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_annotations` text-appearance residual is admitted: Text annotations with `AP/N` stream keep raw `/Rect` geometry (pdf.js `hasAppearance`); empty appearance streams still count as appearance and do not force the 22×22 icon box. Leaf-mutation count is frozen at 28 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; Name field, glyph-perfect boxes, named appearance-state selection, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### read_pdf include_annotations text-named-appearance residual (frozen TS v3.0.14)
 
-A frozen two-case public-stdio `read_pdf` `include_annotations` text named-appearance residual is admitted: Text `AP/N` named-state dictionaries require `AS` selection for `hasAppearance` (pdf.js `setAppearance`); `AS`-selected streams keep raw `/Rect`, while missing `AS` falls back to the 22×22 icon box. Leaf-mutation count is frozen at 28 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; Name field, glyph-perfect boxes, invalid-AS fallback variants, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_annotations` text named-appearance residual is admitted: Text `AP/N` named-state dictionaries require `AS` selection for `hasAppearance` (pdf.js `setAppearance`); `AS`-selected streams keep raw `/Rect`, while missing `AS` falls back to the 22×22 icon box. Leaf-mutation count is frozen at 28 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; Name field, glyph-perfect boxes, invalid-AS fallback variants, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### read_pdf include_annotations text-inverted-rect residual (frozen TS v3.0.14)
 
-A frozen two-case public-stdio `read_pdf` `include_annotations` text inverted-rect residual is admitted: Text without appearance normalizes inverted `/Rect` first (pdf.js `lookupNormalRect`) then applies the 22×22 icon box from the normalized top-left; ordinary no-appearance Text keeps the same icon-box rule. Leaf-mutation count is frozen at 28 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; Name field, glyph-perfect boxes, appearance-stream geometry, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_annotations` text inverted-rect residual is admitted: Text without appearance normalizes inverted `/Rect` first (pdf.js `lookupNormalRect`) then applies the 22×22 icon box from the normalized top-left; ordinary no-appearance Text keeps the same icon-box rule. Leaf-mutation count is frozen at 28 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; Name field, glyph-perfect boxes, appearance-stream geometry, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### read_pdf include_annotations remote-named-dest residual (frozen TS v3.0.14)
 
-A frozen three-case public-stdio `read_pdf` `include_annotations` remote named-dest residual is admitted: GoToR with named dest string and PDF name-object `D` append as `file#name` (pdf.js `fetchRemoteDest`) and suppress `dest`; explicit-array GoToR control keeps `file#` + JSON dest. Leaf-mutation count is frozen at 42 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; GoToE attachments, `newWindow`, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_annotations` remote named-dest residual is admitted: GoToR with named dest string and PDF name-object `D` append as `file#name` (pdf.js `fetchRemoteDest`) and suppress `dest`; explicit-array GoToR control keeps `file#` + JSON dest. Leaf-mutation count is frozen at 42 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; GoToE attachments, `newWindow`, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### read_pdf include_page_labels kids residual (frozen TS v3.0.14)
 
-A frozen three-case public-stdio `read_pdf` `include_page_labels` residual is admitted: PageLabels number-tree `Kids` nodes expand like pdf.js (internal Kids ignore sibling Nums), multi-style control remains stable, and absent labels omit `page_labels`. Leaf-mutation count is frozen at 18 with relocated fixture-root replay. `include_page_labels` remains `PARTIAL`; hostile label overflow and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_page_labels` residual is admitted: PageLabels number-tree `Kids` nodes expand like pdf.js (internal Kids ignore sibling Nums), multi-style control remains stable, and absent labels omit `page_labels`. Leaf-mutation count is frozen at 18 with relocated fixture-root replay. `include_page_labels` remains `PARTIAL`; hostile label overflow and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf include_form_fields button-array residual (frozen TS v3.0.14)
 
-A frozen two-case public-stdio `read_pdf` `include_form_fields` residual is admitted: checkbox/radiobutton/pushbutton non-empty `/V` name arrays preserve pdf.js string arrays, plain string button values remain strings, empty button arrays collapse to `Off`, and absent `/V` falls back to a non-empty `/DV` array for both `value` and `default_value`. Leaf-mutation count is frozen at 68 with relocated fixture-root replay. `include_form_fields` remains `PARTIAL`; malformed-field breadth, nested Kids beyond the parent/child residual, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_form_fields` residual is admitted: checkbox/radiobutton/pushbutton non-empty `/V` name arrays preserve pdf.js string arrays, plain string button values remain strings, empty button arrays collapse to `Off`, and absent `/V` falls back to a non-empty `/DV` array for both `value` and `default_value`. Leaf-mutation count is frozen at 68 with relocated fixture-root replay. `include_form_fields` remains `PARTIAL`; malformed-field breadth, nested Kids beyond the parent/child residual, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf include_attachments attachment odd-names residual (frozen TS v3.0.14)
 
-A frozen two-case public-stdio `read_pdf` `include_attachments` attachment odd-names residual is admitted: odd-length EmbeddedFiles `Names` arrays keep complete key/value pairs and materialize a trailing unpaired key as `filename=unnamed` without `size_bytes` (pdf.js NameTree), covering orphan-only and pair-plus-orphan fixtures. Leaf-mutation count is frozen at 15 with relocated fixture-root replay. `include_attachments` remains `PARTIAL`; broader malformed name-tree breadth, duplicate-kids fail-closed, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_attachments` attachment odd-names residual is admitted: odd-length EmbeddedFiles `Names` arrays keep complete key/value pairs and materialize a trailing unpaired key as `filename=unnamed` without `size_bytes` (pdf.js NameTree), covering orphan-only and pair-plus-orphan fixtures. Leaf-mutation count is frozen at 15 with relocated fixture-root replay. `include_attachments` remains `PARTIAL`; broader malformed name-tree breadth, duplicate-kids fail-closed, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf include_attachments attachment dupkids residual (frozen TS v3.0.14)
 
-A frozen three-case public-stdio `read_pdf` `include_attachments` attachment dupkids residual is admitted: a valid EmbeddedFiles name-tree Kids leaf materializes attachments, while duplicate Kids refs and self-cycle Kids fail closed (omit `attachments`) like pdf.js NameTree `FormatError`. Leaf-mutation count is frozen at 15 with relocated fixture-root replay. Broader malformed name-tree breadth, invalid UF fallback breadth, and whole-product parity remain unclaimed; `include_attachments` remains `PARTIAL`. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_attachments` attachment dupkids residual is admitted: a valid EmbeddedFiles name-tree Kids leaf materializes attachments, while duplicate Kids refs and self-cycle Kids fail closed (omit `attachments`) like pdf.js NameTree `FormatError`. Leaf-mutation count is frozen at 15 with relocated fixture-root replay. Broader malformed name-tree breadth, invalid UF fallback breadth, and whole-product parity remain unclaimed; `include_attachments` remains `PARTIAL`. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### read_pdf include_form_fields form utf16-text residual (frozen TS v3.0.14)
 
-A frozen two-case public-stdio `read_pdf` `include_form_fields` form utf16-text residual is admitted: pdf.js `stringToPDFString` decoding for form `V`/`DV` — valid UTF-16BE BOM, odd-length UTF-16BE drops the trailing unpaired byte, UTF-8 BOM, and PDFDocEncoding plain control. Leaf-mutation count is frozen at 52 with relocated fixture-root replay. `include_form_fields` remains `PARTIAL`; split-surrogate wire parity, metadata/annotation UTF-16 breadth, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_form_fields` form utf16-text residual is admitted: pdf.js `stringToPDFString` decoding for form `V`/`DV` — valid UTF-16BE BOM, odd-length UTF-16BE drops the trailing unpaired byte, UTF-8 BOM, and PDFDocEncoding plain control. Leaf-mutation count is frozen at 52 with relocated fixture-root replay. `include_form_fields` remains `PARTIAL`; split-surrogate wire parity, metadata/annotation UTF-16 breadth, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf include_form_fields form text-multiline residual (frozen TS v3.0.14)
 
-A frozen three-case public-stdio `read_pdf` `include_form_fields` form text-multiline residual is admitted: pdf.js `stringToPDFString` preserves multiline Tx field values for escaped LF, escaped CRLF, and raw LF inside PDF literal strings. Leaf-mutation count is frozen at 45 with relocated fixture-root replay. Password/fileSelect flags, richText/DA, annotation/metadata multiline breadth, and whole-product parity remain unclaimed; `include_form_fields` remains `PARTIAL`. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_form_fields` form text-multiline residual is admitted: pdf.js `stringToPDFString` preserves multiline Tx field values for escaped LF, escaped CRLF, and raw LF inside PDF literal strings. Leaf-mutation count is frozen at 45 with relocated fixture-root replay. Password/fileSelect flags, richText/DA, annotation/metadata multiline breadth, and whole-product parity remain unclaimed; `include_form_fields` remains `PARTIAL`. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf include_annotations contents-multiline residual (frozen TS v3.0.14)
 
-A frozen three-case public-stdio `read_pdf` `include_annotations` contents-multiline residual is admitted: pdf.js `stringToPDFString` preserves multiline FreeText and Text annotation `Contents` for escaped LF and escaped CRLF. FreeText keeps raw Rect geometry; Text without appearance keeps the 22×22 icon box. Leaf-mutation count is frozen at 42 with relocated fixture-root replay. RichText RC fallback, default appearance DA, appearance-stream content bbox, form-field multiline breadth, and whole-product parity remain unclaimed; `include_annotations` remains `PARTIAL`. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_annotations` contents-multiline residual is admitted: pdf.js `stringToPDFString` preserves multiline FreeText and Text annotation `Contents` for escaped LF and escaped CRLF. FreeText keeps raw Rect geometry; Text without appearance keeps the 22×22 icon box. Leaf-mutation count is frozen at 42 with relocated fixture-root replay. RichText RC fallback, default appearance DA, appearance-stream content bbox, form-field multiline breadth, and whole-product parity remain unclaimed; `include_annotations` remains `PARTIAL`. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf include_outline cycle residual (frozen TS v3.0.14)
 
-A frozen three-case public-stdio `read_pdf` `include_outline` cycle residual is admitted: pdf.js global processed-set outline cycle suppression for `Next` self-cycle (single item), sibling `Next` cycle (both siblings once), and self `First` child cycle (no nested items). Leaf-mutation count is frozen at 49 with relocated fixture-root replay. Named dest string lookup, remote GoToR, outline beyond cycle breadth, and whole-product parity remain unclaimed; `include_outline` remains `PARTIAL`. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_outline` cycle residual is admitted: pdf.js global processed-set outline cycle suppression for `Next` self-cycle (single item), sibling `Next` cycle (both siblings once), and self `First` child cycle (no nested items). Leaf-mutation count is frozen at 49 with relocated fixture-root replay. Named dest string lookup, remote GoToR, outline beyond cycle breadth, and whole-product parity remain unclaimed; `include_outline` remains `PARTIAL`. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf include_outline named-dest residual (frozen TS v3.0.14)
 
-A frozen three-case public-stdio `read_pdf` `include_outline` named-dest residual is admitted: pdf.js keeps named outline `Dest`/action `D` as destination strings for literal string, name token, and GoTo `D` string without resolving `Names/Dests` to arrays. Leaf-mutation count is frozen at 33 with relocated fixture-root replay. Named dest resolution to array, remote GoToR, outline beyond named-dest breadth, and whole-product parity remain unclaimed; `include_outline` remains `PARTIAL`. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_outline` named-dest residual is admitted: pdf.js keeps named outline `Dest`/action `D` as destination strings for literal string, name token, and GoTo `D` string without resolving `Names/Dests` to arrays. Leaf-mutation count is frozen at 33 with relocated fixture-root replay. Named dest resolution to array, remote GoToR, outline beyond named-dest breadth, and whole-product parity remain unclaimed; `include_outline` remains `PARTIAL`. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf include_outline GoToR residual (frozen TS v3.0.14)
 
-A frozen three-case public-stdio `read_pdf` `include_outline` GoToR residual is admitted: pdf.js outline `GoToR` projects absolute-safe `url` from `F` + `#` + remote `D` for string, name token, and explicit-array destinations while forcing `dest` null. Leaf-mutation count is frozen at 36 with relocated fixture-root replay. Relative GoToR file urls, named dest array resolution, outline beyond GoToR breadth, and whole-product parity remain unclaimed; `include_outline` remains `PARTIAL`. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_outline` GoToR residual is admitted: pdf.js outline `GoToR` projects absolute-safe `url` from `F` + `#` + remote `D` for string, name token, and explicit-array destinations while forcing `dest` null. Leaf-mutation count is frozen at 36 with relocated fixture-root replay. Relative GoToR file urls, named dest array resolution, outline beyond GoToR breadth, and whole-product parity remain unclaimed; `include_outline` remains `PARTIAL`. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf include_outline Launch residual (frozen TS v3.0.14)
 
-A frozen three-case public-stdio `read_pdf` `include_outline` Launch residual is admitted: pdf.js outline `Launch` projects absolute-safe `url` from `F` + `#` + remote `D` for string, filespec `UF` preference, and explicit-array destinations while forcing `dest` null (same `parseDestDictionary` path as `GoToR`). Leaf-mutation count is frozen at 36 with relocated fixture-root replay. Relative Launch file urls, `newWindow`, outline beyond Launch breadth, and whole-product parity remain unclaimed; `include_outline` remains `PARTIAL`. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_outline` Launch residual is admitted: pdf.js outline `Launch` projects absolute-safe `url` from `F` + `#` + remote `D` for string, filespec `UF` preference, and explicit-array destinations while forcing `dest` null (same `parseDestDictionary` path as `GoToR`). Leaf-mutation count is frozen at 36 with relocated fixture-root replay. Relative Launch file urls, `newWindow`, outline beyond Launch breadth, and whole-product parity remain unclaimed; `include_outline` remains `PARTIAL`. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf include_outline relative-remote residual (frozen TS v3.0.14)
 
-A frozen three-case public-stdio `read_pdf` `include_outline` relative-remote residual is admitted: pdf.js outline `Launch`/`GoToR` drop relative `F` file specs (no absolute-safe `url`) and force `dest` null even when outline `Dest` is present. Leaf-mutation count is frozen at 33 with relocated fixture-root replay. Absolute remote breadth, `newWindow`, named dest array resolution, outline beyond relative-remote breadth, and whole-product parity remain unclaimed; `include_outline` remains `PARTIAL`. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_outline` relative-remote residual is admitted: pdf.js outline `Launch`/`GoToR` drop relative `F` file specs (no absolute-safe `url`) and force `dest` null even when outline `Dest` is present. Leaf-mutation count is frozen at 33 with relocated fixture-root replay. Absolute remote breadth, `newWindow`, named dest array resolution, outline beyond relative-remote breadth, and whole-product parity remain unclaimed; `include_outline` remains `PARTIAL`. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### public-stdio utf16-text residual (frozen TS v3.0.14)
 
-A frozen three-case public-stdio utf16-text residual is admitted: pdf.js `stringToPDFString` odd-length UTF-16BE trailing-byte drop for Text annotation title/contents, FreeText contents, outline titles, and metadata `Title`/`Author`. Leaf-mutation count is frozen at 41 with relocated fixture-root replay. Form-field UTF-16 decoding remains covered by the form utf16-text residual. `include_annotations`/`include_outline`/`include_metadata` remain `PARTIAL`; split-surrogate wire parity, XMP key/value, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio utf16-text residual is admitted: pdf.js `stringToPDFString` odd-length UTF-16BE trailing-byte drop for Text annotation title/contents, FreeText contents, outline titles, and metadata `Title`/`Author`. Leaf-mutation count is frozen at 41 with relocated fixture-root replay. Form-field UTF-16 decoding remains covered by the form utf16-text residual. `include_annotations`/`include_outline`/`include_metadata` remain `PARTIAL`; split-surrogate wire parity, XMP key/value, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### read_pdf include_annotations text invalid-as residual (frozen TS v3.0.14)
 
-A frozen two-case public-stdio `read_pdf` `include_annotations` text invalid-as residual is admitted: Text `AP/N` named-state dictionaries with invalid `AS` selection fall back to the 22×22 icon box (pdf.js `setAppearance`) for missing `AS` name and `AS` pointing at a non-stream. Leaf-mutation count is frozen at 28 with relocated fixture-root replay. Valid `AS` raw-rect selection remains covered by the named-appearance residual. `include_annotations` remains `PARTIAL`; Name field, glyph-perfect boxes, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `read_pdf` `include_annotations` text invalid-as residual is admitted: Text `AP/N` named-state dictionaries with invalid `AS` selection fall back to the 22×22 icon box (pdf.js `setAppearance`) for missing `AS` name and `AS` pointing at a non-stream. Leaf-mutation count is frozen at 28 with relocated fixture-root replay. Valid `AS` raw-rect selection remains covered by the named-appearance residual. `include_annotations` remains `PARTIAL`; Name field, glyph-perfect boxes, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### read_pdf include_annotations line annotation residual (frozen TS v3.0.14)
 
-A frozen three-case public-stdio `read_pdf` `include_annotations` line annotation residual is admitted: Line annotations without appearance expand the public bounding box like pdf.js `LineAnnotation` — default border width 1 expansion, non-intersecting `Rect` replaced from `/L` with `2*width` then public expand by width, and `BS/W=2` expansion. Leaf-mutation count is frozen at 39 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; line endings `LE`, appearance-stream geometry, PolyLine/Polygon, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen three-case public-stdio `read_pdf` `include_annotations` line annotation residual is admitted: Line annotations without appearance expand the public bounding box like pdf.js `LineAnnotation` — default border width 1 expansion, non-intersecting `Rect` replaced from `/L` with `2*width` then public expand by width, and `BS/W=2` expansion. Leaf-mutation count is frozen at 39 with relocated fixture-root replay. `include_annotations` remains `PARTIAL`; line endings `LE`, appearance-stream geometry, PolyLine/Polygon, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### read_pdf include_annotations polyline/polygon residual (frozen TS v3.0.14)
@@ -617,12 +631,12 @@ A frozen three-case public-stdio `read_pdf` `include_form_fields` form radio-bro
 
 ### search_pdf prefer_speed tools/list (post-3.0.14 additive surface)
 
-Pure-Rust tools/list intentionally exposes `search_pdf.prefer_speed` as a post-3.0.14 additive boolean property matching the current TypeScript surface. Frozen v3.0.14 input-schema ranges/enums remain enforced; `prefer_speed` is not a detached v3.0.14 residual claim. `prefer_speed` remains `PARTIAL`; `dropInFor3014` stays false and publish freeze remains enabled.
+Pure-Rust tools/list intentionally exposes `search_pdf.prefer_speed` as a post-3.0.14 additive boolean property matching the current TypeScript surface. Frozen v3.0.14 input-schema ranges/enums remain enforced; `prefer_speed` is not a detached v3.0.14 residual claim. `prefer_speed` remains `PARTIAL`; Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 
 ### search_pdf tesseract-tsv public-stdio subset (bounded)
 
-A frozen two-case public-stdio `search_pdf` tesseract-tsv OCR subset is admitted over `v3014-visual-v1.pdf`: valid TSV level-5 words produce image-to-PDF `ocr_word` geometry on the search match, and malformed TSV soft-falls back to raw text without geometry. Leaf-mutation count is frozen at 34 with relocated fixture-root replay. `include_ocr_text_layer` remains `PARTIAL`; real tesseract binary health checks, selectable/OCR interleaving, URL single-fetch, and whole-product parity remain unclaimed. `dropInFor3014` stays false and publish freeze remains enabled.
+A frozen two-case public-stdio `search_pdf` tesseract-tsv OCR subset is admitted over `v3014-visual-v1.pdf`: valid TSV level-5 words produce image-to-PDF `ocr_word` geometry on the search match, and malformed TSV soft-falls back to raw text without geometry. Leaf-mutation count is frozen at 34 with relocated fixture-root replay. `include_ocr_text_layer` remains `PARTIAL`; real tesseract binary health checks, selectable/OCR interleaving, URL single-fetch, and whole-product parity remain unclaimed. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.
 
 ### Cross-platform native optional packages (Stage B)
 
@@ -635,4 +649,4 @@ Local pure-Rust launcher smoke (`bun run smoke:native-launcher`) verifies staged
 `@sylphx/pdf-reader-mcp/pure-rust` exports an opt-in client that resolves the
 staged pure-Rust MCP server binary and calls `read_pdf` / `search_pdf` /
 `pdf_evidence` over stdio. The default package export remains TypeScript
-`dist/index.js`. `dropInFor3014` stays false and publish freeze remains enabled.
+`dist/index.js`. Live product truth is sole-Rust 4.0.2 — see the capability matrix for current gates.

--- a/docs/specs/performance/4.0.2-same-host-performance-report.md
+++ b/docs/specs/performance/4.0.2-same-host-performance-report.md
@@ -46,6 +46,11 @@ These numbers remain useful diagnostics for MCP spawn/start path cost. They are 
 
 ## Package size (historical run)
 
+> **Do not** market “92 KB TS vs 25 MB Rust executable” as product size. See
+> [installed footprint comparison](./installed-footprint-comparison.md).
+
+## Installed product footprint
+
 See raw suite packageSizeBytes samples (TS 3.0.14 tarball ~92 KB; sole-Rust launcher pack ~16 KB; native binary ~25 MB).
 
 ## Limitations / audit findings

--- a/docs/specs/performance/installed-footprint-comparison.md
+++ b/docs/specs/performance/installed-footprint-comparison.md
@@ -1,0 +1,91 @@
+# Installed product footprint comparison
+
+Status: methodology + representative measurements for product messaging  
+Date: 2026-07-24
+
+## Do not compare
+
+| Misleading comparison | Why it is wrong |
+| --- | --- |
+| TS main tarball (~90–100 KB) vs Rust **executable** (~20–25 MB) | Compares a package manifest wrapper to a full engine binary |
+| “JS is smaller because no .so/.exe” | Ignores `node_modules` closure (PDF.js, SDK, transitive deps) |
+| Sum of all five native packages | Users install **one** platform optional package |
+
+## Compare this instead
+
+For a **clean install on one host**:
+
+1. Main package unpacked size  
+2. Downloaded tarball bytes for packages actually installed  
+3. Full `node_modules` installed footprint (disk usage)  
+4. File count  
+5. Production dependency graph shape  
+6. Matching native binary size (Rust only; one platform)
+
+## Representative registry metadata (public npm)
+
+| Item | TS `3.0.14` | Rust `4.0.2` |
+| --- | ---: | ---: |
+| Main package `dist.unpackedSize` | ~402,169 bytes | ~72,415 bytes |
+| Production `dependencies` | PDF.js, MCP TS SDK, Zod, PNG, … | `{}` |
+| Platform engine | In-process JS + PDF.js workers | One optional native package |
+
+## Representative clean-install findings (audit)
+
+Independent post-publish audits measured on real hosts (values vary by OS/arch):
+
+| Metric | TS `3.0.14` | Rust `4.0.2` | Notes |
+| --- | ---: | ---: | --- |
+| Actual downloaded tarballs | ~25 MB class | ~8 MB class | Platform-dependent |
+| Full installed footprint | ~80–90 MiB class | ~20 MiB class | Includes one native binary on Rust |
+| Installed files | thousands | tens | Rust install graph is tiny |
+| Native executable | n/a | ~16–25 MB before/after strip work | Expected for a self-contained engine |
+
+**Product truth:** Sole-Rust 4.x is a **cleaner, smaller install** than TS 3.0.14 on measured hosts, even though the native binary alone is multi-megabyte.
+
+
+## Measured clean install — linux-x64 (2026-07-24)
+
+Host: `linux x64`, Node `v24.3.0`, npm install of exact versions.
+
+| Metric | TS `3.0.14` | Rust `4.0.2` | Ratio (TS/Rust) |
+| --- | ---: | ---: | ---: |
+| Main package on disk | 402,556 B | 76,786 B | ~5.2× |
+| Full `node_modules` | 86,288,102 B (~82.3 MiB) | 25,553,107 B (~24.4 MiB) | **~3.4×** |
+| Installed files | 4,101 | 20 | **~205×** |
+| Production deps | PDF.js + MCP SDK + Zod + PNG | `{}` + `pdf-reader-mcp-linux-x64-gnu` | cleaner graph |
+
+Evidence:
+
+- `verification/footprint/3.0.14-linux-x64.json`
+- `verification/footprint/4.0.2-linux-x64.json`
+
+Release binary optimization note: with workspace `[profile.release]` (`strip=symbols`, thin LTO, `codegen-units=1`), local linux-x64 `pdf-reader-mcp-server` built to **~14.9 MiB**. Published 4.0.2 natives may still be pre-optimization until the next binary rebuild/publish.
+
+## How to reproduce
+
+```bash
+# metadata
+npm view @sylphx/pdf-reader-mcp@3.0.14 dist.unpackedSize dependencies
+npm view @sylphx/pdf-reader-mcp@4.0.2 dist.unpackedSize dependencies
+
+# clean install footprint (example)
+bun scripts/perf/measure-installed-footprint.ts --version=4.0.2
+bun scripts/perf/measure-installed-footprint.ts --version=3.0.14
+```
+
+Record host triple, npm/node versions, and exact package versions with every public claim.
+
+## Messaging rules
+
+Allowed:
+
+- “Cleaner install graph: empty production dependencies + one platform native binary”
+- “Measured installed footprint smaller than TS 3.0.14 on host X”
+- “Native binary is multi-megabyte because it contains the engine”
+
+Forbidden:
+
+- “Rust is 250× larger” from wrapper-vs-binary
+- Claiming multi-host size guarantees from one host
+- Summing all native packages into “install size”

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sylphx/pdf-reader-mcp",
   "version": "4.0.2",
   "mcpName": "io.github.SylphxAI/pdf-reader-mcp",
-  "description": "Evidence-first PDF MCP. Sole-Rust production via platform native binary (thin JS launcher only). TypeScript PDF runtime is not shipped. Capability-first admission (ADR-0005/0006).",
+  "description": "Give AI agents eyes for PDFs \u2014 structured text, tables, OCR, visual evidence, and page-level citations via MCP. Native Rust engine, local-first, five platforms.",
   "type": "module",
   "bin": {
     "pdf-reader-mcp": "./dist/runtime-entry.js"
@@ -58,7 +58,11 @@
     "layout-analysis",
     "reading-order",
     "pdf-to-markdown",
-    "document-processing"
+    "document-processing",
+    "rust",
+    "local-first",
+    "pdf-mcp",
+    "document-intelligence"
   ],
   "scripts": {
     "build": "bun run build:package",
@@ -242,7 +246,8 @@
     "check:sole-rust-core": "bun scripts/check-sole-rust-core-admission.ts",
     "build:test": "bun run build:package && bun run build:oracle-ts",
     "check:prod-dependency-closure": "bun scripts/check-prod-dependency-closure.ts",
-    "check:no-github-hosted-macos": "bun scripts/check-no-github-hosted-macos.ts"
+    "check:no-github-hosted-macos": "bun scripts/check-no-github-hosted-macos.ts",
+    "perf:installed-footprint": "bun scripts/perf/measure-installed-footprint.ts"
   },
   "dependencies": {},
   "overrides": {

--- a/packages/pdf-reader-mcp-darwin-arm64/README.md
+++ b/packages/pdf-reader-mcp-darwin-arm64/README.md
@@ -1,19 +1,24 @@
 # @sylphx/pdf-reader-mcp-darwin-arm64
 
-Optional pure-Rust MCP server binary for `darwin-arm64`.
+Platform native binary for `darwin-arm64` used by `@sylphx/pdf-reader-mcp`.
 
 ## Status
 
-- Publishable optional package under verified-candidate admission (ADR-0005).
-- Consumed by `@sylphx/pdf-reader-mcp` via `optionalDependencies`.
-- Default package entry of the main package remains TypeScript until
-  `dropInFor3014=true` and sole-runtime cutover.
+- **Production path** for sole-Rust PDF Reader MCP on this platform
+- Installed automatically as an `optionalDependency` of `@sylphx/pdf-reader-mcp` when OS/CPU match
 - Binary path: `bin/pdf-reader-mcp-server`
-- Local host smoke: `bun run smoke:native-package-resolve`
-- Registry install proof: `bun run check:registry-install-proof -- --registry --version=<ver>`
+
+## Install
+
+Prefer the umbrella package (recommended):
+
+```bash
+npm install -g @sylphx/pdf-reader-mcp
+```
+
+You normally do **not** need to install this package directly. npm selects the matching platform package.
 
 ## Notes
 
-This package is not a standalone product surface. Prefer installing
-`@sylphx/pdf-reader-mcp` and opting into pure-Rust with
-`PDF_READER_ENGINE_MODE=pure-rust` (or the `./pure-rust` library export).
+This package is not a separate product surface. It is the native engine binary for one platform.
+There is no TypeScript PDF runtime and no engine “opt-in” flag for production.

--- a/packages/pdf-reader-mcp-darwin-arm64/package.json
+++ b/packages/pdf-reader-mcp-darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sylphx/pdf-reader-mcp-darwin-arm64",
   "version": "4.0.2",
-  "description": "Optional pure-Rust MCP server binary for darwin-arm64. Installed as an optionalDependency of @sylphx/pdf-reader-mcp sole-Rust production package.",
+  "description": "Native Rust MCP server binary for darwin-arm64 (production engine for @sylphx/pdf-reader-mcp).",
   "license": "MIT",
   "os": [
     "darwin"

--- a/packages/pdf-reader-mcp-darwin-x64/README.md
+++ b/packages/pdf-reader-mcp-darwin-x64/README.md
@@ -1,19 +1,24 @@
 # @sylphx/pdf-reader-mcp-darwin-x64
 
-Optional pure-Rust MCP server binary for `darwin-x64`.
+Platform native binary for `darwin-x64` used by `@sylphx/pdf-reader-mcp`.
 
 ## Status
 
-- Publishable optional package under verified-candidate admission (ADR-0005).
-- Consumed by `@sylphx/pdf-reader-mcp` via `optionalDependencies`.
-- Default package entry of the main package remains TypeScript until
-  `dropInFor3014=true` and sole-runtime cutover.
+- **Production path** for sole-Rust PDF Reader MCP on this platform
+- Installed automatically as an `optionalDependency` of `@sylphx/pdf-reader-mcp` when OS/CPU match
 - Binary path: `bin/pdf-reader-mcp-server`
-- Local host smoke: `bun run smoke:native-package-resolve`
-- Registry install proof: `bun run check:registry-install-proof -- --registry --version=<ver>`
+
+## Install
+
+Prefer the umbrella package (recommended):
+
+```bash
+npm install -g @sylphx/pdf-reader-mcp
+```
+
+You normally do **not** need to install this package directly. npm selects the matching platform package.
 
 ## Notes
 
-This package is not a standalone product surface. Prefer installing
-`@sylphx/pdf-reader-mcp` and opting into pure-Rust with
-`PDF_READER_ENGINE_MODE=pure-rust` (or the `./pure-rust` library export).
+This package is not a separate product surface. It is the native engine binary for one platform.
+There is no TypeScript PDF runtime and no engine “opt-in” flag for production.

--- a/packages/pdf-reader-mcp-darwin-x64/package.json
+++ b/packages/pdf-reader-mcp-darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sylphx/pdf-reader-mcp-darwin-x64",
   "version": "4.0.2",
-  "description": "Optional pure-Rust MCP server binary for darwin-x64. Installed as an optionalDependency of @sylphx/pdf-reader-mcp sole-Rust production package.",
+  "description": "Native Rust MCP server binary for darwin-x64 (production engine for @sylphx/pdf-reader-mcp).",
   "license": "MIT",
   "os": [
     "darwin"

--- a/packages/pdf-reader-mcp-linux-arm64-gnu/README.md
+++ b/packages/pdf-reader-mcp-linux-arm64-gnu/README.md
@@ -1,19 +1,24 @@
 # @sylphx/pdf-reader-mcp-linux-arm64-gnu
 
-Optional pure-Rust MCP server binary for `linux-arm64-gnu`.
+Platform native binary for `linux-arm64-gnu` used by `@sylphx/pdf-reader-mcp`.
 
 ## Status
 
-- Publishable optional package under verified-candidate admission (ADR-0005).
-- Consumed by `@sylphx/pdf-reader-mcp` via `optionalDependencies`.
-- Default package entry of the main package remains TypeScript until
-  `dropInFor3014=true` and sole-runtime cutover.
+- **Production path** for sole-Rust PDF Reader MCP on this platform
+- Installed automatically as an `optionalDependency` of `@sylphx/pdf-reader-mcp` when OS/CPU match
 - Binary path: `bin/pdf-reader-mcp-server`
-- Local host smoke: `bun run smoke:native-package-resolve`
-- Registry install proof: `bun run check:registry-install-proof -- --registry --version=<ver>`
+
+## Install
+
+Prefer the umbrella package (recommended):
+
+```bash
+npm install -g @sylphx/pdf-reader-mcp
+```
+
+You normally do **not** need to install this package directly. npm selects the matching platform package.
 
 ## Notes
 
-This package is not a standalone product surface. Prefer installing
-`@sylphx/pdf-reader-mcp` and opting into pure-Rust with
-`PDF_READER_ENGINE_MODE=pure-rust` (or the `./pure-rust` library export).
+This package is not a separate product surface. It is the native engine binary for one platform.
+There is no TypeScript PDF runtime and no engine “opt-in” flag for production.

--- a/packages/pdf-reader-mcp-linux-arm64-gnu/package.json
+++ b/packages/pdf-reader-mcp-linux-arm64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sylphx/pdf-reader-mcp-linux-arm64-gnu",
   "version": "4.0.2",
-  "description": "Optional pure-Rust MCP server binary for linux-arm64-gnu. Installed as an optionalDependency of @sylphx/pdf-reader-mcp sole-Rust production package.",
+  "description": "Native Rust MCP server binary for linux-arm64-gnu (production engine for @sylphx/pdf-reader-mcp).",
   "license": "MIT",
   "os": [
     "linux"

--- a/packages/pdf-reader-mcp-linux-x64-gnu/README.md
+++ b/packages/pdf-reader-mcp-linux-x64-gnu/README.md
@@ -1,19 +1,24 @@
 # @sylphx/pdf-reader-mcp-linux-x64-gnu
 
-Optional pure-Rust MCP server binary for `linux-x64-gnu`.
+Platform native binary for `linux-x64-gnu` used by `@sylphx/pdf-reader-mcp`.
 
 ## Status
 
-- Publishable optional package under verified-candidate admission (ADR-0005).
-- Consumed by `@sylphx/pdf-reader-mcp` via `optionalDependencies`.
-- Default package entry of the main package remains TypeScript until
-  `dropInFor3014=true` and sole-runtime cutover.
+- **Production path** for sole-Rust PDF Reader MCP on this platform
+- Installed automatically as an `optionalDependency` of `@sylphx/pdf-reader-mcp` when OS/CPU match
 - Binary path: `bin/pdf-reader-mcp-server`
-- Local host smoke: `bun run smoke:native-package-resolve`
-- Registry install proof: `bun run check:registry-install-proof -- --registry --version=<ver>`
+
+## Install
+
+Prefer the umbrella package (recommended):
+
+```bash
+npm install -g @sylphx/pdf-reader-mcp
+```
+
+You normally do **not** need to install this package directly. npm selects the matching platform package.
 
 ## Notes
 
-This package is not a standalone product surface. Prefer installing
-`@sylphx/pdf-reader-mcp` and opting into pure-Rust with
-`PDF_READER_ENGINE_MODE=pure-rust` (or the `./pure-rust` library export).
+This package is not a separate product surface. It is the native engine binary for one platform.
+There is no TypeScript PDF runtime and no engine “opt-in” flag for production.

--- a/packages/pdf-reader-mcp-linux-x64-gnu/package.json
+++ b/packages/pdf-reader-mcp-linux-x64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sylphx/pdf-reader-mcp-linux-x64-gnu",
   "version": "4.0.2",
-  "description": "Optional pure-Rust MCP server binary for linux-x64-gnu. Installed as an optionalDependency of @sylphx/pdf-reader-mcp sole-Rust production package.",
+  "description": "Native Rust MCP server binary for linux-x64-gnu (production engine for @sylphx/pdf-reader-mcp).",
   "license": "MIT",
   "os": [
     "linux"

--- a/packages/pdf-reader-mcp-win32-x64-msvc/README.md
+++ b/packages/pdf-reader-mcp-win32-x64-msvc/README.md
@@ -1,19 +1,24 @@
 # @sylphx/pdf-reader-mcp-win32-x64-msvc
 
-Optional pure-Rust MCP server binary for `win32-x64-msvc`.
+Platform native binary for `win32-x64-msvc` used by `@sylphx/pdf-reader-mcp`.
 
 ## Status
 
-- Publishable optional package under verified-candidate admission (ADR-0005).
-- Consumed by `@sylphx/pdf-reader-mcp` via `optionalDependencies`.
-- Default package entry of the main package remains TypeScript until
-  `dropInFor3014=true` and sole-runtime cutover.
-- Binary path: `bin/pdf-reader-mcp-server.exe`
-- Local host smoke: `bun run smoke:native-package-resolve`
-- Registry install proof: `bun run check:registry-install-proof -- --registry --version=<ver>`
+- **Production path** for sole-Rust PDF Reader MCP on this platform
+- Installed automatically as an `optionalDependency` of `@sylphx/pdf-reader-mcp` when OS/CPU match
+- Binary path: `bin/pdf-reader-mcp-server`
+
+## Install
+
+Prefer the umbrella package (recommended):
+
+```bash
+npm install -g @sylphx/pdf-reader-mcp
+```
+
+You normally do **not** need to install this package directly. npm selects the matching platform package.
 
 ## Notes
 
-This package is not a standalone product surface. Prefer installing
-`@sylphx/pdf-reader-mcp` and opting into pure-Rust with
-`PDF_READER_ENGINE_MODE=pure-rust` (or the `./pure-rust` library export).
+This package is not a separate product surface. It is the native engine binary for one platform.
+There is no TypeScript PDF runtime and no engine “opt-in” flag for production.

--- a/packages/pdf-reader-mcp-win32-x64-msvc/package.json
+++ b/packages/pdf-reader-mcp-win32-x64-msvc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sylphx/pdf-reader-mcp-win32-x64-msvc",
   "version": "4.0.2",
-  "description": "Optional pure-Rust MCP server binary for win32-x64-msvc. Installed as an optionalDependency of @sylphx/pdf-reader-mcp sole-Rust production package.",
+  "description": "Native Rust MCP server binary for win32-x64-msvc (production engine for @sylphx/pdf-reader-mcp).",
   "license": "MIT",
   "os": [
     "win32"

--- a/scripts/perf/measure-installed-footprint.ts
+++ b/scripts/perf/measure-installed-footprint.ts
@@ -1,0 +1,70 @@
+#!/usr/bin/env bun
+/**
+ * Measure clean-install product footprint for a published package version.
+ * Compares full install closure — never wrapper tarball vs native exe alone.
+ */
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const version = (process.argv.find((a) => a.startsWith('--version=')) || '--version=4.0.2').split('=')[1]!;
+const pkg = `@sylphx/pdf-reader-mcp@${version}`;
+const root = mkdtempSync(join(tmpdir(), `pdf-footprint-${version}-`));
+
+function run(cmd: string, args: string[], cwd = root) {
+  const r = spawnSync(cmd, args, { cwd, encoding: 'utf8' });
+  if (r.status !== 0) {
+    throw new Error(`${cmd} ${args.join(' ')} failed: ${r.stderr || r.stdout}`);
+  }
+  return r.stdout;
+}
+
+function duBytes(path: string): number {
+  const r = spawnSync('du', ['-sb', path], { encoding: 'utf8' });
+  if (r.status === 0) return Number((r.stdout || '').split(/\s+/)[0] || 0);
+  // macOS du lacks -sb; fall back
+  const r2 = spawnSync('du', ['-sk', path], { encoding: 'utf8' });
+  const kb = Number((r2.stdout || '').split(/\s+/)[0] || 0);
+  return kb * 1024;
+}
+
+function countFiles(dir: string): number {
+  let n = 0;
+  const walk = (p: string) => {
+    for (const ent of readdirSync(p, { withFileTypes: true })) {
+      const fp = join(p, ent.name);
+      if (ent.isDirectory()) walk(fp);
+      else n += 1;
+    }
+  };
+  walk(dir);
+  return n;
+}
+
+run('npm', ['init', '-y']);
+run('npm', ['install', pkg, '--no-fund', '--no-audit']);
+const nm = join(root, 'node_modules');
+const main = join(nm, '@sylphx', 'pdf-reader-mcp');
+const footprint = {
+  package: pkg,
+  host: {
+    platform: process.platform,
+    arch: process.arch,
+    node: process.version,
+  },
+  installDir: root,
+  mainPackageBytes: duBytes(main),
+  nodeModulesBytes: duBytes(nm),
+  nodeModulesFiles: countFiles(nm),
+  productionDependencies: JSON.parse(
+    run('node', ['-e', "console.log(JSON.stringify(require('./node_modules/@sylphx/pdf-reader-mcp/package.json').dependencies||{}))"])
+  ),
+  nativePackages: readdirSync(join(nm, '@sylphx')).filter((n) => n.startsWith('pdf-reader-mcp-')),
+};
+
+const out = join(process.cwd(), 'benchmark-artifacts', 'installed-footprint', `${version}-${process.platform}-${process.arch}.json`);
+spawnSync('mkdir', ['-p', join(process.cwd(), 'benchmark-artifacts', 'installed-footprint')]);
+writeFileSync(out, JSON.stringify(footprint, null, 2) + '\n');
+console.log(JSON.stringify(footprint, null, 2));
+console.log(`wrote ${out}`);

--- a/verification/footprint/3.0.14-linux-x64.json
+++ b/verification/footprint/3.0.14-linux-x64.json
@@ -1,0 +1,19 @@
+{
+  "package": "@sylphx/pdf-reader-mcp@3.0.14",
+  "host": {
+    "platform": "linux",
+    "arch": "x64",
+    "node": "v24.3.0"
+  },
+  "installDir": "/tmp/pdf-footprint-3.0.14-6yWgxb",
+  "mainPackageBytes": 402556,
+  "nodeModulesBytes": 86288102,
+  "nodeModulesFiles": 4101,
+  "productionDependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "pdfjs-dist": "^6.0.227",
+    "pngjs": "^7.0.0",
+    "zod": "^4.4.3"
+  },
+  "nativePackages": []
+}

--- a/verification/footprint/4.0.2-linux-x64.json
+++ b/verification/footprint/4.0.2-linux-x64.json
@@ -1,0 +1,16 @@
+{
+  "package": "@sylphx/pdf-reader-mcp@4.0.2",
+  "host": {
+    "platform": "linux",
+    "arch": "x64",
+    "node": "v24.3.0"
+  },
+  "installDir": "/tmp/pdf-footprint-4.0.2-RHqjLe",
+  "mainPackageBytes": 76786,
+  "nodeModulesBytes": 25553107,
+  "nodeModulesFiles": 20,
+  "productionDependencies": {},
+  "nativePackages": [
+    "pdf-reader-mcp-linux-x64-gnu"
+  ]
+}


### PR DESCRIPTION
## Summary

Phase 1 of productization: stop sounding like a migration control room.

- **Positioning:** “Give your AI agent eyes for PDFs” across README, site hero, GitHub description/topics, npm description
- **Install docs:** sole-Rust **4.0.2** (not TS 3.0.14)
- **Native package READMEs:** production engine binaries, not “opt-in pure-Rust”
- **Size truth:** installed-product comparison (not 92KB wrapper vs 25MB exe)
  - Measured linux-x64 clean install: Rust **~3.4× smaller** `node_modules`, **~205× fewer files** vs TS 3.0.14
- **Release profile:** `strip=symbols`, thin LTO, `codegen-units=1` (local binary ~14.9 MiB)
- **Performance marketing:** still bounded / not universal Nx claims

## Evidence
- `verification/footprint/3.0.14-linux-x64.json`
- `verification/footprint/4.0.2-linux-x64.json`
- `docs/specs/performance/installed-footprint-comparison.md`

## Non-goals (this PR)
- No new npm publish
- No formal performance re-admission
- No demo GIF assets yet
- No 4.1 launch campaign

## Test plan
- [x] `bun run docs:build`
- [x] focused sole-Rust matrix/transport tests
- [x] footprint measurement script on linux-x64
- [ ] CI green