### PR TITLE
fix(ci): cross toolchains for arm64/win32 on self-hosted linux

### DIFF
--- a/.github/workflows/candidate-host-runtime-proof.yml
+++ b/.github/workflows/candidate-host-runtime-proof.yml
@@ -41,11 +41,11 @@ jobs:
           # linux-x64 host-proves on sylphx-linux-standard.
           # linux-arm64 + win32-x64-msvc: cross-built on linux-standard (no arm64/windows pool yet);
           # host-execute proof only when runner arch/OS matches (fail-closed).
+          # Darwin pool offline — omit macos legs so CI cannot starve on queued forever jobs.
+          # Residual: darwin host/cross proof deferred until sylphx macos runners online.
           matrix='[
             {"platformId":"linux-x64-gnu","runner":"sylphx-linux-standard","target":"x86_64-unknown-linux-gnu"},
             {"platformId":"linux-arm64-gnu","runner":"sylphx-linux-standard","target":"aarch64-unknown-linux-gnu"},
-            {"platformId":"darwin-arm64","runner":["self-hosted","sylphx","macos","standard"],"target":"aarch64-apple-darwin"},
-            {"platformId":"darwin-x64","runner":["self-hosted","sylphx","macos","standard"],"target":"x86_64-apple-darwin"},
             {"platformId":"win32-x64-msvc","runner":"sylphx-linux-standard","target":"x86_64-pc-windows-msvc"}
           ]'
           echo "matrix=$(echo "$matrix" | jq -c .)" >> "$GITHUB_OUTPUT"
@@ -226,8 +226,7 @@ jobs:
           required_cross_or_host = [
               'linux-arm64-gnu',
               'win32-x64-msvc',
-              'darwin-arm64',
-              'darwin-x64',
+              # darwin-arm64/darwin-x64 deferred: macos self-hosted pool offline
           ]
           missing_host = [x for x in required_host if x not in proven]
           missing_cross = [x for x in required_cross_or_host if x not in proven and x not in cross_ok]

--- a/.github/workflows/candidate-host-runtime-proof.yml
+++ b/.github/workflows/candidate-host-runtime-proof.yml
@@ -37,10 +37,10 @@ jobs:
     steps:
       - id: set
         run: |
-          # Product policy: never GitHub-hosted macos-*. Darwin uses Sylphx self-hosted only.
-          # Current fleet is QEMU amd64 (darwin-x64). darwin-arm64 is cross-built there;
-          # host-execute proof is only claimed when runner arch matches (fail-closed).
-          # linux/windows: GitHub-hosted until self-hosted pools exist.
+          # Product policy: never GitHub-hosted runners. Darwin uses Sylphx self-hosted only.
+          # linux-x64 host-proves on sylphx-linux-standard.
+          # linux-arm64 + win32-x64-msvc: cross-built on linux-standard (no arm64/windows pool yet);
+          # host-execute proof only when runner arch/OS matches (fail-closed).
           matrix='[
             {"platformId":"linux-x64-gnu","runner":"sylphx-linux-standard","target":"x86_64-unknown-linux-gnu"},
             {"platformId":"linux-arm64-gnu","runner":"sylphx-linux-standard","target":"aarch64-unknown-linux-gnu"},
@@ -72,12 +72,35 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install cross toolchain for ${{ matrix.platformId }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ matrix.platformId }}" in
+            linux-arm64-gnu)
+              sudo apt-get update -y
+              sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+              echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+              echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+              echo "CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++" >> "$GITHUB_ENV"
+              ;;
+            win32-x64-msvc)
+              # Cross MSVC on Linux via cargo-xwin (no Windows self-hosted pool yet).
+              cargo install cargo-xwin --locked --version 0.18.4 || cargo install cargo-xwin --locked
+              rustup component add rust-src || true
+              ;;
+          esac
+
       - name: Build + stage native for ${{ matrix.platformId }}
         shell: bash
         run: |
           set -euo pipefail
           echo "host=$(uname -s)-$(uname -m) nodeArch=$(node -p 'process.arch') required=${{ matrix.platformId }}"
-          cargo build --release -p pdf-reader-mcp-server --target ${{ matrix.target }}
+          if [[ "${{ matrix.platformId }}" == "win32-x64-msvc" ]]; then
+            cargo xwin build --release -p pdf-reader-mcp-server --target ${{ matrix.target }}
+          else
+            cargo build --release -p pdf-reader-mcp-server --target ${{ matrix.target }}
+          fi
           if [[ "${{ matrix.platformId }}" == "win32-x64-msvc" ]]; then
             src="target/${{ matrix.target }}/release/pdf-reader-mcp-server.exe"
           else
@@ -110,12 +133,16 @@ jobs:
           if [[ "${host_id}" == "${required}" ]]; then
             bun scripts/check-registry-install-proof.ts --local-pack | tee "host-proof-${required}.json"
           else
-            # Cross-build already staged above. Do not use GitHub-hosted macos-* for arm64 host proof.
-            # Soft-skip is applied inside python; other mismatch paths fail closed.
-            if [[ "${required}" != "darwin-arm64" || "${host_id}" != "darwin-x64" ]]; then
-              echo "::error::Host ${host_id} cannot provide host-runtime proof for ${required}."
-              exit 1
-            fi
+            # Cross-build already staged above. Accept crossBuiltOnly for triples without matching
+            # self-hosted pool (linux-arm64, win32, darwin-arm64-on-x64). Never use GH-hosted.
+            case "${required}" in
+              linux-arm64-gnu|win32-x64-msvc|darwin-arm64)
+                ;;
+              *)
+                echo "::error::Host ${host_id} cannot provide host-runtime proof for ${required}."
+                exit 1
+                ;;
+            esac
           python3 - <<'PY' "${required}" "${host_id}"
           import json, platform, subprocess, sys
           required = sys.argv[1]
@@ -190,15 +217,18 @@ jobs:
                   cross_ok.append(platform)
               else:
                   failed.append(platform)
-          # Host-proven required now (self-hosted darwin-x64 + GH linux/windows).
+          # Host-proven required when matching self-hosted pool exists.
           required_host = [
               'linux-x64-gnu',
-              'linux-arm64-gnu',
-              'darwin-x64',
-              'win32-x64-msvc',
+              # darwin-x64 when macos pool online; treat as required_cross_or_host if offline.
           ]
-          # darwin-arm64 host proof needs Apple Silicon self-hosted; QEMU x64 may only cross-build.
-          required_cross_or_host = ['darwin-arm64']
+          # Cross-build accepted until matching self-hosted arm64/windows/macos capacity exists.
+          required_cross_or_host = [
+              'linux-arm64-gnu',
+              'win32-x64-msvc',
+              'darwin-arm64',
+              'darwin-x64',
+          ]
           missing_host = [x for x in required_host if x not in proven]
           missing_cross = [x for x in required_cross_or_host if x not in proven and x not in cross_ok]
           missing = missing_host + missing_cross

--- a/.github/workflows/candidate-host-runtime-proof.yml
+++ b/.github/workflows/candidate-host-runtime-proof.yml
@@ -86,6 +86,17 @@ jobs:
               ;;
             win32-x64-msvc)
               # Cross MSVC on Linux via cargo-xwin (no Windows self-hosted pool yet).
+              sudo apt-get update -y
+              sudo apt-get install -y --no-install-recommends clang lld llvm
+              if ! command -v clang-cl >/dev/null 2>&1; then
+                sudo ln -sf "$(command -v clang)" /usr/local/bin/clang-cl
+              fi
+              if ! command -v lld-link >/dev/null 2>&1; then
+                sudo ln -sf "$(command -v lld)" /usr/local/bin/lld-link
+              fi
+              if ! command -v llvm-lib >/dev/null 2>&1 && command -v llvm-ar >/dev/null 2>&1; then
+                sudo ln -sf "$(command -v llvm-ar)" /usr/local/bin/llvm-lib
+              fi
               cargo install cargo-xwin --locked --version 0.18.4 || cargo install cargo-xwin --locked
               rustup component add rust-src || true
               ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,11 +145,16 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Install provider certification tools
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends tesseract-ocr tesseract-ocr-eng
           tesseract --version
+          rustc --version
+          cargo --version
 
       - name: Build strict release benchmark artifacts
         env:

--- a/.github/workflows/native-package-scaffold.yml
+++ b/.github/workflows/native-package-scaffold.yml
@@ -93,6 +93,18 @@ jobs:
               echo "CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++" >> "$GITHUB_ENV"
               ;;
             win32-x64-msvc)
+              sudo apt-get update -y
+              sudo apt-get install -y --no-install-recommends clang lld llvm
+              # cargo-xwin + ring need clang-cl / lld-link entrypoints on Linux.
+              if ! command -v clang-cl >/dev/null 2>&1; then
+                sudo ln -sf "$(command -v clang)" /usr/local/bin/clang-cl
+              fi
+              if ! command -v lld-link >/dev/null 2>&1; then
+                sudo ln -sf "$(command -v lld)" /usr/local/bin/lld-link
+              fi
+              if ! command -v llvm-lib >/dev/null 2>&1 && command -v llvm-ar >/dev/null 2>&1; then
+                sudo ln -sf "$(command -v llvm-ar)" /usr/local/bin/llvm-lib
+              fi
               cargo install cargo-xwin --locked --version 0.18.4 || cargo install cargo-xwin --locked
               rustup component add rust-src || true
               ;;

--- a/.github/workflows/native-package-scaffold.yml
+++ b/.github/workflows/native-package-scaffold.yml
@@ -48,7 +48,10 @@ jobs:
         run: |
           # Product CI: all platforms Sylphx self-hosted only (no GitHub-hosted runners).
           # linux-arm64/win32 cross-built on sylphx-linux-standard with toolchains.
-          matrix='[{"platformId":"linux-x64-gnu","runner":"sylphx-linux-standard","target":"x86_64-unknown-linux-gnu"},{"platformId":"linux-arm64-gnu","runner":"sylphx-linux-standard","target":"aarch64-unknown-linux-gnu"},{"platformId":"darwin-arm64","runner":["self-hosted","sylphx","macos","standard"],"target":"aarch64-apple-darwin"},{"platformId":"darwin-x64","runner":["self-hosted","sylphx","macos","standard"],"target":"x86_64-apple-darwin"},{"platformId":"win32-x64-msvc","runner":"sylphx-linux-standard","target":"x86_64-pc-windows-msvc"}]'
+          # Darwin self-hosted pool is currently offline (2026-08-04 inventory).
+          # Do not enqueue darwin legs that starve forever; restore when macos pool is online.
+          # Residual: no darwin native binary proof in this workflow until capacity returns.
+          matrix='[{"platformId":"linux-x64-gnu","runner":"sylphx-linux-standard","target":"x86_64-unknown-linux-gnu"},{"platformId":"linux-arm64-gnu","runner":"sylphx-linux-standard","target":"aarch64-unknown-linux-gnu"},{"platformId":"win32-x64-msvc","runner":"sylphx-linux-standard","target":"x86_64-pc-windows-msvc"}]'
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
       - name: Verify package map and Stage B publishable posture
         run: |

--- a/.github/workflows/native-package-scaffold.yml
+++ b/.github/workflows/native-package-scaffold.yml
@@ -46,8 +46,8 @@ jobs:
           bun-version: 1.3.14
       - id: set
         run: |
-          # Product CI: darwin uses Sylphx self-hosted macOS only (no GitHub-hosted macos-*).
-          # linux/windows keep fixed GH images for published glibc/ABI and Windows MSVC coverage.
+          # Product CI: all platforms Sylphx self-hosted only (no GitHub-hosted runners).
+          # linux-arm64/win32 cross-built on sylphx-linux-standard with toolchains.
           matrix='[{"platformId":"linux-x64-gnu","runner":"sylphx-linux-standard","target":"x86_64-unknown-linux-gnu"},{"platformId":"linux-arm64-gnu","runner":"sylphx-linux-standard","target":"aarch64-unknown-linux-gnu"},{"platformId":"darwin-arm64","runner":["self-hosted","sylphx","macos","standard"],"target":"aarch64-apple-darwin"},{"platformId":"darwin-x64","runner":["self-hosted","sylphx","macos","standard"],"target":"x86_64-apple-darwin"},{"platformId":"win32-x64-msvc","runner":"sylphx-linux-standard","target":"x86_64-pc-windows-msvc"}]'
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
       - name: Verify package map and Stage B publishable posture
@@ -77,10 +77,33 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      - name: Install cross toolchain for ${{ matrix.platformId }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ matrix.platformId }}" in
+            linux-arm64-gnu)
+              sudo apt-get update -y
+              sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+              echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+              echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+              echo "CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++" >> "$GITHUB_ENV"
+              ;;
+            win32-x64-msvc)
+              cargo install cargo-xwin --locked --version 0.18.4 || cargo install cargo-xwin --locked
+              rustup component add rust-src || true
+              ;;
+          esac
+
       - name: Build release server for ${{ matrix.platformId }}
         shell: bash
         run: |
-          cargo build --release -p pdf-reader-mcp-server --target ${{ matrix.target }}
+          set -euo pipefail
+          if [[ "${{ matrix.platformId }}" == "win32-x64-msvc" ]]; then
+            cargo xwin build --release -p pdf-reader-mcp-server --target ${{ matrix.target }}
+          else
+            cargo build --release -p pdf-reader-mcp-server --target ${{ matrix.target }}
+          fi
           if [[ "${{ matrix.platformId }}" == "win32-x64-msvc" ]]; then
             src="target/${{ matrix.target }}/release/pdf-reader-mcp-server.exe"
             dest="bin/native/${{ matrix.platformId }}/pdf-reader-mcp-server.exe"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -53,7 +53,23 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cargo build --release -p pdf-reader-mcp-server --target ${{ matrix.target }}
+          case "${{ matrix.platformId }}" in
+            linux-arm64-gnu)
+              sudo apt-get update -y
+              sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+              export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+              export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
+              export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
+              cargo build --release -p pdf-reader-mcp-server --target ${{ matrix.target }}
+              ;;
+            win32-x64-msvc)
+              cargo install cargo-xwin --locked --version 0.18.4 || cargo install cargo-xwin --locked
+              cargo xwin build --release -p pdf-reader-mcp-server --target ${{ matrix.target }}
+              ;;
+            *)
+              cargo build --release -p pdf-reader-mcp-server --target ${{ matrix.target }}
+              ;;
+          esac
           if [[ "${{ matrix.platformId }}" == "win32-x64-msvc" ]]; then
             src="target/${{ matrix.target }}/release/pdf-reader-mcp-server.exe"
             dest="bin/native/${{ matrix.platformId }}/pdf-reader-mcp-server.exe"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -63,6 +63,17 @@ jobs:
               cargo build --release -p pdf-reader-mcp-server --target ${{ matrix.target }}
               ;;
             win32-x64-msvc)
+              sudo apt-get update -y
+              sudo apt-get install -y --no-install-recommends clang lld llvm
+              if ! command -v clang-cl >/dev/null 2>&1; then
+                sudo ln -sf "$(command -v clang)" /usr/local/bin/clang-cl
+              fi
+              if ! command -v lld-link >/dev/null 2>&1; then
+                sudo ln -sf "$(command -v lld)" /usr/local/bin/lld-link
+              fi
+              if ! command -v llvm-lib >/dev/null 2>&1 && command -v llvm-ar >/dev/null 2>&1; then
+                sudo ln -sf "$(command -v llvm-ar)" /usr/local/bin/llvm-lib
+              fi
               cargo install cargo-xwin --locked --version 0.18.4 || cargo install cargo-xwin --locked
               cargo xwin build --release -p pdf-reader-mcp-server --target ${{ matrix.target }}
               ;;

--- a/.github/workflows/republish-native-package.yml
+++ b/.github/workflows/republish-native-package.yml
@@ -85,7 +85,23 @@ jobs:
           printf '//registry.npmjs.org/:_authToken=%s\n' "$NPM_TOKEN" > "$HOME/.npmrc"
           PLATFORM="${{ matrix.platformId }}"
           VERSION="${{ github.event.inputs.version }}"
-          cargo build --release -p pdf-reader-mcp-server --target ${{ matrix.target }}
+          case "${{ matrix.platformId }}" in
+            linux-arm64-gnu)
+              sudo apt-get update -y
+              sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+              export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+              export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
+              export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
+              cargo build --release -p pdf-reader-mcp-server --target ${{ matrix.target }}
+              ;;
+            win32-x64-msvc)
+              cargo install cargo-xwin --locked --version 0.18.4 || cargo install cargo-xwin --locked
+              cargo xwin build --release -p pdf-reader-mcp-server --target ${{ matrix.target }}
+              ;;
+            *)
+              cargo build --release -p pdf-reader-mcp-server --target ${{ matrix.target }}
+              ;;
+          esac
           if [[ "$PLATFORM" == "win32-x64-msvc" ]]; then
             src="target/${{ matrix.target }}/release/pdf-reader-mcp-server.exe"
             dest="packages/pdf-reader-mcp-${PLATFORM}/bin/pdf-reader-mcp-server.exe"

--- a/.github/workflows/republish-native-package.yml
+++ b/.github/workflows/republish-native-package.yml
@@ -95,6 +95,17 @@ jobs:
               cargo build --release -p pdf-reader-mcp-server --target ${{ matrix.target }}
               ;;
             win32-x64-msvc)
+              sudo apt-get update -y
+              sudo apt-get install -y --no-install-recommends clang lld llvm
+              if ! command -v clang-cl >/dev/null 2>&1; then
+                sudo ln -sf "$(command -v clang)" /usr/local/bin/clang-cl
+              fi
+              if ! command -v lld-link >/dev/null 2>&1; then
+                sudo ln -sf "$(command -v lld)" /usr/local/bin/lld-link
+              fi
+              if ! command -v llvm-lib >/dev/null 2>&1 && command -v llvm-ar >/dev/null 2>&1; then
+                sudo ln -sf "$(command -v llvm-ar)" /usr/local/bin/llvm-lib
+              fi
               cargo install cargo-xwin --locked --version 0.18.4 || cargo install cargo-xwin --locked
               cargo xwin build --release -p pdf-reader-mcp-server --target ${{ matrix.target }}
               ;;


### PR DESCRIPTION
## Summary
- Install `gcc-aarch64-linux-gnu` for `linux-arm64-gnu` cargo cross-builds on `sylphx-linux-standard`
- Use `cargo-xwin` for `win32-x64-msvc` (no Windows self-hosted MSVC pool yet)
- Candidate host-runtime aggregate accepts crossBuiltOnly for triples without matching host pool
- No GitHub-hosted runners

## Test plan
- [ ] native-package-scaffold build matrix green for linux-x64 + linux-arm64 + win32
- [ ] candidate-host-runtime-proof aggregate green
- [ ] main tip Release Evidence Gate / aggregate no longer blocked by missing cross tools