### PR TITLE
chore(security): workflow least-privilege + MCP Toplist badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
   merge_group:
     types: [checks_requested]
 
+# Least privilege for GITHUB_TOKEN (CodeQL actions/missing-workflow-permissions).
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate Code Quality

--- a/.github/workflows/unpublish-bad-versions.yml
+++ b/.github/workflows/unpublish-bad-versions.yml
@@ -11,6 +11,9 @@ on:
         required: true
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   unpublish:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Plain-text PDF tools make agents guess. **PDF Reader MCP gives them evidence.**
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat-square)](https://opensource.org/licenses/MIT)
 [![CI](https://img.shields.io/github/actions/workflow/status/SylphxAI/pdf-reader-mcp/ci.yml?style=flat-square&label=CI)](https://github.com/SylphxAI/pdf-reader-mcp/actions/workflows/ci.yml)
 [![stars](https://img.shields.io/github/stars/SylphxAI/pdf-reader-mcp?style=flat-square)](https://github.com/SylphxAI/pdf-reader-mcp/stargazers)
+[![MCP Toplist](https://mcptoplist.com/badge/io.github.SylphxAI%2Fpdf-reader-mcp.svg)](https://mcptoplist.com/server/io.github.SylphxAI%2Fpdf-reader-mcp)
 
 </div>
 


### PR DESCRIPTION
## Summary
- Fix open CodeQL alert [#6](https://github.com/SylphxAI/pdf-reader-mcp/security/code-scanning/6) (`actions/missing-workflow-permissions`) by adding explicit `permissions: contents: read` to `ci.yml` and the emergency `unpublish-bad-versions.yml`.
- Incorporate community MCP Toplist rank badge from #597 into the existing README badge row (placement polish vs. the original PR).

## Security advisories readback
Published advisories remain **historical / already patched** relative to live `@sylphx/pdf-reader-mcp@4.1.2`:
- GHSA-f3xw-ff5r-rj7c (IPv6 transition SSRF) — patched `>= 3.0.15`
- GHSA-q344-5v34-gm84 / CVE-2026-62264 (HTTP API key not enforced) — patched `>= 3.0.1`
- GHSA-34gp-w56h-r2mv (`file://` / SSRF URL source) — patched `>= 2.4.1`

Current sole-Rust path still has SSRF guards (`crates/pdf-reader-core/src/ssrf.rs`) and HTTP `X-API-Key` middleware (`http_transport.rs`). No open Dependabot alerts.

Closes #597

## Test plan
- [ ] CI green
- [ ] After merge, CodeQL re-analysis clears alert #6 (or becomes fixed)
- [x] README badge renders in badge row