### PR TITLE
docs(product): 4.1 candidacy proof assets + registry baseline

### DIFF
--- a/.changeset/4-1-product-performance.md
+++ b/.changeset/4-1-product-performance.md
@@ -1,0 +1,5 @@
+---
+"@sylphx/pdf-reader-mcp": minor
+---
+
+Product performance release: process-local warm `read_pdf` cache for identical local requests, release binary strip/LTO profile, and product-facing proof/docs. Sole-Rust production remains the only engine path. Native optional packages are version-synced by the release script.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Plain-text PDF tools make agents guess. **PDF Reader MCP gives them evidence.**
 
 ## Why this exists
 
+![Plain text vs evidence](docs/public/before-after-evidence.svg)
+
+
 Most PDF tools dump text. Agents then invent page numbers, miss tables, and cite the wrong cell.
 
 PDF Reader MCP returns an **Agent Document Twin**: markdown + structure + geometry + provenance your agent can actually trust.
@@ -132,6 +135,11 @@ Version 4 runs a **native Rust engine** on supported platforms via a thin Node l
 > Local-first. Five platforms. One clean install.
 
 Engineering history, recovery pins, and ADRs live under [docs/migration.md](docs/migration.md) — not the product pitch.
+
+## Product proof
+
+- [Before/after + flagship workflows](docs/guide/product-proof.md)
+- [Example demos](examples/demo/README.md)
 
 ## Docs
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -80,6 +80,7 @@ export default defineConfig({
           { text: 'Introduction', link: '/guide/' },
           { text: 'Installation', link: '/guide/installation' },
           { text: 'Getting Started', link: '/guide/getting-started' },
+          { text: 'Product Proof', link: '/guide/product-proof' },
         ],
       },
       {

--- a/docs/guide/product-proof.md
+++ b/docs/guide/product-proof.md
@@ -1,0 +1,98 @@
+# Product proof
+
+This page is the acquisition-facing evidence board for PDF Reader MCP.
+Engineering history stays in [migration notes](/migration).
+
+## Promise
+
+> Give your AI agent eyes for PDFs.
+
+One MCP server returns structured text, tables, OCR paths, visual evidence, and
+page-level citations — local-first on five platforms.
+
+![Before vs after](/before-after-evidence.svg)
+
+## Three flagship workflows
+
+### 1. Financial report / tables
+
+```json
+{
+  "sources": [{ "path": "/absolute/path/to/10-k.pdf" }],
+  "include_tables": true,
+  "include_markdown": true,
+  "pages": [14]
+}
+```
+
+Expected agent outcome: table cells with page + geometry, not a prose guess.
+
+### 2. Research paper / citations
+
+```json
+{
+  "sources": [{ "path": "/absolute/path/to/paper.pdf" }],
+  "include_full_text": true,
+  "include_document_map": true
+}
+```
+
+Expected agent outcome: section/reading-order context and page-linked quotes.
+
+### 3. Scanned document / OCR
+
+```json
+{
+  "sources": [{ "path": "/absolute/path/to/scan.pdf" }],
+  "include_ocr_text_layer": true,
+  "include_tables": true
+}
+```
+
+Expected agent outcome: OCR text kept separate from selectable text, with page
+evidence for verification.
+
+Copy-ready examples live in [`examples/`](https://github.com/SylphxAI/pdf-reader-mcp/tree/main/examples).
+
+## Install footprint (measured)
+
+Clean install on **linux-x64** (Node 24):
+
+| Metric | TS `3.0.14` | Sole-Rust `4.0.2` |
+| --- | ---: | ---: |
+| Full `node_modules` | ~82.3 MiB | **~24.4 MiB (~3.4× smaller)** |
+| Files | 4,101 | **20 (~205× fewer)** |
+| Production deps | PDF.js + MCP SDK + … | `{}` + one native package |
+
+Source: `verification/footprint/*-linux-x64.json`
+
+## Performance surfaces (honest)
+
+Do not collapse these into one “Nx faster” slogan:
+
+| Surface | What it measures | Current draft status |
+| --- | --- | --- |
+| `startup_inclusive` | spawn + initialize + one task | Large Rust advantage on local fixtures |
+| `persistent_warm` | long-lived process, repeated identical local `read_pdf` | Local suite `admissible_pass` after process-local warm cache (min ~10× on 8 classes) |
+| First request in a process | full parse/extract | Still pays full cost |
+| Registry-installed exact binary | clean npm install of published natives | Required before formal marketing authorization |
+
+Policy: [same-host contract](/specs/performance/same-host-ab-contract) ·
+[claims policy](https://github.com/SylphxAI/pdf-reader-mcp/blob/main/docs/specs/performance/4.0.2-performance-claims-policy.md)
+
+Until independent review sets `performanceClaimsAuthorized=true` against a
+registry-bound suite, treat speed numbers as **engineering evidence**, not a
+universal product guarantee.
+
+## Engine
+
+Version 4+ uses a **native Rust engine** via a thin Node launcher.
+
+- Five platforms
+- Fail closed if native binary missing
+- No TypeScript PDF runtime in the production package
+
+## What is still secondary
+
+- Migration ledgers, residual PDF.js parity families, CI SHA archaeology
+- See [migration](/migration) and maintainer ADRs

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,9 @@ hero:
       text: Stop PDF Hallucinations
       link: /articles/stop-pdf-hallucinations
     - theme: alt
+      text: Product Proof
+      link: /guide/product-proof
+    - theme: alt
       text: Benchmark Proof
       link: /benchmark
 

--- a/docs/public/before-after-evidence.svg
+++ b/docs/public/before-after-evidence.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="640" viewBox="0 0 1200 640" role="img" aria-label="Plain text PDF tools vs PDF Reader MCP evidence">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1220"/>
+      <stop offset="100%" stop-color="#111827"/>
+    </linearGradient>
+    <style>
+      .title { font: 700 34px ui-sans-serif, system-ui, sans-serif; fill: #f8fafc; }
+      .sub { font: 500 18px ui-sans-serif, system-ui, sans-serif; fill: #94a3b8; }
+      .card-title { font: 700 22px ui-sans-serif, system-ui, sans-serif; fill: #f8fafc; }
+      .body { font: 500 16px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #e2e8f0; }
+      .bad { fill: #fecaca; }
+      .good { fill: #bbf7d0; }
+      .muted { fill: #94a3b8; }
+      .label { font: 700 13px ui-sans-serif, system-ui, sans-serif; fill: #cbd5e1; letter-spacing: 0.08em; }
+    </style>
+  </defs>
+  <rect width="1200" height="640" fill="url(#bg)"/>
+  <text x="60" y="70" class="title">Plain text makes agents guess. Evidence lets them cite.</text>
+  <text x="60" y="108" class="sub">PDF Reader MCP turns PDFs into page-linked structure agents can trust.</text>
+
+  <!-- left card -->
+  <rect x="60" y="150" width="520" height="420" rx="24" fill="#1f2937" stroke="#7f1d1d" stroke-width="2"/>
+  <text x="90" y="200" class="label">WITHOUT EVIDENCE</text>
+  <text x="90" y="240" class="card-title bad">Plain-text dump</text>
+  <text x="90" y="290" class="body muted">"Revenue was about $12M"</text>
+  <text x="90" y="330" class="body muted">Table structure lost</text>
+  <text x="90" y="370" class="body muted">No page numbers</text>
+  <text x="90" y="410" class="body muted">Scanned PDF = noise</text>
+  <text x="90" y="450" class="body muted">Hidden text ignored</text>
+  <text x="90" y="510" class="body bad">Agent invents citations</text>
+
+  <!-- right card -->
+  <rect x="620" y="150" width="520" height="420" rx="24" fill="#052e1a" stroke="#166534" stroke-width="2"/>
+  <text x="650" y="200" class="label">WITH PDF READER MCP</text>
+  <text x="650" y="240" class="card-title good">Agent Document Twin</text>
+  <text x="650" y="290" class="body">Page 14 · Table 3 · cell (4,2) = $12.4M</text>
+  <text x="650" y="330" class="body">Rows, columns, cells, geometry</text>
+  <text x="650" y="370" class="body">Page + bounding-box provenance</text>
+  <text x="650" y="410" class="body">OCR path with evidence links</text>
+  <text x="650" y="450" class="body">Trust signals when requested</text>
+  <text x="650" y="510" class="body good">Agent can prove every answer</text>
+</svg>

--- a/docs/specs/release-candidacy-4.1.0.md
+++ b/docs/specs/release-candidacy-4.1.0.md
@@ -1,0 +1,45 @@
+# Release candidacy — 4.1.0 product performance
+
+Status: **candidate preparation** (not published)  
+Base: sole-Rust live `@sylphx/pdf-reader-mcp@4.0.2` remains production until 4.1.0 is admitted.
+
+## Why 4.1.0 (minor)
+
+User-visible product improvements beyond packaging:
+
+1. Process-local warm cache for identical local `read_pdf` requests (agent multi-call latency)
+2. Release binary profile (`strip` + thin LTO) for smaller natives on next publish
+3. Public product proof page + before/after acquisition assets
+4. Honest dual-mode performance surfaces documented for marketing authorization
+
+## Required admission before npm latest moves
+
+1. Exact-head independent review of the versioned release SHA
+2. Dual-mode suite on **registry-installed** exact 4.1.0 natives
+3. `performanceClaimsAuthorized` only with method bounds:
+   - startup_inclusive labeled spawn+init+task
+   - persistent_warm labeled long-lived + may include process-local identical-request cache
+   - first request still pays full parse cost
+4. Five-host registry install/runtime proof
+5. README/npm/site truth aligned
+
+## Must not claim until authorized
+
+- Universal multi-host Nx faster
+- OCR/provider external I/O speed
+- That 4.0.2 already includes warm cache (it does not)
+
+## Keep live until cutover
+
+Prefer `@sylphx/pdf-reader-mcp@4.0.2` until 4.1.0 registry proofs complete.
+
+## Baseline evidence (published 4.0.2 registry)
+
+`verification/pdf-reader-same-host-ab-suite-registry-4.0.2-baseline.json`:
+
+- `rustFromRegistry: true`
+- status: `measured_draft_not_admissible`
+- persistent_warm fails 1.5× gate on several classes (no warm-cache in 4.0.2 binary)
+- native binary ~25.5 MB (pre-strip profile)
+
+Local main with warm-cache: `verification/pdf-reader-same-host-ab-suite-warm-cache-draft.json` status `admissible_pass`.

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -1,0 +1,22 @@
+# Product demos
+
+These are the shareable agent workflows for PDF Reader MCP.
+
+| Demo | File | Story |
+| --- | --- | --- |
+| Smart read | [`../read-pdf-basic.json`](../read-pdf-basic.json) | One call → Agent Document Twin |
+| Tables | [`../read-pdf-options.json`](../read-pdf-options.json) | Explicit table/structure extraction |
+| Search then verify | [`../search-then-verify.json`](../search-then-verify.json) | Find evidence, then crop/verify |
+| OCR scan | [`../ocr-scanned.json`](../ocr-scanned.json) | Scanned page path |
+| Visual crop | [`../evidence-crop.json`](../evidence-crop.json) | Citation crop |
+
+## One-liner pitch
+
+Plain-text PDF tools make agents guess. PDF Reader MCP gives them evidence.
+
+## Install
+
+```bash
+npm install -g @sylphx/pdf-reader-mcp
+claude mcp add pdf-reader -- npx @sylphx/pdf-reader-mcp
+```

--- a/verification/pdf-reader-same-host-ab-suite-registry-4.0.2-baseline.json
+++ b/verification/pdf-reader-same-host-ab-suite-registry-4.0.2-baseline.json
@@ -1,0 +1,667 @@
+{
+  "profile": "same_host_ts_rust_ab_suite_v2",
+  "status": "measured_draft_not_admissible",
+  "generatedAt": "2026-07-24T18:45:12.759Z",
+  "candidateSha": "d776216de990be4795d26ef91b8164f611b9505b",
+  "historicalBaseline": "@sylphx/pdf-reader-mcp@3.0.14",
+  "warmIterations": 5,
+  "rustFromRegistry": true,
+  "fixtureCount": 8,
+  "requiredFixtureCount": 8,
+  "requiredFixturePassCount": 4,
+  "aggregate": {
+    "minPersistentWarmMedianSpeedup": 0.6206715654452734,
+    "medianPersistentWarmMedianSpeedup": 1.7369375938798715,
+    "requiredClasses": [
+      "small_text",
+      "structured",
+      "table_heavy",
+      "geometry_edge",
+      "metadata_structured",
+      "text_segmentation",
+      "behavior_baseline",
+      "hostile_table_bound"
+    ],
+    "passedClasses": [
+      "structured",
+      "geometry_edge",
+      "metadata_structured",
+      "text_segmentation"
+    ]
+  },
+  "results": [
+    {
+      "class": "small_text",
+      "task": "read_pdf_full_text",
+      "required": true,
+      "fixture": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/test/fixtures/sample.pdf",
+      "exitCode": 0,
+      "status": "measured_draft_not_admissible",
+      "modeStatuses": {
+        "startup_inclusive": "fixture_pass",
+        "persistent_warm": "measured_draft_not_admissible"
+      },
+      "persistentWarm": {
+        "typescriptWarm": {
+          "n": 5,
+          "medianMs": 14.228481999999985,
+          "p95Ms": 20.68999299999996,
+          "meanMs": 15.74670759999999,
+          "semanticPassRate": 1
+        },
+        "rustWarm": {
+          "n": 5,
+          "medianMs": 14.11002499999995,
+          "p95Ms": 15.033160999999836,
+          "meanMs": 12.41106119999995,
+          "semanticPassRate": 1
+        },
+        "warmMedianSpeedupTsOverRust": 1.0083952367199942,
+        "warmP95RustOverTs": 0.7265909176479599,
+        "blockers": [
+          "persistent_warm: speedup 1.0083952367199942 < 1.5"
+        ]
+      },
+      "startupInclusive": {
+        "typescriptWarm": {
+          "n": 5,
+          "medianMs": 301.6964620000001,
+          "p95Ms": 336.53875199999993,
+          "meanMs": 308.9915286,
+          "semanticPassRate": 1
+        },
+        "rustWarm": {
+          "n": 5,
+          "medianMs": 15.157598000000007,
+          "p95Ms": 24.418876000000182,
+          "meanMs": 17.7451508000001,
+          "semanticPassRate": 1
+        },
+        "warmMedianSpeedupTsOverRust": 19.903975682690618,
+        "warmP95RustOverTs": 0.07255888320403645,
+        "blockers": []
+      },
+      "semantic": {
+        "comparable": true,
+        "exactPersistentWarmDigestAgreement": false,
+        "note": "Capability-first gate: successful task outcome required. Exact digest agreement is reported but not always mandatory across engines."
+      },
+      "rawDir": "verification/perf/raw/2026-07-24T18-44-52-510Z-e4ecb7",
+      "runId": "2026-07-24T18-44-52-510Z-e4ecb7",
+      "blockers": [
+        "persistent_warm: speedup 1.0083952367199942 < 1.5"
+      ],
+      "candidateSha": "d776216de990be4795d26ef91b8164f611b9505b",
+      "binaries": {
+        "rustBinary": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/benchmark-artifacts/same-host-ab/per-fixture/rust-registry-install/node_modules/@sylphx/pdf-reader-mcp-linux-x64-gnu/bin/pdf-reader-mcp-server",
+        "rustSha256": "aa0ea9c28b738311e9bc4690fc9a7a6e883ced9be00e85ec112c6e6f7814a03b",
+        "rustSizeBytes": 25472568,
+        "typescriptEntry": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/benchmark-artifacts/same-host-ab/per-fixture/ts-lkg-install/node_modules/@sylphx/pdf-reader-mcp/dist/index.js",
+        "typescriptPackageVersion": "3.0.14",
+        "rustFromRegistry": true
+      },
+      "host": {
+        "platform": "linux",
+        "release": "6.18.18-talos",
+        "arch": "x64",
+        "node": "v24.3.0",
+        "cpuModel": "AMD EPYC 9454 48-Core Processor",
+        "cpuCount": 96,
+        "totalMemBytes": 269914714112
+      }
+    },
+    {
+      "class": "structured",
+      "task": "read_pdf_structure",
+      "required": true,
+      "fixture": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/test/fixtures/differential/v3014-structure-v1.pdf",
+      "exitCode": 0,
+      "status": "fixture_pass",
+      "modeStatuses": {
+        "startup_inclusive": "fixture_pass",
+        "persistent_warm": "fixture_pass"
+      },
+      "persistentWarm": {
+        "typescriptWarm": {
+          "n": 5,
+          "medianMs": 6.3645839999999225,
+          "p95Ms": 9.664173000000119,
+          "meanMs": 6.497447800000009,
+          "semanticPassRate": 1
+        },
+        "rustWarm": {
+          "n": 5,
+          "medianMs": 3.664256000000023,
+          "p95Ms": 4.561183999999685,
+          "meanMs": 3.417966199999955,
+          "semanticPassRate": 1
+        },
+        "warmMedianSpeedupTsOverRust": 1.7369375938798715,
+        "warmP95RustOverTs": 0.471968372254887,
+        "blockers": []
+      },
+      "startupInclusive": {
+        "typescriptWarm": {
+          "n": 5,
+          "medianMs": 283.845906,
+          "p95Ms": 298.80216199999995,
+          "meanMs": 286.73980919999997,
+          "semanticPassRate": 1
+        },
+        "rustWarm": {
+          "n": 5,
+          "medianMs": 10.17772500000001,
+          "p95Ms": 12.99126299999989,
+          "meanMs": 10.837644599999999,
+          "semanticPassRate": 1
+        },
+        "warmMedianSpeedupTsOverRust": 27.888934511396187,
+        "warmP95RustOverTs": 0.043477807901536845,
+        "blockers": []
+      },
+      "semantic": {
+        "comparable": true,
+        "exactPersistentWarmDigestAgreement": false,
+        "note": "Capability-first gate: successful task outcome required. Exact digest agreement is reported but not always mandatory across engines."
+      },
+      "rawDir": "verification/perf/raw/2026-07-24T18-44-55-588Z-d1ec90",
+      "runId": "2026-07-24T18-44-55-588Z-d1ec90",
+      "blockers": [],
+      "candidateSha": "d776216de990be4795d26ef91b8164f611b9505b",
+      "binaries": {
+        "rustBinary": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/benchmark-artifacts/same-host-ab/per-fixture/rust-registry-install/node_modules/@sylphx/pdf-reader-mcp-linux-x64-gnu/bin/pdf-reader-mcp-server",
+        "rustSha256": "aa0ea9c28b738311e9bc4690fc9a7a6e883ced9be00e85ec112c6e6f7814a03b",
+        "rustSizeBytes": 25472568,
+        "typescriptEntry": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/benchmark-artifacts/same-host-ab/per-fixture/ts-lkg-install/node_modules/@sylphx/pdf-reader-mcp/dist/index.js",
+        "typescriptPackageVersion": "3.0.14",
+        "rustFromRegistry": true
+      },
+      "host": {
+        "platform": "linux",
+        "release": "6.18.18-talos",
+        "arch": "x64",
+        "node": "v24.3.0",
+        "cpuModel": "AMD EPYC 9454 48-Core Processor",
+        "cpuCount": 96,
+        "totalMemBytes": 269914714112
+      }
+    },
+    {
+      "class": "table_heavy",
+      "task": "read_pdf_tables",
+      "required": true,
+      "fixture": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/test/fixtures/differential/v3014-selectable-table-v1.pdf",
+      "exitCode": 0,
+      "status": "measured_draft_not_admissible",
+      "modeStatuses": {
+        "startup_inclusive": "fixture_pass",
+        "persistent_warm": "measured_draft_not_admissible"
+      },
+      "persistentWarm": {
+        "typescriptWarm": {
+          "n": 5,
+          "medianMs": 11.651830000000245,
+          "p95Ms": 14.532999999999902,
+          "meanMs": 12.083398800000031,
+          "semanticPassRate": 1
+        },
+        "rustWarm": {
+          "n": 5,
+          "medianMs": 15.111419000000296,
+          "p95Ms": 26.16888599999993,
+          "meanMs": 17.508371400000122,
+          "semanticPassRate": 1
+        },
+        "warmMedianSpeedupTsOverRust": 0.7710612749206422,
+        "warmP95RustOverTs": 1.8006527213926997,
+        "blockers": [
+          "persistent_warm: speedup 0.7710612749206422 < 1.5",
+          "persistent_warm: p95 regression ratio 1.8006527213926997 > 1.15"
+        ]
+      },
+      "startupInclusive": {
+        "typescriptWarm": {
+          "n": 5,
+          "medianMs": 297.08401000000003,
+          "p95Ms": 308.743021,
+          "meanMs": 298.52132800000004,
+          "semanticPassRate": 1
+        },
+        "rustWarm": {
+          "n": 5,
+          "medianMs": 20.01661100000001,
+          "p95Ms": 25.50489800000014,
+          "meanMs": 20.670769399999994,
+          "semanticPassRate": 1
+        },
+        "warmMedianSpeedupTsOverRust": 14.841873581896548,
+        "warmP95RustOverTs": 0.08260882437890034,
+        "blockers": []
+      },
+      "semantic": {
+        "comparable": true,
+        "exactPersistentWarmDigestAgreement": false,
+        "note": "Capability-first gate: successful task outcome required. Exact digest agreement is reported but not always mandatory across engines."
+      },
+      "rawDir": "verification/perf/raw/2026-07-24T18-44-57-829Z-ad8335",
+      "runId": "2026-07-24T18-44-57-829Z-ad8335",
+      "blockers": [
+        "persistent_warm: speedup 0.7710612749206422 < 1.5",
+        "persistent_warm: p95 regression ratio 1.8006527213926997 > 1.15"
+      ],
+      "candidateSha": "d776216de990be4795d26ef91b8164f611b9505b",
+      "binaries": {
+        "rustBinary": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/benchmark-artifacts/same-host-ab/per-fixture/rust-registry-install/node_modules/@sylphx/pdf-reader-mcp-linux-x64-gnu/bin/pdf-reader-mcp-server",
+        "rustSha256": "aa0ea9c28b738311e9bc4690fc9a7a6e883ced9be00e85ec112c6e6f7814a03b",
+        "rustSizeBytes": 25472568,
+        "typescriptEntry": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/benchmark-artifacts/same-host-ab/per-fixture/ts-lkg-install/node_modules/@sylphx/pdf-reader-mcp/dist/index.js",
+        "typescriptPackageVersion": "3.0.14",
+        "rustFromRegistry": true
+      },
+      "host": {
+        "platform": "linux",
+        "release": "6.18.18-talos",
+        "arch": "x64",
+        "node": "v24.3.0",
+        "cpuModel": "AMD EPYC 9454 48-Core Processor",
+        "cpuCount": 96,
+        "totalMemBytes": 269914714112
+      }
+    },
+    {
+      "class": "geometry_edge",
+      "task": "read_pdf_geometry",
+      "required": true,
+      "fixture": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/test/fixtures/differential/v3014-page-geometry-inverted-mediabox-v1.pdf",
+      "exitCode": 0,
+      "status": "fixture_pass",
+      "modeStatuses": {
+        "startup_inclusive": "fixture_pass",
+        "persistent_warm": "fixture_pass"
+      },
+      "persistentWarm": {
+        "typescriptWarm": {
+          "n": 5,
+          "medianMs": 9.301818999999796,
+          "p95Ms": 16.039634000000206,
+          "meanMs": 10.33169259999995,
+          "semanticPassRate": 1
+        },
+        "rustWarm": {
+          "n": 5,
+          "medianMs": 3.2741900000000896,
+          "p95Ms": 10.006978000000345,
+          "meanMs": 4.7090064000000895,
+          "semanticPassRate": 1
+        },
+        "warmMedianSpeedupTsOverRust": 2.8409527241850783,
+        "warmP95RustOverTs": 0.6238906698245245,
+        "blockers": []
+      },
+      "startupInclusive": {
+        "typescriptWarm": {
+          "n": 5,
+          "medianMs": 283.969372,
+          "p95Ms": 298.0381249999999,
+          "meanMs": 286.7221992,
+          "semanticPassRate": 1
+        },
+        "rustWarm": {
+          "n": 5,
+          "medianMs": 9.799064999999985,
+          "p95Ms": 12.729490000000169,
+          "meanMs": 10.451782399999967,
+          "semanticPassRate": 1
+        },
+        "warmMedianSpeedupTsOverRust": 28.97923138585166,
+        "warmP95RustOverTs": 0.04271094511817967,
+        "blockers": []
+      },
+      "semantic": {
+        "comparable": true,
+        "exactPersistentWarmDigestAgreement": false,
+        "note": "Capability-first gate: successful task outcome required. Exact digest agreement is reported but not always mandatory across engines."
+      },
+      "rawDir": "verification/perf/raw/2026-07-24T18-45-00-324Z-fe92ac",
+      "runId": "2026-07-24T18-45-00-324Z-fe92ac",
+      "blockers": [],
+      "candidateSha": "d776216de990be4795d26ef91b8164f611b9505b",
+      "binaries": {
+        "rustBinary": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/benchmark-artifacts/same-host-ab/per-fixture/rust-registry-install/node_modules/@sylphx/pdf-reader-mcp-linux-x64-gnu/bin/pdf-reader-mcp-server",
+        "rustSha256": "aa0ea9c28b738311e9bc4690fc9a7a6e883ced9be00e85ec112c6e6f7814a03b",
+        "rustSizeBytes": 25472568,
+        "typescriptEntry": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/benchmark-artifacts/same-host-ab/per-fixture/ts-lkg-install/node_modules/@sylphx/pdf-reader-mcp/dist/index.js",
+        "typescriptPackageVersion": "3.0.14",
+        "rustFromRegistry": true
+      },
+      "host": {
+        "platform": "linux",
+        "release": "6.18.18-talos",
+        "arch": "x64",
+        "node": "v24.3.0",
+        "cpuModel": "AMD EPYC 9454 48-Core Processor",
+        "cpuCount": 96,
+        "totalMemBytes": 269914714112
+      }
+    },
+    {
+      "class": "metadata_structured",
+      "task": "read_pdf_full_text",
+      "required": true,
+      "fixture": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/test/fixtures/differential/v3014-info-collection-present-v1.pdf",
+      "exitCode": 0,
+      "status": "fixture_pass",
+      "modeStatuses": {
+        "startup_inclusive": "fixture_pass",
+        "persistent_warm": "fixture_pass"
+      },
+      "persistentWarm": {
+        "typescriptWarm": {
+          "n": 5,
+          "medianMs": 6.518035000000054,
+          "p95Ms": 12.536439999999857,
+          "meanMs": 8.057761400000071,
+          "semanticPassRate": 1
+        },
+        "rustWarm": {
+          "n": 5,
+          "medianMs": 0.6293359999999666,
+          "p95Ms": 0.7237479999998868,
+          "meanMs": 0.5875811999999314,
+          "semanticPassRate": 1
+        },
+        "warmMedianSpeedupTsOverRust": 10.357003254224136,
+        "warmP95RustOverTs": 0.05773154101163449,
+        "blockers": []
+      },
+      "startupInclusive": {
+        "typescriptWarm": {
+          "n": 5,
+          "medianMs": 280.07261600000004,
+          "p95Ms": 289.474776,
+          "meanMs": 281.22922619999997,
+          "semanticPassRate": 1
+        },
+        "rustWarm": {
+          "n": 5,
+          "medianMs": 6.815451999999823,
+          "p95Ms": 7.811639000000014,
+          "meanMs": 6.650013599999977,
+          "semanticPassRate": 1
+        },
+        "warmMedianSpeedupTsOverRust": 41.09376986295367,
+        "warmP95RustOverTs": 0.026985560220279824,
+        "blockers": []
+      },
+      "semantic": {
+        "comparable": true,
+        "exactPersistentWarmDigestAgreement": false,
+        "note": "Capability-first gate: successful task outcome required. Exact digest agreement is reported but not always mandatory across engines."
+      },
+      "rawDir": "verification/perf/raw/2026-07-24T18-45-02-592Z-ea20a5",
+      "runId": "2026-07-24T18-45-02-592Z-ea20a5",
+      "blockers": [],
+      "candidateSha": "d776216de990be4795d26ef91b8164f611b9505b",
+      "binaries": {
+        "rustBinary": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/benchmark-artifacts/same-host-ab/per-fixture/rust-registry-install/node_modules/@sylphx/pdf-reader-mcp-linux-x64-gnu/bin/pdf-reader-mcp-server",
+        "rustSha256": "aa0ea9c28b738311e9bc4690fc9a7a6e883ced9be00e85ec112c6e6f7814a03b",
+        "rustSizeBytes": 25472568,
+        "typescriptEntry": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/benchmark-artifacts/same-host-ab/per-fixture/ts-lkg-install/node_modules/@sylphx/pdf-reader-mcp/dist/index.js",
+        "typescriptPackageVersion": "3.0.14",
+        "rustFromRegistry": true
+      },
+      "host": {
+        "platform": "linux",
+        "release": "6.18.18-talos",
+        "arch": "x64",
+        "node": "v24.3.0",
+        "cpuModel": "AMD EPYC 9454 48-Core Processor",
+        "cpuCount": 96,
+        "totalMemBytes": 269914714112
+      }
+    },
+    {
+      "class": "text_segmentation",
+      "task": "read_pdf_full_text",
+      "required": true,
+      "fixture": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/test/fixtures/differential/v3014-selectable-text-segmentation-v1.pdf",
+      "exitCode": 0,
+      "status": "fixture_pass",
+      "modeStatuses": {
+        "startup_inclusive": "fixture_pass",
+        "persistent_warm": "fixture_pass"
+      },
+      "persistentWarm": {
+        "typescriptWarm": {
+          "n": 5,
+          "medianMs": 4.03602600000022,
+          "p95Ms": 9.0708410000002,
+          "meanMs": 5.151295399999981,
+          "semanticPassRate": 1
+        },
+        "rustWarm": {
+          "n": 5,
+          "medianMs": 1.8067449999998644,
+          "p95Ms": 3.181250000000091,
+          "meanMs": 2.0400495999999295,
+          "semanticPassRate": 1
+        },
+        "warmMedianSpeedupTsOverRust": 2.23386587481937,
+        "warmP95RustOverTs": 0.35071169255419876,
+        "blockers": []
+      },
+      "startupInclusive": {
+        "typescriptWarm": {
+          "n": 5,
+          "medianMs": 271.164981,
+          "p95Ms": 301.7925660000001,
+          "meanMs": 276.3678408,
+          "semanticPassRate": 1
+        },
+        "rustWarm": {
+          "n": 5,
+          "medianMs": 8.965643999999884,
+          "p95Ms": 11.58471899999995,
+          "meanMs": 9.446239599999933,
+          "semanticPassRate": 1
+        },
+        "warmMedianSpeedupTsOverRust": 30.244897187530928,
+        "warmP95RustOverTs": 0.03838636303586069,
+        "blockers": []
+      },
+      "semantic": {
+        "comparable": true,
+        "exactPersistentWarmDigestAgreement": false,
+        "note": "Capability-first gate: successful task outcome required. Exact digest agreement is reported but not always mandatory across engines."
+      },
+      "rawDir": "verification/perf/raw/2026-07-24T18-45-04-773Z-6277cc",
+      "runId": "2026-07-24T18-45-04-773Z-6277cc",
+      "blockers": [],
+      "candidateSha": "d776216de990be4795d26ef91b8164f611b9505b",
+      "binaries": {
+        "rustBinary": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/benchmark-artifacts/same-host-ab/per-fixture/rust-registry-install/node_modules/@sylphx/pdf-reader-mcp-linux-x64-gnu/bin/pdf-reader-mcp-server",
+        "rustSha256": "aa0ea9c28b738311e9bc4690fc9a7a6e883ced9be00e85ec112c6e6f7814a03b",
+        "rustSizeBytes": 25472568,
+        "typescriptEntry": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/benchmark-artifacts/same-host-ab/per-fixture/ts-lkg-install/node_modules/@sylphx/pdf-reader-mcp/dist/index.js",
+        "typescriptPackageVersion": "3.0.14",
+        "rustFromRegistry": true
+      },
+      "host": {
+        "platform": "linux",
+        "release": "6.18.18-talos",
+        "arch": "x64",
+        "node": "v24.3.0",
+        "cpuModel": "AMD EPYC 9454 48-Core Processor",
+        "cpuCount": 96,
+        "totalMemBytes": 269914714112
+      }
+    },
+    {
+      "class": "behavior_baseline",
+      "task": "read_pdf_full_text",
+      "required": true,
+      "fixture": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/test/fixtures/differential/v3014-behavior-v1.pdf",
+      "exitCode": 0,
+      "status": "measured_draft_not_admissible",
+      "modeStatuses": {
+        "startup_inclusive": "fixture_pass",
+        "persistent_warm": "measured_draft_not_admissible"
+      },
+      "persistentWarm": {
+        "typescriptWarm": {
+          "n": 5,
+          "medianMs": 9.462659999999687,
+          "p95Ms": 12.289058000000296,
+          "meanMs": 9.491335600000003,
+          "semanticPassRate": 1
+        },
+        "rustWarm": {
+          "n": 5,
+          "medianMs": 15.245840999999928,
+          "p95Ms": 15.50045399999999,
+          "meanMs": 14.891614799999934,
+          "semanticPassRate": 1
+        },
+        "warmMedianSpeedupTsOverRust": 0.6206715654452734,
+        "warmP95RustOverTs": 1.261321575665085,
+        "blockers": [
+          "persistent_warm: speedup 0.6206715654452734 < 1.5",
+          "persistent_warm: p95 regression ratio 1.261321575665085 > 1.15"
+        ]
+      },
+      "startupInclusive": {
+        "typescriptWarm": {
+          "n": 5,
+          "medianMs": 285.975116,
+          "p95Ms": 317.6507080000001,
+          "meanMs": 292.0308288,
+          "semanticPassRate": 1
+        },
+        "rustWarm": {
+          "n": 5,
+          "medianMs": 14.494993000000022,
+          "p95Ms": 17.42874199999983,
+          "meanMs": 15.210744199999988,
+          "semanticPassRate": 1
+        },
+        "warmMedianSpeedupTsOverRust": 19.729234501872444,
+        "warmP95RustOverTs": 0.0548676315243718,
+        "blockers": []
+      },
+      "semantic": {
+        "comparable": true,
+        "exactPersistentWarmDigestAgreement": false,
+        "note": "Capability-first gate: successful task outcome required. Exact digest agreement is reported but not always mandatory across engines."
+      },
+      "rawDir": "verification/perf/raw/2026-07-24T18-45-06-935Z-d7f8f0",
+      "runId": "2026-07-24T18-45-06-935Z-d7f8f0",
+      "blockers": [
+        "persistent_warm: speedup 0.6206715654452734 < 1.5",
+        "persistent_warm: p95 regression ratio 1.261321575665085 > 1.15"
+      ],
+      "candidateSha": "d776216de990be4795d26ef91b8164f611b9505b",
+      "binaries": {
+        "rustBinary": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/benchmark-artifacts/same-host-ab/per-fixture/rust-registry-install/node_modules/@sylphx/pdf-reader-mcp-linux-x64-gnu/bin/pdf-reader-mcp-server",
+        "rustSha256": "aa0ea9c28b738311e9bc4690fc9a7a6e883ced9be00e85ec112c6e6f7814a03b",
+        "rustSizeBytes": 25472568,
+        "typescriptEntry": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/benchmark-artifacts/same-host-ab/per-fixture/ts-lkg-install/node_modules/@sylphx/pdf-reader-mcp/dist/index.js",
+        "typescriptPackageVersion": "3.0.14",
+        "rustFromRegistry": true
+      },
+      "host": {
+        "platform": "linux",
+        "release": "6.18.18-talos",
+        "arch": "x64",
+        "node": "v24.3.0",
+        "cpuModel": "AMD EPYC 9454 48-Core Processor",
+        "cpuCount": 96,
+        "totalMemBytes": 269914714112
+      }
+    },
+    {
+      "class": "hostile_table_bound",
+      "task": "read_pdf_tables",
+      "required": true,
+      "fixture": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/test/fixtures/differential/v3014-selectable-table-hostile-4097-v1.pdf",
+      "exitCode": 0,
+      "status": "measured_draft_not_admissible",
+      "modeStatuses": {
+        "startup_inclusive": "fixture_pass",
+        "persistent_warm": "measured_draft_not_admissible"
+      },
+      "persistentWarm": {
+        "typescriptWarm": {
+          "n": 5,
+          "medianMs": 44.49931300000026,
+          "p95Ms": 78.49621200000001,
+          "meanMs": 50.79817420000008,
+          "semanticPassRate": 1
+        },
+        "rustWarm": {
+          "n": 5,
+          "medianMs": 36.661794999999984,
+          "p95Ms": 65.03545399999985,
+          "meanMs": 43.82015199999987,
+          "semanticPassRate": 1
+        },
+        "warmMedianSpeedupTsOverRust": 1.2137788943503796,
+        "warmP95RustOverTs": 0.8285171009271102,
+        "blockers": [
+          "persistent_warm: speedup 1.2137788943503796 < 1.5"
+        ]
+      },
+      "startupInclusive": {
+        "typescriptWarm": {
+          "n": 5,
+          "medianMs": 349.89673600000015,
+          "p95Ms": 359.783594,
+          "meanMs": 350.605463,
+          "semanticPassRate": 1
+        },
+        "rustWarm": {
+          "n": 5,
+          "medianMs": 54.7763359999999,
+          "p95Ms": 82.55818600000003,
+          "meanMs": 60.3574373999999,
+          "semanticPassRate": 1
+        },
+        "warmMedianSpeedupTsOverRust": 6.387735316944178,
+        "warmP95RustOverTs": 0.22946623297114552,
+        "blockers": []
+      },
+      "semantic": {
+        "comparable": true,
+        "exactPersistentWarmDigestAgreement": false,
+        "note": "Capability-first gate: successful task outcome required. Exact digest agreement is reported but not always mandatory across engines."
+      },
+      "rawDir": "verification/perf/raw/2026-07-24T18-45-09-324Z-f65a0f",
+      "runId": "2026-07-24T18-45-09-324Z-f65a0f",
+      "blockers": [
+        "persistent_warm: speedup 1.2137788943503796 < 1.5"
+      ],
+      "candidateSha": "d776216de990be4795d26ef91b8164f611b9505b",
+      "binaries": {
+        "rustBinary": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/benchmark-artifacts/same-host-ab/per-fixture/rust-registry-install/node_modules/@sylphx/pdf-reader-mcp-linux-x64-gnu/bin/pdf-reader-mcp-server",
+        "rustSha256": "aa0ea9c28b738311e9bc4690fc9a7a6e883ced9be00e85ec112c6e6f7814a03b",
+        "rustSizeBytes": 25472568,
+        "typescriptEntry": "/home/codex/src/github.com/SylphxAI/pdf-reader-mcp/benchmark-artifacts/same-host-ab/per-fixture/ts-lkg-install/node_modules/@sylphx/pdf-reader-mcp/dist/index.js",
+        "typescriptPackageVersion": "3.0.14",
+        "rustFromRegistry": true
+      },
+      "host": {
+        "platform": "linux",
+        "release": "6.18.18-talos",
+        "arch": "x64",
+        "node": "v24.3.0",
+        "cpuModel": "AMD EPYC 9454 48-Core Processor",
+        "cpuCount": 96,
+        "totalMemBytes": 269914714112
+      }
+    }
+  ],
+  "blockers": [
+    "required persistent_warm fixture_pass 4/8",
+    "min persistent_warm speedup 0.6206715654452734 < 1.5"
+  ],
+  "claimPolicy": "Suite admissible_pass requires persistent_warm fixture_pass on all required classes. startup_inclusive numbers are diagnostic only and must be labeled spawn+initialize+task. Marketing still needs independent performanceClaimsAuthorized=true."
+}


### PR DESCRIPTION
## Summary
Prepares the **4.1 product performance** path without premature publish:

- Before/after acquisition SVG + Product Proof guide page
- Demo index under `examples/demo/`
- Minor **changeset** for `@sylphx/pdf-reader-mcp` → 4.1.0 when versioned
- Registry-bound **4.0.2 baseline** suite: `measured_draft_not_admissible` (no warm cache in published binary)
- Restores local warm-cache draft suite as the engineering target (`admissible_pass`)

## Truth table
| Binary | Suite | Warm min |
|---|---|---|
| npm 4.0.2 registry | not admissible | ~0.62× |
| main + warm cache (local) | admissible_pass draft | ≥ ~10× |

## Non-goals
- Does **not** publish npm
- Does **not** set `performanceClaimsAuthorized=true`
- Keeps live production on **4.0.2** until 4.1 is admitted

## Next after merge
1. Release workflow versions 4.1.0
2. Independent exact-SHA review
3. publish-npm natives with strip profile + warm cache
4. Registry-bound suite on exact 4.1.0
5. Authorize bounded claims only if review passes