### PR TITLE
ci: native concurrency — retire free-runners / sha groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name: Validate Code Quality

--- a/.github/workflows/rust-parity-differential.yml
+++ b/.github/workflows/rust-parity-differential.yml
@@ -12,7 +12,7 @@ on:
 concurrency:
   # Bind cancellation to one immutable candidate. A wedged runner proving an
   # older candidate must not block admission proof for a newer exact head.
-  group: rust-parity-differential-${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
+  group: rust-parity-differential-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary

Retire **free-runners / API cancel-superseded** workarounds and unify CI concurrency on GitHub-native cancellation:

```yaml
concurrency:
  group: …-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

- Same PR new commit cancels old PR CI
- New main push cancels old main CI
- No custom free-runners job

Aligns with Agent-native Fast Trunk (ADR-01KYTNAGENTFASTTRUNK01).

## Test plan
- [ ] CI starts without free-runners job
- [ ] Superseded runs cancel via concurrency
