### PR TITLE
chore(actions)(deps): bump actions/setup-node from 4 to 7

### DIFF
--- a/.github/workflows/fix-citra-alias.yml
+++ b/.github/workflows/fix-citra-alias.yml
@@ -16,7 +16,7 @@ jobs:
     if: ${{ inputs.confirm == 'FIX_CITRA' }}
     runs-on: sylphx-linux-standard
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish-brand-alias.yml
+++ b/.github/workflows/publish-brand-alias.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ inputs.confirm == 'PUBLISH' }}
     runs-on: sylphx-linux-standard
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/registry-install-proof.yml
+++ b/.github/workflows/registry-install-proof.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.14"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           registry-url: https://registry.npmjs.org
@@ -40,7 +40,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.14"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           registry-url: https://registry.npmjs.org
@@ -59,7 +59,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.14"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           registry-url: https://registry.npmjs.org
@@ -78,7 +78,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.14"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
Recreated on the current main after the original Dependabot PR was closed by the merge-queue command. Contains the same dependency-only action update and is ready for normal merge-queue admission.