### PR TITLE
chore(actions)(deps): bump actions/deploy-pages from 4 to 5

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Recreated on the current main after the original Dependabot PR was closed by the merge-queue command. Contains the same dependency-only action update and is ready for normal merge-queue admission.