### PR TITLE
docs: fence residual TS backend as non-authoritative (Work: wi_01KYFN6993PMG8WD00Q51AE231)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,3 +33,19 @@ bun test test/project-control.test.ts
 
 - Prefer the **narrowest** affected check before full workspace runs.
 - Report layers honestly: local diff · trunk FF · deploy · prod proof (do not collapse).
+
+## Backend false-authority fence
+
+Work: wi_01KYFN6993PMG8WD00Q51AE231
+
+If this repository has completed a **Rust backend** cutover:
+
+1. Production backend behavior authority is the Rust crate/binary/service path declared in `sylphx.toml` / deploy manifests / package `bin` native path / Docker ENTRYPOINT.
+2. Residual TypeScript service trees or alternate TS engines are **not** product authority unless explicitly proven still on the live path.
+3. Do not "fix production" by editing residual TypeScript and assuming deploy/runtime will pick it up.
+4. Prefer deleting residual TS backend trees after Rust sole proof; keep history in Git.
+5. Intentional TypeScript frontends, npm packaging wrappers, and native-binding surfaces may remain.
+
+### Repo-specific note
+
+Native Rust engine is product authority; npm dist/bin wrappers are packaging surface only, not alternate backend authority.


### PR DESCRIPTION
## Summary
- AGENTS false-authority fence for residual TS after Rust cutover.
- Native Rust engine is product authority; npm dist/bin wrappers are packaging surface only, not alternate backend authority.

Work: wi_01KYFN6993PMG8WD00Q51AE231

## Test plan
- [ ] Docs-only
