### PR TITLE
fix(release): refresh bun.lock during changesets version step

### DIFF
--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -9,6 +9,12 @@ cd "$root"
 echo "[release-version] bump package versions from changesets"
 node node_modules/@changesets/cli/bin.js version
 
+# Version bumps drift bun.lock's bundled optional-package versions/optionalDependencies
+# (the bot's version PR otherwise fails CI's `bun install --frozen-lockfile`). Refresh
+# the lockfile here so the version PR ships a consistent lock (mirrors the manual
+# "refresh bun.lock" commits that were previously pushed to each release PR).
+bun install
+
 echo "[release-version] sync native optional package manifests to root version"
 bun run native:sync-manifests
 


### PR DESCRIPTION
## What / why

Every bot-authored `chore(release): version packages` PR failed CI at `bun install --frozen-lockfile` because the version bump drifts `bun.lock` (the bundled native optional-package versions) without refreshing it. Historically each release PR needed a manual "refresh bun.lock" follow-up commit (pushed by hand for 4.1.0 and again for 4.1.3 in #610).

This source fix makes `release-version.sh` run `bun install` after `changesets version`, so the generated version PR ships a consistent lockfile automatically.

## Verification

- `bash -n scripts/release-version.sh` passes.
- `bun install` on the 4.1.3 bump produced exactly the minimal expected lock change (native optional deps 4.1.2 → 4.1.3 + dropped stale registry entries), no dependency churn.
- CI Validate Code Quality exercises `bun install --frozen-lockfile` on this branch.

## Note

No version bump changeset is needed — this is release-infra only.