### PR TITLE
ci: drop default merge_group (Fast Trunk MQ off)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,13 @@
 name: CI
 
 on:
+  # No merge_group — Merge Queue off by default (Fast Trunk).
   push:
     branches:
       - main
   pull_request:
     branches:
       - main
-  merge_group:
-    types: [checks_requested]
 
 # Least privilege for GITHUB_TOKEN (CodeQL actions/missing-workflow-permissions).
 permissions:

--- a/.github/workflows/rust-parity-differential.yml
+++ b/.github/workflows/rust-parity-differential.yml
@@ -5,8 +5,6 @@ name: rust-parity-differential
 on:
   pull_request:
     branches: [main]
-  merge_group:
-    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Fleet Fast Trunk alignment: remove default `merge_group` from ordinary CI (Merge Queue off unless intentionally enabled).

Does not change publish/release packaging authority paths.

## Test plan
- [ ] CI triggers on PR/push only
- [ ] No merge_group under `on:` for tip CI
