### PR TITLE
ci: self-hosted runners only (no GitHub-hosted)

### DIFF
--- a/.github/workflows/candidate-host-runtime-proof.yml
+++ b/.github/workflows/candidate-host-runtime-proof.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   map:
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
     steps:
@@ -42,11 +42,11 @@ jobs:
           # host-execute proof is only claimed when runner arch matches (fail-closed).
           # linux/windows: GitHub-hosted until self-hosted pools exist.
           matrix='[
-            {"platformId":"linux-x64-gnu","runner":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu"},
-            {"platformId":"linux-arm64-gnu","runner":"ubuntu-22.04-arm","target":"aarch64-unknown-linux-gnu"},
+            {"platformId":"linux-x64-gnu","runner":"sylphx-linux-standard","target":"x86_64-unknown-linux-gnu"},
+            {"platformId":"linux-arm64-gnu","runner":"sylphx-linux-standard","target":"aarch64-unknown-linux-gnu"},
             {"platformId":"darwin-arm64","runner":["self-hosted","sylphx","macos","standard"],"target":"aarch64-apple-darwin"},
             {"platformId":"darwin-x64","runner":["self-hosted","sylphx","macos","standard"],"target":"x86_64-apple-darwin"},
-            {"platformId":"win32-x64-msvc","runner":"windows-latest","target":"x86_64-pc-windows-msvc"}
+            {"platformId":"win32-x64-msvc","runner":"sylphx-linux-standard","target":"x86_64-pc-windows-msvc"}
           ]'
           echo "matrix=$(echo "$matrix" | jq -c .)" >> "$GITHUB_OUTPUT"
 
@@ -151,7 +151,7 @@ jobs:
   aggregate:
     needs: proof
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
 
   release-evidence:
     name: Release Evidence Gate
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
     needs: validate
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   build-and-push:
     name: Build and Push
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build:
     name: Build Docs Site
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -45,7 +45,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/native-package-scaffold.yml
+++ b/.github/workflows/native-package-scaffold.yml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   map:
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
     steps:
@@ -48,7 +48,7 @@ jobs:
         run: |
           # Product CI: darwin uses Sylphx self-hosted macOS only (no GitHub-hosted macos-*).
           # linux/windows keep fixed GH images for published glibc/ABI and Windows MSVC coverage.
-          matrix='[{"platformId":"linux-x64-gnu","runner":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu"},{"platformId":"linux-arm64-gnu","runner":"ubuntu-22.04-arm","target":"aarch64-unknown-linux-gnu"},{"platformId":"darwin-arm64","runner":["self-hosted","sylphx","macos","standard"],"target":"aarch64-apple-darwin"},{"platformId":"darwin-x64","runner":["self-hosted","sylphx","macos","standard"],"target":"x86_64-apple-darwin"},{"platformId":"win32-x64-msvc","runner":"windows-latest","target":"x86_64-pc-windows-msvc"}]'
+          matrix='[{"platformId":"linux-x64-gnu","runner":"sylphx-linux-standard","target":"x86_64-unknown-linux-gnu"},{"platformId":"linux-arm64-gnu","runner":"sylphx-linux-standard","target":"aarch64-unknown-linux-gnu"},{"platformId":"darwin-arm64","runner":["self-hosted","sylphx","macos","standard"],"target":"aarch64-apple-darwin"},{"platformId":"darwin-x64","runner":["self-hosted","sylphx","macos","standard"],"target":"x86_64-apple-darwin"},{"platformId":"win32-x64-msvc","runner":"sylphx-linux-standard","target":"x86_64-pc-windows-msvc"}]'
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
       - name: Verify package map and Stage B publishable posture
         run: |

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
     if: ${{ github.event.inputs.confirm == 'I_UNDERSTAND_USER_IMPACT' }}
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   publish:
     name: Publish MCP Registry metadata
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
     steps:
       - name: Checkout admission policy
         uses: actions/checkout@v7

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -23,10 +23,10 @@ jobs:
       matrix:
         include:
           - platformId: linux-x64-gnu
-            runner: ubuntu-22.04
+            runner: sylphx-linux-standard
             target: x86_64-unknown-linux-gnu
           - platformId: linux-arm64-gnu
-            runner: ubuntu-22.04-arm
+            runner: sylphx-linux-standard
             target: aarch64-unknown-linux-gnu
           # Product macOS: Sylphx self-hosted only (no GitHub-hosted macos-*).
           - platformId: darwin-arm64
@@ -36,7 +36,7 @@ jobs:
             runner: [self-hosted, sylphx, macos, standard]
             target: x86_64-apple-darwin
           - platformId: win32-x64-msvc
-            runner: windows-latest
+            runner: sylphx-linux-standard
             target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.runner }}
     steps:
@@ -78,7 +78,7 @@ jobs:
     name: Publish natives + main
     needs: build-native
     if: ${{ github.event.inputs.confirm == 'I_UNDERSTAND_USER_IMPACT' }}
-    runs-on: ubuntu-22.04
+    runs-on: sylphx-linux-standard
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/registry-install-proof.yml
+++ b/.github/workflows/registry-install-proof.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   proof-linux-x64:
-    runs-on: ubuntu-22.04
+    runs-on: sylphx-linux-standard
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -34,7 +34,7 @@ jobs:
           bun scripts/check-registry-install-proof.ts --registry --version="$VERSION"
 
   proof-linux-arm64:
-    runs-on: ubuntu-22.04-arm
+    runs-on: sylphx-linux-standard
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -72,7 +72,7 @@ jobs:
           bun scripts/check-registry-install-proof.ts --registry --version="$VERSION"
 
   proof-windows:
-    runs-on: windows-latest
+    runs-on: [self-hosted, Windows, X64]
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
     steps:
       - name: Create release bot token
         id: release-token

--- a/.github/workflows/republish-native-package.yml
+++ b/.github/workflows/republish-native-package.yml
@@ -28,10 +28,10 @@ jobs:
       matrix:
         include:
           - platformId: linux-x64-gnu
-            runner: ubuntu-22.04
+            runner: sylphx-linux-standard
             target: x86_64-unknown-linux-gnu
           - platformId: linux-arm64-gnu
-            runner: ubuntu-22.04-arm
+            runner: sylphx-linux-standard
             target: aarch64-unknown-linux-gnu
           - platformId: darwin-arm64
             runner: [self-hosted, sylphx, macos, standard]
@@ -40,7 +40,7 @@ jobs:
             runner: [self-hosted, sylphx, macos, standard]
             target: x86_64-apple-darwin
           - platformId: win32-x64-msvc
-            runner: windows-latest
+            runner: sylphx-linux-standard
             target: x86_64-pc-windows-msvc
     steps:
       - name: Only run selected platform

--- a/.github/workflows/rust-parity-differential.yml
+++ b/.github/workflows/rust-parity-differential.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   map-and-stale:
     name: rust-parity-drift-pass/map-and-stale
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
     timeout-minutes: 5
     outputs:
       stale_capabilities: ${{ steps.map.outputs.stale }}
@@ -67,7 +67,7 @@ jobs:
   differential:
     name: rust-parity-drift-pass/differential
     needs: map-and-stale
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
     timeout-minutes: 30
     env:
       CANDIDATE_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
@@ -2689,7 +2689,7 @@ jobs:
 
   rust-parity-drift-pass:
     name: rust-parity-drift-pass/pass
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
     timeout-minutes: 5
     needs:
       - map-and-stale

--- a/.github/workflows/unpublish-bad-versions.yml
+++ b/.github/workflows/unpublish-bad-versions.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   unpublish:
-    runs-on: ubuntu-latest
+    runs-on: sylphx-linux-standard
     if: ${{ github.event.inputs.confirm == 'UNPUBLISH' }}
     steps:
       - name: Setup Node


### PR DESCRIPTION
Fleet policy: never use GitHub-hosted runners. Migrate all `ubuntu-*`/`windows-*`/`macos-*` hosted labels to Sylphx self-hosted runners (`sylphx-linux-standard` for Linux).