### PR TITLE
fix(core): stop whole-process crash on malformed CMap destinations (#608)

### DIFF
--- a/.changeset/fix-cmap-crash-608.md
+++ b/.changeset/fix-cmap-crash-608.md
@@ -1,0 +1,5 @@
+---
+"@sylphx/pdf-reader-mcp": patch
+---
+
+Fix a whole-process crash when reading PDFs whose ToUnicode CMaps contain malformed destinations (pdfTeX 1-byte `beginbfrange` like `<C5> <D6> <C5>`). Vendor a patched `adobe-cmap-parser` that skips destinations that are not valid UTF-16BE instead of panicking, keep multi-code (6/8-byte) ligature destinations working, and build with panic-unwind so no malformed document can abort the MCP server from a worker-thread panic (fixes #608).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,8 +11,6 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 [[package]]
 name = "adobe-cmap-parser"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8abfa9a4688de8fc9f42b3f013b6fffec18ed8a554f5f113577e0b9b3212a3"
 dependencies = [
  "pom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/pdf-reader-core",
     "crates/pdf-reader-cli",
     "crates/pdf-reader-mcp-server",
+    "vendor/adobe-cmap-parser",
 ]
 resolver = "2"
 
@@ -17,11 +18,18 @@ readme = "README.md"
 
 # Production binaries: smaller artifacts without requiring runtime downloads.
 # Keep debuginfo available via separate tooling/dSYM workflows in CI when needed.
+
+# pdf-extract depends on adobe-cmap-parser 0.4.1, which panics on malformed
+# CMap destinations (see SylphxAI/pdf-reader-mcp#608). Vendor a patched copy
+# so arbitrary PDFs can never abort the server from a CMap parse panic.
+[patch.crates-io]
+adobe-cmap-parser = { path = "vendor/adobe-cmap-parser" }
+
 [profile.release]
 lto = "thin"
 codegen-units = 1
 strip = "symbols"
-panic = "abort"
+panic = "unwind"
 
 [profile.release-with-debug]
 inherits = "release"

--- a/README.md
+++ b/README.md
@@ -205,6 +205,11 @@ Version 4 runs a **native Rust engine** on supported platforms via a thin Node l
 
 > Local-first. Five platforms. One clean install.
 
+Unusually formed or broken ToUnicode CMaps are handled without crashing, and
+the release binary is built panic-unwind so a worker-thread panic fails the
+affected request instead of aborting the whole process
+([#608](https://github.com/SylphxAI/pdf-reader-mcp/issues/608)).
+
 Engineering history, recovery pins, and ADRs live under [docs/migration.md](docs/migration.md) — not the product pitch.
 
 ## Product proof

--- a/crates/pdf-reader-core/src/text_index.rs
+++ b/crates/pdf-reader-core/src/text_index.rs
@@ -2252,4 +2252,26 @@ mod tests {
         let snip2 = build_snippet(short, &short_projection, 0, 5, 10).unwrap();
         assert_eq!(snip2, "short");
     }
+
+    #[test]
+    fn extraction_survives_cid_cmap_with_odd_length_bfrange_destination() {
+        // Regression for SylphxAI/pdf-reader-mcp#608. pdfTeX files ship ToUnicode
+        // CMaps with 1-byte beginbfrange destinations (e.g. <C5> <D6> <C5>), which
+        // made the upstream adobe-cmap-parser panic with "bad length of hexstring".
+        // pdf-extract unwraps that Result, so the panic used to abort the whole
+        // pdf-reader-mcp process. This fixture reproduces the exact crashing
+        // construct and must extract without panicking.
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../test/fixtures/differential/v3014-bug608-cid-bfrange-odd-v1.pdf");
+        let extracted = extract_pdf_text(&fixture, 256 * 1024 * 1024)
+            .expect("malformed CMap must not abort extraction");
+        assert_eq!(extracted.pages.len(), 1);
+        assert_eq!(extracted.info.format_version, "1.4");
+
+        // The search path is the same one exposed over MCP; it must complete.
+        let search = search_pdf_text(&fixture, 256 * 1024 * 1024, "a", false, false, 100, 50, 120)
+            .expect("malformed CMap must not abort search");
+        assert_eq!(search.num_pages, 1);
+        assert_eq!(search.truncated, false);
+    }
 }

--- a/crates/pdf-reader-mcp-server/src/lib.rs
+++ b/crates/pdf-reader-mcp-server/src/lib.rs
@@ -372,6 +372,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn search_pdf_handles_malformed_cid_cmap_fixture_without_aborting() {
+        // Regression for SylphxAI/pdf-reader-mcp#608: a pdfTeX ToUnicode CMap
+        // using 1-byte beginbfrange destinations (like <C5> <D6> <C5>) made the
+        // upstream adobe-cmap-parser panic with "bad length of hexstring",
+        // aborting the whole MCP server. The tool entrypoint must return a
+        // structured result instead.
+        let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../test/fixtures/differential/v3014-bug608-cid-bfrange-odd-v1.pdf");
+        let server = PdfReaderMcp::new();
+        let search = serde_json::from_value(serde_json::json!({
+            "sources": [{"path": fixture}],
+            "query": "a"
+        }))
+        .expect("structurally valid search args");
+        let result = server
+            .search_pdf(Parameters(search))
+            .await
+            .expect("search_pdf must complete on a malformed CMap PDF");
+        assert!(
+            !result.content.is_empty(),
+            "expected a structured search_pdf result"
+        );
+
+        let read = serde_json::from_value(serde_json::json!({
+            "sources": [{"path": fixture}]
+        }))
+        .expect("structurally valid read args");
+        let result = server
+            .read_pdf(Parameters(read))
+            .await
+            .expect("read_pdf must complete on a malformed CMap PDF");
+        assert!(
+            !result.content.is_empty(),
+            "expected a structured read_pdf result"
+        );
+    }
+
+    #[tokio::test]
     async fn tool_entrypoints_reject_values_outside_v3_0_14_runtime_bounds() {
         let server = PdfReaderMcp::new();
         let read = serde_json::from_value(serde_json::json!({

--- a/docs/specs/performance/installed-footprint-comparison.md
+++ b/docs/specs/performance/installed-footprint-comparison.md
@@ -60,7 +60,7 @@ Evidence:
 - `verification/footprint/3.0.14-linux-x64.json`
 - `verification/footprint/4.0.2-linux-x64.json`
 
-Release binary optimization note: with workspace `[profile.release]` (`strip=symbols`, thin LTO, `codegen-units=1`), local linux-x64 `pdf-reader-mcp-server` built to **~14.9 MiB**. Published 4.0.2 natives may still be pre-optimization until the next binary rebuild/publish.
+Release binary optimization note: with workspace `[profile.release]` (`strip=symbols`, thin LTO, `codegen-units=1`), local linux-x64 `pdf-reader-mcp-server` built to **~15.0 MiB**. Crashing on malformed PDFs is a real bug class for an MCP server, so the release profile is deliberately built **panic-unwind** (worker-thread panics degrade to a failed request instead of aborting the whole process; see issue #608). Unwinding adds roughly **+1.3 MiB (~+9%)** to the server binary versus `panic=abort` — the installed-footprint story vs TS remains intact. Measured on the issue-608 fix tree (linux-x64, `strip=symbols`, thin LTO): `panic=abort` ~15.01 MiB vs `panic=unwind` ~16.36 MiB. Published 4.0.2 natives may still be pre-optimization until the next binary rebuild/publish.
 
 ## How to reproduce
 

--- a/test/fixtures/differential/v3014-bug608-cid-bfrange-odd-v1.pdf
+++ b/test/fixtures/differential/v3014-bug608-cid-bfrange-odd-v1.pdf
@@ -1,0 +1,66 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 33 >>
+stream
+BT /F1 12 Tf 72 720 Td <C5> Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type0 /BaseFont /Test /Encoding /Identity-H /DescendantFonts [6 0 R] /ToUnicode 8 0 R >>
+endobj
+6 0 obj
+<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Test /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> /FontDescriptor 7 0 R /DW 1000 /W [0 [500]] >>
+endobj
+7 0 obj
+<< /Type /FontDescriptor /FontName /Test /Flags 4 /FontBBox [0 0 1000 1000] /ItalicAngle 0 /Ascent 800 /Descent -200 /CapHeight 700 /StemV 80 >>
+endobj
+8 0 obj
+<< /Length 310 >>
+stream
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def
+/CMapName /Test def
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+1 beginbfrange
+<C5> <D6> <C5>
+endbfrange
+endcmap
+CMapName currentdict /CMapName defineresource pop
+end
+end
+endstream
+endobj
+9 0 obj
+<< /Producer (fix-pdf-reader-mcp-608-fixture) >>
+endobj
+xref
+0 10
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000330 00000 n 
+0000000459 00000 n 
+0000000649 00000 n 
+0000000809 00000 n 
+0000001170 00000 n 
+trailer
+<< /Size 10 /Root 1 0 R /Info 9 0 R >>
+startxref
+1234
+%%EOF

--- a/vendor/adobe-cmap-parser/Cargo.toml
+++ b/vendor/adobe-cmap-parser/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "adobe-cmap-parser"
+version = "0.4.1"
+edition = "2018"
+authors = ["Jeff Muizelaar <jmuizelaar@mozilla.com>"]
+description = "Vendored adobe-cmap-parser 0.4.1 with malformed-CMap crash fixes"
+license = "MIT"
+repository = "https://github.com/jrmuizel/adobe-cmap-parser"
+readme = "README.md"
+
+[lib]
+name = "adobe_cmap_parser"
+path = "src/lib.rs"
+
+[dependencies.pom]
+version = "1.0.1"

--- a/vendor/adobe-cmap-parser/Cargo.toml.orig
+++ b/vendor/adobe-cmap-parser/Cargo.toml.orig
@@ -1,0 +1,13 @@
+[package]
+authors = ["Jeff Muizelaar <jmuizelaar@mozilla.com>"]
+name = "adobe-cmap-parser"
+version = "0.4.1"
+license = "MIT"
+documentation = "https://docs.rs/crate/adobe-cmap-parser/"
+description = "A library to parse Adobe CMap files"
+keywords = ["cmap", "font", "pdf", "postscript"]
+repository = "https://github.com/jrmuizel/adobe-cmap-parser"
+include = ["src/lib.rs"]
+
+[dependencies]
+pom = "1.0.1"

--- a/vendor/adobe-cmap-parser/README.md
+++ b/vendor/adobe-cmap-parser/README.md
@@ -1,0 +1,50 @@
+# vendored adobe-cmap-parser (patched)
+
+This directory is a vendored copy of the published
+[`adobe-cmap-parser`](https://crates.io/crates/adobe-cmap-parser) crate
+`v0.4.1` (MIT, © Jeff Muizelaar), with a small correctness/safety patch that
+SylphxAI/pdf-reader-mcp depends on through `pdf-extract`.
+
+## Why it is vendored
+
+The upstream crate panics with `bad length of hexstring` when a
+`beginbfrange` destination is not 2 or 4 bytes long, and uses similar
+`panic!`/`assert!`/indexing on other malformed input. Malformed or unusual
+CMaps emitted by pdfTeX (for example 1-byte `beginbfrange` destinations and
+6-byte ligature `beginbfchar` destinations) reachable from arbitrary PDFs
+therefore crash the host process. Because the workspace `[profile.release]`
+previously compiled with `panic = "abort"`, such a panic aborted the entire
+MCP server.
+
+## Patch delta vs upstream 0.4.1
+
+- `get_unicode_map` is now effectively infallible on malformed input:
+  - a parse failure returns an empty map instead of panicking;
+  - an operator whose preceding count token is missing is skipped instead of
+    indexing `lexed[i - 1]` out of bounds;
+  - `beginbfrange` string destinations of odd byte length (not valid UTF-16BE,
+    e.g. `<C5>`) are skipped instead of panicking;
+  - even-length wide destinations (6/8 bytes, multi-code UTF-16BE) are
+    preserved by advancing the full big-endian destination value instead of
+    only handling 2/4 bytes;
+  - array destinations are iterated with bounds checks and odd-length
+    elements are skipped;
+  - `beginbfchar` is skipped when the destination would not be valid UTF-16BE.
+- `get_byte_mapping`:
+  - a parse failure returns an empty mapping instead of panicking;
+  - codespace ranges whose start/end have mismatched byte lengths are skipped
+    instead of `assert!` panicking;
+  - missing count/operand tokens bail out instead of indexing out of bounds.
+
+The public API is unchanged, so `pdf-extract` still compiles unmodified; its
+`.unwrap()` calls on these functions can no longer trigger a panic from
+malformed CMaps.
+
+## Verification
+
+```bash
+cargo test -p adobe-cmap-parser
+```
+
+Run from the pdf-reader-mcp workspace root (`vendor/adobe-cmap-parser` is
+wired through `[patch.crates-io]` in `Cargo.toml`).

--- a/vendor/adobe-cmap-parser/src/lib.rs
+++ b/vendor/adobe-cmap-parser/src/lib.rs
@@ -1,0 +1,494 @@
+extern crate pom;
+
+use pom::char_class::{alpha, hex_digit, multispace, oct_digit};
+use pom::parser::*;
+use pom::DataInput;
+use pom::Parser;
+use std::collections::HashMap;
+
+use std::str::FromStr;
+
+#[derive(Debug)]
+pub enum Value {
+    LiteralString(Vec<u8>),
+    Name(Vec<u8>),
+    Number(String),
+    Integer(i64),
+    Array(Vec<Value>),
+    Operator(String),
+    Boolean(bool),
+    Dictionary(HashMap<String, Value>),
+}
+
+fn hex_char() -> Parser<u8, u8> {
+    let number = is_a(hex_digit).repeat(2);
+    number
+        .collect()
+        .convert(|v| u8::from_str_radix(&String::from_utf8(v).unwrap(), 16))
+}
+
+fn comment() -> Parser<u8, ()> {
+    sym(b'%') * none_of(b"\r\n").repeat(0..) * eol().discard()
+}
+
+fn content_space() -> Parser<u8, ()> {
+    is_a(multispace).repeat(0..).discard()
+}
+
+fn operator() -> Parser<u8, String> {
+    (is_a(alpha) | one_of(b"*'\""))
+        .repeat(1..)
+        .convert(|v| String::from_utf8(v))
+}
+
+fn oct_char() -> Parser<u8, u8> {
+    let number = is_a(oct_digit).repeat(1..4);
+    number
+        .collect()
+        .convert(|v| u8::from_str_radix(&String::from_utf8(v).unwrap(), 8))
+}
+
+fn escape_sequence() -> Parser<u8, Vec<u8>> {
+    sym(b'\\')
+        * (sym(b'\\').map(|_| vec![b'\\'])
+            | sym(b'(').map(|_| vec![b'('])
+            | sym(b')').map(|_| vec![b')'])
+            | sym(b'n').map(|_| vec![b'\n'])
+            | sym(b'r').map(|_| vec![b'\r'])
+            | sym(b't').map(|_| vec![b'\t'])
+            | sym(b'b').map(|_| vec![b'\x08'])
+            | sym(b'f').map(|_| vec![b'\x0C'])
+            | oct_char().map(|c| vec![c])
+            | eol().map(|_| vec![])
+            | empty().map(|_| vec![]))
+}
+
+fn nested_literal_string() -> Parser<u8, Vec<u8>> {
+    sym(b'(')
+        * (none_of(b"\\()").repeat(1..) | escape_sequence() | call(nested_literal_string))
+            .repeat(0..)
+            .map(|segments| {
+                let mut bytes = segments
+                    .into_iter()
+                    .fold(vec![b'('], |mut bytes, mut segment| {
+                        bytes.append(&mut segment);
+                        bytes
+                    });
+                bytes.push(b')');
+                bytes
+            })
+        - sym(b')')
+}
+
+fn literal_string() -> Parser<u8, Vec<u8>> {
+    sym(b'(')
+        * (none_of(b"\\()").repeat(1..) | escape_sequence() | nested_literal_string())
+            .repeat(0..)
+            .map(|segments| segments.concat())
+        - sym(b')')
+}
+
+fn name() -> Parser<u8, Vec<u8>> {
+    sym(b'/') * (none_of(b" \t\n\r\x0C()<>[]{}/%#") | sym(b'#') * hex_char()).repeat(0..)
+}
+
+fn integer() -> Parser<u8, i64> {
+    let number = one_of(b"+-").opt() + one_of(b"0123456789").repeat(1..);
+    number
+        .collect()
+        .convert(|v| String::from_utf8(v))
+        .convert(|s| i64::from_str(&s))
+}
+
+fn number() -> Parser<u8, String> {
+    let number = one_of(b"+-").opt()
+        + ((one_of(b"0123456789") - one_of(b"0123456789").repeat(0..).discard())
+            | (one_of(b"0123456789").repeat(1..) * sym(b'.') - one_of(b"0123456789").repeat(0..))
+            | sym(b'.') - one_of(b"0123456789").repeat(1..));
+    number.collect().convert(|v| String::from_utf8(v))
+}
+
+fn space() -> Parser<u8, ()> {
+    (one_of(b" \t\n\r\0\x0C").repeat(1..).discard())
+        .repeat(0..)
+        .discard()
+}
+
+// Dictionaries are not mentioned in the CMap spec but are produced by software like Cairo and Skia and supported other by readers
+fn dictionary() -> Parser<u8, HashMap<String, Value>> {
+    let entry = name() - space() + call(value);
+    let entries = seq(b"<<") * space() * entry.repeat(0..) - seq(b">>");
+    entries.map(|entries| {
+        entries.into_iter().fold(
+            HashMap::new(),
+            |mut dict: HashMap<String, Value>, (key, value)| {
+                dict.insert(String::from_utf8(key).unwrap(), value);
+                dict
+            },
+        )
+    })
+}
+
+fn hexadecimal_string() -> Parser<u8, Vec<u8>> {
+    sym(b'<') * (space() * hex_char()).repeat(0..) - (space() * sym(b'>'))
+}
+
+fn eol() -> Parser<u8, u8> {
+    sym(b'\r') * sym(b'\n') | sym(b'\n') | sym(b'\r')
+}
+
+fn value() -> Parser<u8, Value> {
+    (seq(b"true").map(|_| Value::Boolean(true))
+        | seq(b"false").map(|_| Value::Boolean(false))
+        | integer().map(|v| Value::Integer(v))
+        | number().map(|v| Value::Number(v))
+        | name().map(|v| Value::Name(v))
+        | operator().map(|v| Value::Operator(v))
+        | literal_string().map(|v| Value::LiteralString(v))
+        | dictionary().map(|v| Value::Dictionary(v))
+        | hexadecimal_string().map(|v| Value::LiteralString(v))
+        | array().map(|v| Value::Array(v)))
+        - content_space()
+}
+
+fn array() -> Parser<u8, Vec<Value>> {
+    sym(b'[') * space() * call(value).repeat(0..) - sym(b']')
+}
+
+fn file() -> Parser<u8, Vec<Value>> {
+    (comment().repeat(0..) * content_space() * value()).repeat(1..)
+}
+
+pub fn parse(input: &[u8]) -> Result<Vec<Value>, pom::Error> {
+    file().parse(&mut DataInput::new(input))
+}
+
+fn as_code(str: &[u8]) -> u32 {
+    let mut code: u32 = 0;
+    for c in str {
+        code = (code << 8) | (*c as u32);
+    }
+    code
+}
+
+// Wide variant that does not truncate past 4 bytes; used for Unicode destination
+// values in beginbfrange so multi-code (6/8-byte) destinations are preserved.
+fn as_code_wide(str: &[u8]) -> u128 {
+    let mut code: u128 = 0;
+    for c in str {
+        code = (code << 8) | (*c as u128);
+    }
+    code
+}
+
+/// Return a mapping from character codes to Unicode character sequences expressed in UTF-16BE encoding.
+///
+/// This vendored copy diverges from upstream `adobe-cmap-parser` only in that it is
+/// *infallible on malformed input*: instead of `panic!`/index-panics on unusual or
+/// broken CMap destinations (for example 1-byte `beginbfrange` destinations or
+/// odd-length UTF-16BE values emitted by some TeX/pdfTeX fonts), it skips the
+/// unusable entries. Odd-length destinations cannot be valid UTF-16BE and are dropped.
+/// The upstream crate panicked with "bad length of hexstring", which aborted the whole
+/// pdf-reader-mcp server process.
+pub fn get_unicode_map(input: &[u8]) -> Result<HashMap<u32, Vec<u8>>, &'static str> {
+    let lexed = match parse(input) {
+        Ok(lexed) => lexed,
+        Err(_) => return Ok(HashMap::new()),
+    };
+
+    let mut i = 0;
+    let mut map = HashMap::new();
+    while i < lexed.len() {
+        match lexed[i] {
+            Value::Operator(ref o) => {
+                match o.as_ref() {
+                    "beginbfchar" => {
+                        let Some(&Value::Integer(ref count)) = lexed.get(i.wrapping_sub(1)) else {
+                            i += 1;
+                            continue;
+                        };
+                        i += 1;
+                        let mut handled = 0usize;
+                        while handled < *count as usize {
+                            let (
+                                Some(Value::LiteralString(char_code)),
+                                Some(Value::LiteralString(uni_code)),
+                            ) = (lexed.get(i), lexed.get(i + 1))
+                            else {
+                                break;
+                            };
+                            // Only even-length destinations are valid UTF-16BE; skip the rest.
+                            if uni_code.len() % 2 == 0 {
+                                map.insert(as_code(char_code), uni_code.clone());
+                            }
+                            // Advance even when skipping so later pairs stay aligned.
+                            i += 2;
+                            handled += 1;
+                        }
+                        i += 1;
+                    }
+                    "beginbfrange" => {
+                        let Some(&Value::Integer(ref count)) = lexed.get(i.wrapping_sub(1)) else {
+                            i += 1;
+                            continue;
+                        };
+                        i += 1;
+                        let mut handled = 0usize;
+                        while handled < *count as usize {
+                            let (
+                                Some(Value::LiteralString(lower)),
+                                Some(Value::LiteralString(upper)),
+                            ) = (lexed.get(i), lexed.get(i + 1))
+                            else {
+                                break;
+                            };
+                            let lower_code = as_code(lower);
+                            let upper_code = as_code(upper);
+                            match lexed.get(i + 2) {
+                                Some(Value::LiteralString(start)) => {
+                                    if start.len() % 2 == 0 {
+                                        let width = start.len();
+                                        let base = as_code_wide(start);
+                                        for c in lower_code..=upper_code {
+                                            let offset = (c - lower_code) as u128;
+                                            let value = base.wrapping_add(offset);
+                                            let bytes = value.to_be_bytes();
+                                            let first = bytes.len() - width;
+                                            map.insert(c, bytes[first..].to_vec());
+                                        }
+                                    }
+                                    // Odd-length destinations cannot be UTF-16BE; skip.
+                                }
+                                Some(Value::Array(codes)) => {
+                                    let mut ci = 0usize;
+                                    while ci < codes.len() {
+                                        if let Some(Value::LiteralString(s)) = codes.get(ci) {
+                                            if s.len() % 2 == 0 {
+                                                map.insert(lower_code + ci as u32, s.clone());
+                                            }
+                                        }
+                                        ci += 1;
+                                    }
+                                }
+                                _ => {
+                                    // Malformed third element; skip this range.
+                                }
+                            }
+                            i += 3;
+                            handled += 1;
+                        }
+                        i += 1;
+                    }
+                    _ => {
+                        i += 1;
+                    }
+                }
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+    Ok(map)
+}
+
+fn as_code_range(start_chars: &[u8], end_chars: &[u8]) -> Option<CodeRange> {
+    // Upstream asserted equal lengths (a panic on malformed input); be lenient instead.
+    if start_chars.len() != end_chars.len() {
+        return None;
+    }
+    let mut start = 0;
+    let mut end = 0;
+    let width = start_chars.len();
+    for i in 0..width {
+        start = (start << 8) | (start_chars[i] as u32);
+        end = (end << 8) | (end_chars[i] as u32);
+    }
+    Some(CodeRange {
+        start,
+        end,
+        width: width as u32 / 2,
+    })
+}
+
+#[derive(Debug)]
+pub struct CodeRange {
+    pub width: u32,
+    pub start: u32,
+    pub end: u32,
+}
+
+#[derive(Debug)]
+#[allow(non_snake_case)]
+pub struct CIDRange {
+    pub src_code_lo: u32,
+    pub src_code_hi: u32,
+    pub dst_CID_lo: u32,
+}
+
+#[derive(Debug)]
+pub struct ByteMapping {
+    pub codespace: Vec<CodeRange>,
+    pub cid: Vec<CIDRange>,
+}
+
+pub fn get_byte_mapping(input: &[u8]) -> Result<ByteMapping, &'static str> {
+    let lexed = match parse(input) {
+        Ok(lexed) => lexed,
+        Err(_) => {
+            return Ok(ByteMapping {
+                codespace: Vec::new(),
+                cid: Vec::new(),
+            })
+        }
+    };
+
+    let mut i = 0;
+    let mut result = ByteMapping {
+        codespace: Vec::new(),
+        cid: Vec::new(),
+    };
+    while i < lexed.len() {
+        match lexed[i] {
+            Value::Operator(ref o) => match o.as_ref() {
+                "begincodespacerange" => {
+                    let Some(&Value::Integer(ref count)) = lexed.get(i.wrapping_sub(1)) else {
+                        i += 1;
+                        continue;
+                    };
+                    i += 1;
+                    let mut handled = 0usize;
+                    while handled < *count as usize {
+                        let (Some(Value::LiteralString(start)), Some(Value::LiteralString(end))) =
+                            (lexed.get(i), lexed.get(i + 1))
+                        else {
+                            break;
+                        };
+                        if let Some(range) = as_code_range(start, end) {
+                            result.codespace.push(range);
+                        }
+                        i += 2;
+                        handled += 1;
+                    }
+                    i += 1;
+                }
+                "begincidrange" => {
+                    let Some(&Value::Integer(ref count)) = lexed.get(i.wrapping_sub(1)) else {
+                        i += 1;
+                        continue;
+                    };
+                    i += 1;
+                    let mut handled = 0usize;
+                    while handled < *count as usize {
+                        let (Some(Value::LiteralString(start)), Some(Value::LiteralString(end))) =
+                            (lexed.get(i), lexed.get(i + 1))
+                        else {
+                            break;
+                        };
+                        let offset = match lexed.get(i + 2) {
+                            Some(Value::Integer(offset)) => *offset as u32,
+                            _ => break,
+                        };
+                        result.cid.push(CIDRange {
+                            src_code_lo: as_code(start),
+                            src_code_hi: as_code(end),
+                            dst_CID_lo: offset,
+                        });
+                        i += 2;
+                        handled += 1;
+                    }
+                    i += 1;
+                }
+                _ => {
+                    i += 1;
+                }
+            },
+            _ => {
+                i += 1;
+            }
+        }
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{get_byte_mapping, get_unicode_map};
+
+    #[test]
+    fn bfrange_odd_length_destination_does_not_panic() {
+        // Regression for SylphxAI/pdf-reader-mcp#608: pdfTeX emits 1-byte
+        // beginbfrange destinations like <C5> <D6> <C5>. Upstream panicked
+        // with "bad length of hexstring"; we must skip it instead.
+        let cmap = b"/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def
+/cmapname /TeX-MI-H def
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+1 beginbfrange
+<C5> <D6> <C5>
+endbfrange
+endcmap
+CMapName currentdict /cmapname defineresource pop
+end
+end";
+        let map = get_unicode_map(cmap).expect("should not panic");
+        assert!(
+            !map.contains_key(&0xC5),
+            "odd-length bfrange destination must be skipped"
+        );
+    }
+
+    #[test]
+    fn bfrange_even_wide_destination_preserved() {
+        // A 6-byte (3 UTF-16 code unit) destination is valid UTF-16BE and kept.
+        let cmap = b"1 beginbfrange
+<01> <01> <006600660069>
+endbfrange";
+        let map = get_unicode_map(cmap).expect("ok");
+        assert_eq!(
+            map.get(&0x01).map(Vec::as_slice),
+            Some(&[0x00, 0x66, 0x00, 0x66, 0x00, 0x69][..])
+        );
+    }
+
+    #[test]
+    fn bfchar_odd_length_destination_skipped() {
+        let cmap = b"1 beginbfchar
+<00> <0FF>
+endbfchar";
+        let map = get_unicode_map(cmap).expect("ok");
+        assert!(!map.contains_key(&0x00));
+    }
+
+    #[test]
+    fn bfchar_six_byte_destination_kept() {
+        // pdfTeX ligature destination <006600660069> == "ffi".
+        let cmap = b"1 beginbfchar
+<1E> <006600660069>
+endbfchar";
+        let map = get_unicode_map(cmap).expect("ok");
+        assert_eq!(
+            map.get(&0x1E).map(Vec::as_slice),
+            Some(&[0x00, 0x66, 0x00, 0x66, 0x00, 0x69][..])
+        );
+    }
+
+    #[test]
+    fn parse_failure_returns_empty_map() {
+        let map = get_unicode_map(b"\x00 not a cmap \xff\xfe").expect("no panic");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn byte_mapping_codespace_length_mismatch_no_panic() {
+        let cmap = b"1 begincodespacerange
+<00> <0000>
+endcodespacerange";
+        let mapping = get_byte_mapping(cmap).expect("no panic");
+        assert!(mapping.codespace.is_empty());
+    }
+}


### PR DESCRIPTION
## What

Fixes #608 — the MCP server aborts when reading the reported pdfTeX file.

**Root cause (two layers):**
1. `pdf-extract` depends on `adobe-cmap-parser` 0.4.1, which panics with `bad length of hexstring` when a ToUnicode `beginbfrange` destination is not 2/4 bytes. This PDF (and files like it) carry 1-byte destinations such as `<C5> <D6> <C5>` (pdfTeX `TeX-MI-H`) plus 6-byte ligature `bfchar` destinations like `<1E> <006600660069>` (`TeX-T1-0`/`TeX-OT1-0`).
2. `pdf-extract` unwraps that `Result`, and the workspace release profile compiled with `panic = "abort"` — so the panic in the extraction worker aborts the **whole MCP server** process.

## Fix

- **Vendored + patched `adobe-cmap-parser`** (`vendor/adobe-cmap-parser`, MIT, unchanged public API; wired via `[patch.crates-io]`). It is now infallible on malformed input: skips destinations that are not valid UTF-16BE (odd-length), preserves even-length wide/multi-code destinations (6/8-byte), and bounds-checks codespace/cid parsing instead of `panic!`/`assert!`/indexing out of range.
- **Release profile hardened** to `panic = "unwind"` so a residual worker-thread panic fails the affected request instead of aborting the process (measured ≈ +9% on the server binary; install-footprint-vs-TS story unchanged — see updated footprint note).

## Verification

- New ~1.5 KB fixture reproduces the exact crashing construct; **without** the patch the CLI aborts with the same `bad length of hexstring` on both the fixture and the real 24 MB PDF. **With** the patch both extract and search successfully (real file: 231 pages, search works).
- New regression tests: `adobe-cmap-parser` unit tests + `pdf-reader-core` extraction test + `pdf-reader-mcp-server` tool-entrypoint test.
- Local: full `cargo test` (all members) green, `typecheck`, `biome check`, `check:ts-production-absence`, `project-control`, `docs:build`, `package:smoke` all pass.
- Changeset added; npm release remains Changesets/bot-owned (this PR is the source fix only).

## Residuals (honest)

- `pdf-extract` still has its own `.unwrap()`/`panic!()` sites on other malformed-PDF shapes (e.g. unpaired-surrogate UTF-16). Those are now **non-fatal** to the process thanks to panic-unwind, but a follow-up could vendor a patched `pdf-extract` to make those structured errors too.
- Final customer-visible delivery requires the normal trunk CI + changesets version PR + npm publish + registry readback via the repo release workflow.