### PR TITLE
fix(security): bump rmcp to 1.8.0 (DNS rebinding / Dependabot #17)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1647,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.4.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
 dependencies = [
  "async-trait",
  "base64",
@@ -1705,7 +1705,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2012,10 +2012,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1647,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.16.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c9c94680f75470ee8083a0667988b5d7b5beb70b9f998a8e51de7c682ce60"
+checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
 dependencies = [
  "async-trait",
  "base64",
@@ -1678,9 +1678,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.16.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c23c8f26cae4da838fbc3eadfaecf2d549d97c04b558e7bd90526a9c28b42a"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1705,7 +1705,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2012,10 +2012,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/pdf-reader-mcp-server/Cargo.toml
+++ b/crates/pdf-reader-mcp-server/Cargo.toml
@@ -25,7 +25,7 @@ base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 command-group = { version = "5", features = ["with-tokio"] }
 pdf-reader-core = { path = "../pdf-reader-core", version = "3.1.1" }
-rmcp = { version = "1.4.0", features = ["server", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "1.8.0", features = ["server", "macros", "schemars", "transport-io", "transport-streamable-http-server"] }
 schemars = { version = "1", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/pdf-reader-mcp-server/Cargo.toml
+++ b/crates/pdf-reader-mcp-server/Cargo.toml
@@ -25,7 +25,7 @@ base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 command-group = { version = "5", features = ["with-tokio"] }
 pdf-reader-core = { path = "../pdf-reader-core", version = "3.1.1" }
-rmcp = { version = "0.16.0", features = ["server", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "1.4.0", features = ["server", "transport-io", "transport-streamable-http-server"] }
 schemars = { version = "1", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/pdf-reader-mcp-server/src/http_transport.rs
+++ b/crates/pdf-reader-mcp-server/src/http_transport.rs
@@ -229,11 +229,9 @@ pub async fn serve_http(config: HttpConfig) -> anyhow::Result<()> {
     let mcp_service = StreamableHttpService::new(
         || Ok(PdfReaderMcp::new()),
         LocalSessionManager::default().into(),
-        StreamableHttpServerConfig {
-            cancellation_token: cancellation.child_token(),
-            allowed_hosts: shared_config.allowed_hosts(),
-            ..Default::default()
-        },
+        StreamableHttpServerConfig::default()
+            .with_cancellation_token(cancellation.child_token())
+            .with_allowed_hosts(shared_config.allowed_hosts()),
     );
 
     let mcp_router = Router::new()

--- a/crates/pdf-reader-mcp-server/src/http_transport.rs
+++ b/crates/pdf-reader-mcp-server/src/http_transport.rs
@@ -75,6 +75,52 @@ impl HttpConfig {
             || self.host == "127.0.0.1"
             || self.host.starts_with("127.")
     }
+
+    /// Host authorities accepted by rmcp Streamable HTTP DNS-rebinding protection.
+    ///
+    /// Defaults: loopbacks + the configured bind host (and host:port). Override with
+    /// `MCP_ALLOWED_HOSTS` / `PDF_READER_MCP_ALLOWED_HOSTS` (comma-separated).
+    pub fn allowed_hosts(&self) -> Vec<String> {
+        if let Ok(raw) = std::env::var("MCP_ALLOWED_HOSTS")
+            .or_else(|_| std::env::var("PDF_READER_MCP_ALLOWED_HOSTS"))
+        {
+            let hosts: Vec<String> = raw
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+                .collect();
+            if !hosts.is_empty() {
+                return hosts;
+            }
+        }
+
+        let mut hosts = vec![
+            "localhost".to_string(),
+            "127.0.0.1".to_string(),
+            "::1".to_string(),
+        ];
+        if !hosts.iter().any(|host| host == &self.host) {
+            hosts.push(self.host.clone());
+        }
+        let with_port = format!("{}:{}", self.host, self.port);
+        if !hosts.iter().any(|host| host == &with_port) {
+            hosts.push(with_port);
+        }
+        if self.is_loopback_host() {
+            for extra in [
+                "0.0.0.0".to_string(),
+                format!("0.0.0.0:{}", self.port),
+                format!("localhost:{}", self.port),
+                format!("127.0.0.1:{}", self.port),
+            ] {
+                if !hosts.iter().any(|host| host == &extra) {
+                    hosts.push(extra);
+                }
+            }
+        }
+        hosts
+    }
 }
 
 pub fn transport_from_env() -> Option<&'static str> {
@@ -185,6 +231,7 @@ pub async fn serve_http(config: HttpConfig) -> anyhow::Result<()> {
         LocalSessionManager::default().into(),
         StreamableHttpServerConfig {
             cancellation_token: cancellation.child_token(),
+            allowed_hosts: shared_config.allowed_hosts(),
             ..Default::default()
         },
     );
@@ -254,5 +301,19 @@ mod tests {
         };
         assert!(config.is_loopback_host());
         assert_eq!(config.socket_addr().expect("addr").port(), 8080);
+    }
+
+    #[test]
+    fn allowed_hosts_include_bind_host_and_loopbacks() {
+        let config = HttpConfig {
+            host: "127.0.0.1".to_string(),
+            port: 8080,
+            api_key: None,
+            cors_origin: None,
+        };
+        let hosts = config.allowed_hosts();
+        assert!(hosts.iter().any(|host| host == "127.0.0.1"));
+        assert!(hosts.iter().any(|host| host == "localhost"));
+        assert!(hosts.iter().any(|host| host == "127.0.0.1:8080"));
     }
 }

--- a/crates/pdf-reader-mcp-server/src/lib.rs
+++ b/crates/pdf-reader-mcp-server/src/lib.rs
@@ -162,21 +162,15 @@ impl PdfReaderMcp {
 #[tool_handler]
 impl ServerHandler for PdfReaderMcp {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            protocol_version: rmcp::model::ProtocolVersion::default(),
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            server_info: Implementation {
-                name: SERVER_NAME.into(),
-                title: None,
-                version: SERVER_VERSION.into(),
-                description: Some(
-                    "@sylphx/pdf-reader-mcp sole-Rust MCP server (native binary; no TypeScript PDF runtime)".into(),
-                ),
-                icons: None,
-                website_url: Some("https://sylphxai.github.io/pdf-reader-mcp/".into()),
-            },
-            instructions: Some(SERVER_INSTRUCTIONS.into()),
-        }
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(
+                Implementation::new(SERVER_NAME, SERVER_VERSION)
+                    .with_description(
+                        "@sylphx/pdf-reader-mcp sole-Rust MCP server (native binary; no TypeScript PDF runtime)",
+                    )
+                    .with_website_url("https://sylphxai.github.io/pdf-reader-mcp/"),
+            )
+            .with_instructions(SERVER_INSTRUCTIONS)
     }
 }
 

--- a/crates/pdf-reader-mcp-server/src/lib.rs
+++ b/crates/pdf-reader-mcp-server/src/lib.rs
@@ -303,20 +303,28 @@ mod tests {
                     properties.contains_key(property),
                     "post-3.0.14 {tool} must expose additive property {property}"
                 );
-                let ty = properties[property]
+                let schema = &properties[property];
+                let is_boolean = schema
                     .get("type")
-                    .and_then(|value| value.as_str())
-                    .or_else(|| {
-                        properties[property]
-                            .get("anyOf")
-                            .and_then(|value| value.as_array())
-                            .and_then(|items| {
-                                items.iter().find_map(|item| item.get("type").and_then(|t| t.as_str()))
+                    .map(|value| match value {
+                        Value::String(ty) => ty == "boolean",
+                        Value::Array(items) => items.iter().any(|item| item.as_str() == Some("boolean")),
+                        _ => false,
+                    })
+                    .unwrap_or(false)
+                    || schema
+                        .get("anyOf")
+                        .or_else(|| schema.get("oneOf"))
+                        .and_then(|value| value.as_array())
+                        .map(|items| {
+                            items.iter().any(|item| {
+                                item.get("type").and_then(|ty| ty.as_str()) == Some("boolean")
                             })
-                    });
+                        })
+                        .unwrap_or(false);
                 assert!(
-                    matches!(ty, Some("boolean")),
-                    "post-3.0.14 {tool}.{property} must be boolean-typed, got {ty:?}"
+                    is_boolean,
+                    "post-3.0.14 {tool}.{property} must be boolean-typed, got {schema}"
                 );
             } else {
                 assert!(

--- a/crates/pdf-reader-mcp-server/src/ocr_evidence.rs
+++ b/crates/pdf-reader-mcp-server/src/ocr_evidence.rs
@@ -768,11 +768,10 @@ pub(crate) fn run_read_ocr(
 
 fn text_result(payload: Value) -> CallToolResult {
     let text = serde_json::to_string_pretty(&payload).unwrap_or_else(|_| payload.to_string());
-    CallToolResult {
-        content: vec![Content::text(text)],
-        structured_content: Some(payload),
-        is_error: Some(false),
-        meta: None,
+    {
+        let mut result = CallToolResult::structured(payload);
+        result.content = vec![Content::text(text)];
+        result
     }
 }
 

--- a/crates/pdf-reader-mcp-server/src/region_analysis_evidence.rs
+++ b/crates/pdf-reader-mcp-server/src/region_analysis_evidence.rs
@@ -1082,11 +1082,10 @@ fn run_provider(
 
 fn text_result(payload: Value) -> CallToolResult {
     let text = serde_json::to_string_pretty(&payload).unwrap_or_else(|_| payload.to_string());
-    CallToolResult {
-        content: vec![Content::text(text)],
-        structured_content: Some(payload),
-        is_error: Some(false),
-        meta: None,
+    {
+        let mut result = CallToolResult::structured(payload);
+        result.content = vec![Content::text(text)];
+        result
     }
 }
 

--- a/crates/pdf-reader-mcp-server/src/schema.rs
+++ b/crates/pdf-reader-mcp-server/src/schema.rs
@@ -7,6 +7,15 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+fn option_bool_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    // Keep Option semantics (nullable) while guaranteeing a boolean type keyword for tools/list.
+    serde_json::from_value(serde_json::json!({
+        "type": ["boolean", "null"]
+    }))
+    .expect("option bool schema")
+}
+
+
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(transparent)]
 pub struct PageNumber(#[schemars(range(min = 1))] pub u32);
@@ -163,6 +172,10 @@ pub struct SearchPdfArgs {
     pub context_chars: Option<u32>,
     /// When true, match the current TS prefer_speed route: omit match geometry and
     /// emit the rust-text-index speed-route warning (ignored when OCR is enabled).
+    #[schemars(
+        description = "Prefer faster text-index search (omit match geometry; ignored when OCR is enabled).",
+        schema_with = "option_bool_schema"
+    )]
     pub prefer_speed: Option<bool>,
 }
 

--- a/crates/pdf-reader-mcp-server/src/visual_evidence.rs
+++ b/crates/pdf-reader-mcp-server/src/visual_evidence.rs
@@ -153,11 +153,10 @@ fn tool_result(payload: Value, images: Vec<ImagePart>) -> CallToolResult {
             .into_iter()
             .map(|image| Content::image(image.data, image.mime_type)),
     );
-    CallToolResult {
-        content,
-        structured_content: Some(payload),
-        is_error: Some(false),
-        meta: None,
+    {
+        let mut result = CallToolResult::structured(payload);
+        result.content = content;
+        result
     }
 }
 

--- a/docs/evidence/2026-07-24-rmcp-dns-rebind-dependabot-17.md
+++ b/docs/evidence/2026-07-24-rmcp-dns-rebind-dependabot-17.md
@@ -8,7 +8,7 @@
 - First patched: `1.4.0`
 
 ## Fix
-- Bump `rmcp` from `0.16.0` → `1.4.0` (includes Host-header validation for Streamable HTTP).
+- Bump `rmcp` from `0.16.0` → `1.8.0` (includes Host-header validation for Streamable HTTP).
 - Wire `StreamableHttpServerConfig.allowed_hosts` from bind host + loopbacks, with
   `MCP_ALLOWED_HOSTS` / `PDF_READER_MCP_ALLOWED_HOSTS` override for public deploys.
 

--- a/docs/evidence/2026-07-24-rmcp-dns-rebind-dependabot-17.md
+++ b/docs/evidence/2026-07-24-rmcp-dns-rebind-dependabot-17.md
@@ -1,0 +1,17 @@
+# Evidence: Dependabot alert #17 (rmcp DNS rebinding)
+
+## Alert
+- Package: `rmcp` (Rust), runtime via `crates/pdf-reader-mcp-server/Cargo.toml`
+- Advisory: GHSA-89vp-x53w-74fx / CVE-2026-42559
+- Severity: high
+- Vulnerable range: `< 1.4.0`
+- First patched: `1.4.0`
+
+## Fix
+- Bump `rmcp` from `0.16.0` → `1.4.0` (includes Host-header validation for Streamable HTTP).
+- Wire `StreamableHttpServerConfig.allowed_hosts` from bind host + loopbacks, with
+  `MCP_ALLOWED_HOSTS` / `PDF_READER_MCP_ALLOWED_HOSTS` override for public deploys.
+
+## Notes
+- Stdio transport is unaffected by this advisory; risk is Streamable HTTP server mode.
+- Public non-loopback binds should set allowed hosts explicitly to the public hostname.


### PR DESCRIPTION
## Summary
- Resolves [Dependabot alert #17](https://github.com/SylphxAI/pdf-reader-mcp/security/dependabot/17): **rmcp** Streamable HTTP DNS rebinding (GHSA-89vp-x53w-74fx / CVE-2026-42559, high).
- Bumps `rmcp` `0.16.0` → `1.8.0` (vulnerability patched since 1.4.0; 1.8.x needed for current tool-macro APIs).
- Configures `StreamableHttpServerConfig.allowed_hosts` from bind host + loopbacks.
- Optional override: `MCP_ALLOWED_HOSTS` / `PDF_READER_MCP_ALLOWED_HOSTS`.
- Updates non-exhaustive model construction to rmcp constructors.

## Test plan
- [ ] CI native builds / parity
- [x] Unit: `allowed_hosts_include_bind_host_and_loopbacks`
- [ ] HTTP mode on loopback still serves `/mcp` with local Host headers

## Evidence
- `docs/evidence/2026-07-24-rmcp-dns-rebind-dependabot-17.md`