### PR TITLE
fix(mcp): answer server/discover before initialize (#598)

### DIFF
--- a/.changeset/fix-server-discover-preinit.md
+++ b/.changeset/fix-server-discover-preinit.md
@@ -1,0 +1,5 @@
+---
+"@sylphx/pdf-reader-mcp": patch
+---
+
+Fix Gemini Antigravity / dual-era MCP clients that send `server/discover` before `initialize`: answer SEP-2575 discovery without closing stdio, then complete the legacy handshake (fixes #598).

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ claude mcp add pdf-reader -- npx @sylphx/pdf-reader-mcp
 }
 ```
 
+Dual-era hosts that send `server/discover` before `initialize` (e.g. Gemini Antigravity CLI) are supported on stdio — the server answers discovery and keeps the session open for the legacy handshake.
+
 **Stdio / HTTP**
 
 ```bash

--- a/crates/pdf-reader-mcp-server/src/discover_compat.rs
+++ b/crates/pdf-reader-mcp-server/src/discover_compat.rs
@@ -1,0 +1,190 @@
+//! MCP `server/discover` (SEP-2575) compatibility for dual-era clients.
+//!
+//! Modern MCP clients (including Gemini Antigravity CLI) probe with
+//! `server/discover` *before* the legacy `initialize` handshake. rmcp 1.8.0 only
+//! tolerates `ping` in that pre-init window and otherwise aborts the transport
+//! (`expect initialized request`), which surfaces as EOF to the client.
+//!
+//! This module:
+//! 1. builds a draft-shaped DiscoverResult from our ServerInfo
+//! 2. wraps any RoleServer transport so pre-init `server/discover` is answered
+//!    without killing the connection, then `initialize` can proceed
+
+use std::borrow::Cow;
+use std::future::Future;
+use std::sync::Arc;
+
+use rmcp::model::{
+    ClientJsonRpcMessage, ClientRequest, CustomRequest, CustomResult, ProtocolVersion,
+    ServerJsonRpcMessage, ServerResult, ServerInfo,
+};
+use rmcp::service::RoleServer;
+use rmcp::transport::Transport;
+use serde_json::{json, Value};
+
+/// Canonical MCP method name for SEP-2575 discovery.
+pub const SERVER_DISCOVER_METHOD: &str = "server/discover";
+
+const SERVER_INFO_META_KEY: &str = "io.modelcontextprotocol/serverInfo";
+
+/// Build a draft-shaped `server/discover` result from the server's initialize identity.
+///
+/// Shape follows
+/// <https://modelcontextprotocol.io/specification/draft/server/discover>:
+/// `resultType`, `supportedVersions`, `capabilities`, `_meta.serverInfo`,
+/// `instructions`.
+pub fn discover_result_value(info: &ServerInfo) -> Value {
+    let supported_versions: Vec<String> = ProtocolVersion::KNOWN_VERSIONS
+        .iter()
+        .map(|version| version.as_str().to_string())
+        .collect();
+
+    let mut server_info = json!({
+        "name": info.server_info.name,
+        "version": info.server_info.version,
+    });
+    if let Some(title) = &info.server_info.title {
+        server_info["title"] = json!(title);
+    }
+    if let Some(description) = &info.server_info.description {
+        server_info["description"] = json!(description);
+    }
+    if let Some(website_url) = &info.server_info.website_url {
+        server_info["websiteUrl"] = json!(website_url);
+    }
+
+    let mut result = json!({
+        "resultType": "complete",
+        "supportedVersions": supported_versions,
+        "capabilities": info.capabilities,
+        "_meta": {
+            SERVER_INFO_META_KEY: server_info,
+        },
+    });
+
+    if let Some(instructions) = &info.instructions {
+        result["instructions"] = json!(instructions);
+    }
+
+    result
+}
+
+/// True when the client request is SEP-2575 `server/discover`.
+pub fn is_server_discover_request(request: &ClientRequest) -> bool {
+    matches!(
+        request,
+        ClientRequest::CustomRequest(CustomRequest { method, .. })
+            if method == SERVER_DISCOVER_METHOD
+    )
+}
+
+/// Transport wrapper that answers pre-init `server/discover` and keeps the
+/// connection open for the subsequent legacy `initialize` handshake.
+pub struct DiscoverAwareTransport<T> {
+    inner: T,
+    discover_result: Arc<Value>,
+}
+
+impl<T> DiscoverAwareTransport<T> {
+    pub fn new(inner: T, discover_result: Value) -> Self {
+        Self {
+            inner,
+            discover_result: Arc::new(discover_result),
+        }
+    }
+}
+
+impl<T> Transport<RoleServer> for DiscoverAwareTransport<T>
+where
+    T: Transport<RoleServer> + 'static,
+{
+    type Error = T::Error;
+
+    fn name() -> Cow<'static, str> {
+        Cow::Borrowed("discover-aware-transport")
+    }
+
+    fn send(
+        &mut self,
+        item: ServerJsonRpcMessage,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static {
+        self.inner.send(item)
+    }
+
+    fn receive(&mut self) -> impl Future<Output = Option<ClientJsonRpcMessage>> + Send {
+        async {
+            loop {
+                let message = self.inner.receive().await?;
+                let ClientJsonRpcMessage::Request(request) = &message else {
+                    return Some(message);
+                };
+
+                if !is_server_discover_request(&request.request) {
+                    return Some(message);
+                }
+
+                let response = ServerJsonRpcMessage::response(
+                    ServerResult::CustomResult(CustomResult::new(
+                        self.discover_result.as_ref().clone(),
+                    )),
+                    request.id.clone(),
+                );
+
+                if self.inner.send(response).await.is_err() {
+                    return None;
+                }
+                // Answer discover and wait for the next client message (usually initialize).
+            }
+        }
+    }
+
+    fn close(&mut self) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.close()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::model::{Implementation, ServerCapabilities};
+
+    fn sample_info() -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(
+                Implementation::new("pdf-reader-mcp", "4.1.1")
+                    .with_description("test description")
+                    .with_website_url("https://example.test/"),
+            )
+            .with_instructions("test instructions")
+    }
+
+    #[test]
+    fn discover_result_includes_required_fields() {
+        let value = discover_result_value(&sample_info());
+        assert_eq!(value["resultType"], "complete");
+        assert!(value["supportedVersions"]
+            .as_array()
+            .expect("supportedVersions array")
+            .iter()
+            .any(|v| v.as_str() == Some("2026-07-28")));
+        assert!(value["capabilities"]["tools"].is_object());
+        assert_eq!(
+            value["_meta"][SERVER_INFO_META_KEY]["name"],
+            "pdf-reader-mcp"
+        );
+        assert_eq!(value["_meta"][SERVER_INFO_META_KEY]["version"], "4.1.1");
+        assert_eq!(value["instructions"], "test instructions");
+    }
+
+    #[test]
+    fn is_server_discover_matches_method_only() {
+        let discover = ClientRequest::CustomRequest(CustomRequest::new(
+            SERVER_DISCOVER_METHOD,
+            Some(json!({})),
+        ));
+        let other =
+            ClientRequest::CustomRequest(CustomRequest::new("tools/list", Some(json!({}))));
+        assert!(is_server_discover_request(&discover));
+        assert!(!is_server_discover_request(&other));
+    }
+}

--- a/crates/pdf-reader-mcp-server/src/lib.rs
+++ b/crates/pdf-reader-mcp-server/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli_bridge;
+pub mod discover_compat;
 mod command_provider;
 pub mod evidence;
 pub mod http_transport;
@@ -15,7 +16,8 @@ mod visual_evidence;
 use rmcp::{
     handler::server::router::tool::ToolRouter,
     handler::server::wrapper::Parameters,
-    model::{Implementation, ServerCapabilities, ServerInfo},
+    model::{CustomRequest, CustomResult, Implementation, ServerCapabilities, ServerInfo},
+    service::{RequestContext, RoleServer},
     tool, tool_handler, tool_router, ErrorData, ServerHandler,
 };
 
@@ -171,6 +173,27 @@ impl ServerHandler for PdfReaderMcp {
                     .with_website_url("https://sylphxai.github.io/pdf-reader-mcp/"),
             )
             .with_instructions(SERVER_INSTRUCTIONS)
+    }
+
+    /// Post-init `server/discover` (SEP-2575). Pre-init is handled by
+    /// [`discover_compat::DiscoverAwareTransport`].
+    fn on_custom_request(
+        &self,
+        request: CustomRequest,
+        _context: RequestContext<RoleServer>,
+    ) -> impl std::future::Future<Output = Result<CustomResult, ErrorData>> + Send + '_ {
+        async move {
+            if request.method == discover_compat::SERVER_DISCOVER_METHOD {
+                return Ok(CustomResult::new(discover_compat::discover_result_value(
+                    &self.get_info(),
+                )));
+            }
+            Err(ErrorData::new(
+                rmcp::model::ErrorCode::METHOD_NOT_FOUND,
+                request.method,
+                None,
+            ))
+        }
     }
 }
 

--- a/crates/pdf-reader-mcp-server/src/main.rs
+++ b/crates/pdf-reader-mcp-server/src/main.rs
@@ -1,5 +1,8 @@
-use pdf_reader_mcp_server::{cli_bridge, http_transport, PdfReaderMcp, SERVER_VERSION};
-use rmcp::ServiceExt;
+use pdf_reader_mcp_server::{
+    cli_bridge, discover_compat, http_transport, PdfReaderMcp, SERVER_VERSION,
+};
+use rmcp::transport::async_rw::AsyncRwTransport;
+use rmcp::{ServerHandler, ServiceExt};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -20,7 +23,14 @@ async fn main() -> anyhow::Result<()> {
         return http_transport::serve_http(http_transport::HttpConfig::from_env()).await;
     }
 
-    let service = PdfReaderMcp::new().serve(rmcp::transport::stdio()).await?;
+    let server = PdfReaderMcp::new();
+    let discover_payload = discover_compat::discover_result_value(&server.get_info());
+    let (stdin, stdout) = rmcp::transport::stdio();
+    let transport = discover_compat::DiscoverAwareTransport::new(
+        AsyncRwTransport::new_server(stdin, stdout),
+        discover_payload,
+    );
+    let service = server.serve(transport).await?;
     service.waiting().await?;
     Ok(())
 }

--- a/crates/pdf-reader-mcp-server/tests/server_discover_preinit.rs
+++ b/crates/pdf-reader-mcp-server/tests/server_discover_preinit.rs
@@ -1,0 +1,234 @@
+//! Regression for #598: Gemini Antigravity (and other dual-era clients) send
+//! `server/discover` before `initialize`. The process must answer discover and
+//! still complete the legacy initialize handshake.
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("repo root")
+        .to_path_buf()
+}
+
+fn resolve_mcp_binary() -> PathBuf {
+    for relative in [
+        "bin/native/pdf-reader-mcp-server",
+        "target/release/pdf-reader-mcp-server",
+        "target/debug/pdf-reader-mcp-server",
+    ] {
+        let candidate = repo_root().join(relative);
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+    // Fall back to cargo-built test binary next to this test via CARGO_BIN_EXE
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_pdf-reader-mcp-server") {
+        return PathBuf::from(path);
+    }
+    panic!("pdf-reader-mcp-server binary not found; run cargo build -p pdf-reader-mcp-server");
+}
+
+struct StdioClient {
+    child: Child,
+    stdin: std::process::ChildStdin,
+    stdout: BufReader<std::process::ChildStdout>,
+}
+
+impl StdioClient {
+    fn spawn() -> Self {
+        let binary = resolve_mcp_binary();
+        let mut child = Command::new(&binary)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .env_remove("MCP_TRANSPORT")
+            .env_remove("PDF_READER_MCP_TRANSPORT")
+            .spawn()
+            .unwrap_or_else(|error| panic!("spawn {}: {error}", binary.display()));
+        let stdout = child.stdout.take().expect("stdout");
+        let stdin = child.stdin.take().expect("stdin");
+        Self {
+            child,
+            stdin,
+            stdout: BufReader::new(stdout),
+        }
+    }
+
+    fn write_message(&mut self, message: &Value) {
+        let payload = serde_json::to_string(message).expect("serialize");
+        writeln!(self.stdin, "{payload}").expect("write stdin");
+        self.stdin.flush().expect("flush stdin");
+    }
+
+    fn read_response(&mut self, id: u64) -> Value {
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        let mut line = String::new();
+        loop {
+            if std::time::Instant::now() > deadline {
+                let _ = self.child.kill();
+                panic!("timed out waiting for id={id}");
+            }
+            line.clear();
+            match self.stdout.read_line(&mut line) {
+                Ok(0) => panic!("server closed stdout while waiting for id={id}"),
+                Ok(_) => {}
+                Err(error) => panic!("read stdout: {error}"),
+            }
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let payload: Value = serde_json::from_str(trimmed)
+                .unwrap_or_else(|error| panic!("parse `{trimmed}`: {error}"));
+            if payload.get("id").and_then(Value::as_u64) == Some(id) {
+                return payload;
+            }
+        }
+    }
+
+    fn send_request(&mut self, method: &str, params: Value) -> Value {
+        let id = REQUEST_ID.fetch_add(1, Ordering::Relaxed);
+        self.write_message(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        }));
+        self.read_response(id)
+    }
+
+    fn send_notification(&mut self, method: &str, params: Value) {
+        self.write_message(&json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        }));
+    }
+}
+
+impl Drop for StdioClient {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn server_discover_before_initialize_keeps_session_alive() {
+    let mut client = StdioClient::spawn();
+
+    // Gemini Antigravity dual-era probe shape.
+    let discover = client.send_request(
+        "server/discover",
+        json!({
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientInfo": {
+                    "name": "antigravity-client",
+                    "version": "v1.0.0"
+                },
+                "io.modelcontextprotocol/clientCapabilities": {}
+            }
+        }),
+    );
+
+    assert!(
+        discover.get("error").is_none(),
+        "discover must not fail: {discover}"
+    );
+    let result = discover
+        .get("result")
+        .expect("discover result")
+        .as_object()
+        .expect("result object");
+    assert_eq!(result.get("resultType").and_then(Value::as_str), Some("complete"));
+    assert!(
+        result
+            .get("supportedVersions")
+            .and_then(Value::as_array)
+            .is_some_and(|versions| !versions.is_empty()),
+        "supportedVersions required: {discover}"
+    );
+    assert_eq!(
+        discover
+            // JSON Pointer escapes '/' in key names as ~1
+            .pointer("/result/_meta/io.modelcontextprotocol~1serverInfo/name")
+            .and_then(Value::as_str),
+        Some("pdf-reader-mcp")
+    );
+
+    // Legacy initialize must still succeed on the same connection.
+    let initialize = client.send_request(
+        "initialize",
+        json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "discover-preinit-test", "version": "1.0.0" },
+        }),
+    );
+    assert!(
+        initialize.get("error").is_none(),
+        "initialize after discover must succeed: {initialize}"
+    );
+    assert_eq!(
+        initialize
+            .pointer("/result/serverInfo/name")
+            .and_then(Value::as_str),
+        Some("pdf-reader-mcp")
+    );
+
+    client.send_notification("notifications/initialized", json!({}));
+
+    let tools = client.send_request("tools/list", json!({}));
+    assert!(
+        tools.get("error").is_none(),
+        "tools/list after discover+initialize must succeed: {tools}"
+    );
+    let tool_names: Vec<&str> = tools
+        .pointer("/result/tools")
+        .and_then(Value::as_array)
+        .expect("tools array")
+        .iter()
+        .filter_map(|tool| tool.get("name").and_then(Value::as_str))
+        .collect();
+    assert!(
+        tool_names.iter().any(|name| *name == "read_pdf"),
+        "expected read_pdf in {tool_names:?}"
+    );
+}
+
+#[test]
+fn repeated_server_discover_before_initialize_is_tolerated() {
+    let mut client = StdioClient::spawn();
+
+    for _ in 0..2 {
+        let discover = client.send_request("server/discover", json!({}));
+        assert!(
+            discover.get("error").is_none(),
+            "discover must succeed: {discover}"
+        );
+    }
+
+    let initialize = client.send_request(
+        "initialize",
+        json!({
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": { "name": "discover-repeat-test", "version": "1.0.0" },
+        }),
+    );
+    assert!(
+        initialize.get("error").is_none(),
+        "initialize after repeated discover must succeed: {initialize}"
+    );
+}

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -66,6 +66,15 @@ Add to `claude_desktop_config.json`:
 }
 ```
 
+### Dual-era clients (Gemini Antigravity CLI)
+
+Some MCP hosts probe with SEP-2575 `server/discover` **before** the legacy
+`initialize` handshake (for example Gemini Antigravity CLI on Windows). The
+native server answers that discovery request on stdio without closing the
+transport, then completes `initialize` as usual. If an older published build
+fails with `expect initialized request` / `EOF` on plugin load, upgrade to a
+release that includes this fix.
+
 ## Run directly
 
 ```bash


### PR DESCRIPTION
## Summary
- Gemini Antigravity CLI (and other dual-era MCP clients) send SEP-2575 `server/discover` before the legacy `initialize` handshake.
- rmcp 1.8.0 only tolerates `ping` in that pre-init window, so the process aborted with `expect initialized request` → client `EOF`.
- Wrap stdio with `DiscoverAwareTransport` that returns a draft-shaped DiscoverResult, keeps the connection open, and still completes `initialize` + `tools/list`.
- Handle post-init `server/discover` via `on_custom_request`.
- Regression tests + public install notes for dual-era clients.

Fixes #598

## Test plan
- [x] `cargo test -p pdf-reader-mcp-server --lib`
- [x] `cargo test -p pdf-reader-mcp-server --test server_discover_preinit`
- [x] Manual stdio probe: `server/discover` → `initialize` → `tools/list` on debug binary
- [ ] CI green on PR
- [ ] Version/release PR publishes fixed package (changeset included)

## Notes
This is dual-era compatibility: discover is answered so clients that still run `initialize` after the probe (Gemini Antigravity) no longer die on EOF. Full modern-only (no-initialize) request paths remain out of scope for this fix.