### PR TITLE
fix(schema): OpenCode/Fireworks path|url schema compatibility (#562)

### DIFF
--- a/crates/pdf-reader-mcp-server/src/lib.rs
+++ b/crates/pdf-reader-mcp-server/src/lib.rs
@@ -332,10 +332,17 @@ mod tests {
             }
         }
 
+        // Provider-compat (#562): tools/list must not advertise exclusive path|url
+        // via oneOf + not/required — Fireworks/OpenCode reject that keyword shape.
+        // Runtime still enforces exactly-one-of via PdfSource::validate().
         let read_json = tool_schema("read_pdf").to_string();
         assert!(
-            read_json.contains("\"oneOf\""),
-            "source locator XOR must be machine-readable"
+            !read_json.contains("\"not\""),
+            "read_pdf inputSchema must not use JSON Schema not for path|url XOR (OpenCode/Fireworks)"
+        );
+        assert!(
+            !read_json.contains("\"oneOf\""),
+            "read_pdf inputSchema must not use oneOf for path|url XOR after #562"
         );
     }
 

--- a/crates/pdf-reader-mcp-server/src/schema.rs
+++ b/crates/pdf-reader-mcp-server/src/schema.rs
@@ -32,20 +32,21 @@ impl PageSpecifier {
     }
 }
 
+// Client-visible tools/list schema intentionally omits oneOf/not exclusive
+// constructs: OpenCode + Fireworks (and similar strict tool-schema validators)
+// reject `{"required":["path"],"not":{"required":["url"]}}` (issue #562).
+// Exactly-one-of path|url remains a hard runtime contract via `validate()`.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
-#[schemars(extend(
-    "oneOf" = [
-        {"required": ["path"], "not": {"required": ["url"]}},
-        {"required": ["url"], "not": {"required": ["path"]}}
-    ]
-))]
 pub struct PdfSource {
     #[schemars(
         length(min = 1),
-        description = "Path to the local PDF file (absolute or relative to cwd)."
+        description = "Path to the local PDF file (absolute or relative to cwd). Provide exactly one of path or url (not both)."
     )]
     pub path: Option<String>,
-    #[schemars(length(min = 1), description = "URL of the PDF file.")]
+    #[schemars(
+        length(min = 1),
+        description = "URL of the PDF file. Provide exactly one of path or url (not both)."
+    )]
     pub url: Option<String>,
     pub pages: Option<PageSpecifier>,
 }
@@ -237,17 +238,19 @@ impl PdfEvidenceRegion {
     }
 }
 
+// Same provider-compat policy as PdfSource (#562): no oneOf/not in tools/list;
+// exclusive path|url enforced at runtime by validate()/as_pdf_source().
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
-#[schemars(extend(
-    "oneOf" = [
-        {"required": ["path"], "not": {"required": ["url"]}},
-        {"required": ["url"], "not": {"required": ["path"]}}
-    ]
-))]
 pub struct PdfEvidenceSource {
-    #[schemars(length(min = 1))]
+    #[schemars(
+        length(min = 1),
+        description = "Path to the local PDF file. Provide exactly one of path or url (not both)."
+    )]
     pub path: Option<String>,
-    #[schemars(length(min = 1))]
+    #[schemars(
+        length(min = 1),
+        description = "URL of the PDF file. Provide exactly one of path or url (not both)."
+    )]
     pub url: Option<String>,
     pub pages: Option<PageSpecifier>,
     pub regions: Option<Vec<PdfEvidenceRegion>>,
@@ -412,5 +415,58 @@ mod tests {
             let actual = accepts(tool, case["args"].clone());
             assert_eq!(actual, expected, "v3.0.14 contract case {id}");
         }
+    }
+}
+
+
+#[cfg(test)]
+mod provider_schema_compat_tests {
+    use super::*;
+    use schemars::schema_for;
+
+    #[test]
+    fn pdf_source_schema_omits_not_required_xor() {
+        let schema = schema_for!(PdfSource);
+        let json = serde_json::to_string(&schema).expect("serialize schema");
+        assert!(
+            !json.contains("\"not\""),
+            "PdfSource tools/list schema must not emit not/required XOR for provider compat (#562): {json}"
+        );
+        assert!(
+            !json.contains("\"oneOf\""),
+            "PdfSource tools/list schema must not emit oneOf XOR for provider compat (#562): {json}"
+        );
+    }
+
+    #[test]
+    fn pdf_source_runtime_still_enforces_exactly_one_locator() {
+        assert!(PdfSource {
+            path: Some("a.pdf".into()),
+            url: None,
+            pages: None,
+        }
+        .validate()
+        .is_ok());
+        assert!(PdfSource {
+            path: None,
+            url: Some("https://example.com/a.pdf".into()),
+            pages: None,
+        }
+        .validate()
+        .is_ok());
+        assert!(PdfSource {
+            path: None,
+            url: None,
+            pages: None,
+        }
+        .validate()
+        .is_err());
+        assert!(PdfSource {
+            path: Some("a.pdf".into()),
+            url: Some("https://example.com/a.pdf".into()),
+            pages: None,
+        }
+        .validate()
+        .is_err());
     }
 }

--- a/docs/evidence/2026-07-24-opencode-schema-compat-562.md
+++ b/docs/evidence/2026-07-24-opencode-schema-compat-562.md
@@ -1,0 +1,26 @@
+# Evidence: OpenCode / Fireworks tool-schema compatibility (#562)
+
+## Problem
+Published MCP `tools/list` inputSchema for PDF sources used:
+
+```json
+"oneOf": [
+  {"required": ["path"], "not": {"required": ["url"]}},
+  {"required": ["url"], "not": {"required": ["path"]}}
+]
+```
+
+Fireworks (via OpenCode + Kimi) rejects:
+
+> JSON Schema not supported: could not understand the instance
+> `{'not': {'required': ['url']}, 'required': ['path']}`
+
+## Fix
+- Remove client-visible `oneOf`/`not` exclusive constructs from `PdfSource` and
+  `PdfEvidenceSource` schemars annotations.
+- Keep hard runtime validation: exactly one of `path` or `url`.
+- Document the exclusive locator requirement in field descriptions.
+
+## Non-goals
+- Do not weaken path|url security policy.
+- Do not archive/delete the issue; reopen and fix.

--- a/src/schemas/pdfEvidence.ts
+++ b/src/schemas/pdfEvidence.ts
@@ -27,9 +27,14 @@ export const pdfEvidenceOperationSchema = union(
 
 export const pdfEvidenceSourceSchema = object({
   path: optional(
-    str(min(1), description('Path to the local PDF file. Provide exactly one of path or url (not both).'))
+    str(
+      min(1),
+      description('Path to the local PDF file. Provide exactly one of path or url (not both).')
+    )
   ),
-  url: optional(str(min(1), description('URL of the PDF file. Provide exactly one of path or url (not both).'))),
+  url: optional(
+    str(min(1), description('URL of the PDF file. Provide exactly one of path or url (not both).'))
+  ),
   pages: optional(pageSpecifierSchema),
   regions: optional(
     array(

--- a/src/schemas/pdfEvidence.ts
+++ b/src/schemas/pdfEvidence.ts
@@ -27,9 +27,9 @@ export const pdfEvidenceOperationSchema = union(
 
 export const pdfEvidenceSourceSchema = object({
   path: optional(
-    str(min(1), description('Path to the local PDF file (absolute or relative to cwd).'))
+    str(min(1), description('Path to the local PDF file. Provide exactly one of path or url (not both).'))
   ),
-  url: optional(str(min(1), description('URL of the PDF file.'))),
+  url: optional(str(min(1), description('URL of the PDF file. Provide exactly one of path or url (not both).'))),
   pages: optional(pageSpecifierSchema),
   regions: optional(
     array(

--- a/src/schemas/readPdf.ts
+++ b/src/schemas/readPdf.ts
@@ -26,9 +26,9 @@ export const readPdfAutoDetailSchema = union(literal('fast'), literal('balanced'
 // cannot be bypassed by ambiguous path+URL payloads.
 export const pdfSourceSchema = object({
   path: optional(
-    str(min(1), description('Path to the local PDF file (absolute or relative to cwd).'))
+    str(min(1), description('Path to the local PDF file (absolute or relative to cwd). Provide exactly one of path or url (not both).'))
   ),
-  url: optional(str(min(1), description('URL of the PDF file.'))),
+  url: optional(str(min(1), description('URL of the PDF file. Provide exactly one of path or url (not both).'))),
   pages: optional(pageSpecifierSchema),
 }).refine((source) => Boolean(source.path) !== Boolean(source.url), {
   message: 'Provide exactly one of path or url for each PDF source.',

--- a/src/schemas/readPdf.ts
+++ b/src/schemas/readPdf.ts
@@ -26,9 +26,16 @@ export const readPdfAutoDetailSchema = union(literal('fast'), literal('balanced'
 // cannot be bypassed by ambiguous path+URL payloads.
 export const pdfSourceSchema = object({
   path: optional(
-    str(min(1), description('Path to the local PDF file (absolute or relative to cwd). Provide exactly one of path or url (not both).'))
+    str(
+      min(1),
+      description(
+        'Path to the local PDF file (absolute or relative to cwd). Provide exactly one of path or url (not both).'
+      )
+    )
   ),
-  url: optional(str(min(1), description('URL of the PDF file. Provide exactly one of path or url (not both).'))),
+  url: optional(
+    str(min(1), description('URL of the PDF file. Provide exactly one of path or url (not both).'))
+  ),
   pages: optional(pageSpecifierSchema),
 }).refine((source) => Boolean(source.path) !== Boolean(source.url), {
   message: 'Provide exactly one of path or url for each PDF source.',


### PR DESCRIPTION
## Summary
- Fixes [#562](https://github.com/SylphxAI/pdf-reader-mcp/issues/562): OpenCode + Fireworks reject the published MCP `inputSchema` when path|url exclusivity is advertised as `oneOf` + `not`/`required`.
- Removes those constructs from `PdfSource` / `PdfEvidenceSource` schemars annotations.
- Keeps hard runtime validation: exactly one of `path` or `url`.
- Documents the exclusive locator requirement in field descriptions; adds unit tests and an evidence note.

## Test plan
- [x] Unit tests: schema omits `not`/`oneOf`; runtime still rejects 0/2 locators
- [ ] CI: package / parity checks
- [ ] After release: OpenCode + Fireworks/Kimi can list/call `read_pdf` without a schema parse error

## Evidence
- `docs/evidence/2026-07-24-opencode-schema-compat-562.md`