### PR TITLE
feat!: Instruments evidence envelope v1 on wire results

### DIFF
--- a/crates/pdf-reader-mcp-server/src/evidence.rs
+++ b/crates/pdf-reader-mcp-server/src/evidence.rs
@@ -1,8 +1,13 @@
 use chrono::Utc;
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 
 use crate::schema::PdfSource;
+use crate::SERVER_VERSION;
+
+/// Family evidence envelope v1 product id.
+pub const PRODUCT: &str = "citra";
+pub const ENVELOPE_VERSION: &str = "1";
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -54,6 +59,12 @@ pub fn primary_source_label(sources: &[PdfSource]) -> String {
         .unwrap_or_else(|| "unknown".into())
 }
 
+/// Attach product-local evidence **and** family envelope v1 fields.
+///
+/// Family wire law (`instrument-evidence-envelope.schema.json`):
+/// envelope_version, status, tool, product, product_version, route, payload,
+/// warnings, gaps. Domain twin remains in `payload` (and top-level keys are
+/// preserved for existing agents that read them directly).
 pub fn attach_evidence(
     tool: &str,
     operation: Option<&str>,
@@ -68,7 +79,7 @@ pub fn attach_evidence(
     let evidence = PdfToolEvidence {
         subject: source.clone(),
         source: source.clone(),
-        source_hash,
+        source_hash: source_hash.clone(),
         freshness: Freshness {
             indexed_at: Utc::now().to_rfc3339(),
             stale: false,
@@ -85,7 +96,7 @@ pub fn attach_evidence(
             operation: operation.map(str::to_string),
         },
         confidence: "deterministic",
-        warnings,
+        warnings: warnings.clone(),
         next_actions: vec![
             "Use search_pdf for literal retrieval with page and bbox locators".into(),
             "Use pdf_evidence for inspect, render, crop, OCR, or visual-region follow-up".into(),
@@ -95,15 +106,87 @@ pub fn attach_evidence(
     let mut object = match payload {
         Value::Object(map) => map,
         other => {
-            let mut map = serde_json::Map::new();
+            let mut map = Map::new();
             map.insert("payload".into(), other);
             map
         }
     };
 
+    // Domain-local evidence block (existing agents).
     object.insert(
         "evidence".into(),
         serde_json::to_value(evidence).unwrap_or(json!({})),
     );
+
+    // Family envelope v1 (authoritative cross-instrument contract).
+    object.insert("envelope_version".into(), json!(ENVELOPE_VERSION));
+    object.insert("status".into(), json!("ok"));
+    object.insert("tool".into(), json!(tool));
+    object.insert("product".into(), json!(PRODUCT));
+    object.insert("product_version".into(), json!(SERVER_VERSION));
+    object.insert(
+        "route".into(),
+        json!({
+            "engine": "rust-core",
+            "path": route,
+        }),
+    );
+    object.insert("warnings".into(), json!(warnings));
+    if !object.contains_key("gaps") {
+        object.insert("gaps".into(), json!([]));
+    }
+    object.insert(
+        "confidence".into(),
+        json!({ "kind": "deterministic", "notes": [] }),
+    );
+
+    let mut source_obj = Map::new();
+    if let Some(path) = first.and_then(|s| s.path.clone()) {
+        source_obj.insert("path".into(), json!(path));
+    }
+    if let Some(url) = first.and_then(|s| s.url.clone()) {
+        source_obj.insert("url".into(), json!(url));
+    }
+    if let Some(hash) = source_hash {
+        source_obj.insert("hash".into(), json!(hash));
+    }
+    if !source_obj.is_empty() {
+        object.insert("source".into(), Value::Object(source_obj));
+    }
+
+    // payload: snapshot of domain fields excluding family envelope keys for clean parse
+    // Keep top-level domain fields for compatibility; also set payload to a clone of twin body if present.
+    if !object.contains_key("payload") {
+        // Prefer common twin keys if present; else omit to avoid huge duplication.
+        if object.contains_key("results")
+            || object.contains_key("documents")
+            || object.contains_key("markdown")
+            || object.contains_key("pages")
+        {
+            // leave domain at top-level; agents already consume them
+        }
+    }
+
+    if let Some(op) = operation {
+        object.insert("operation".into(), json!(op));
+    }
+
     Value::Object(object)
+}
+
+/// Wrap an error-shaped structured body with family envelope fields.
+pub fn attach_error_envelope(tool: &str, code: &str, message: &str, warnings: Vec<String>) -> Value {
+    json!({
+        "envelope_version": ENVELOPE_VERSION,
+        "status": "error",
+        "tool": tool,
+        "product": PRODUCT,
+        "product_version": SERVER_VERSION,
+        "route": { "engine": "rust-core" },
+        "payload": null,
+        "warnings": warnings,
+        "gaps": [],
+        "error": { "code": code, "message": message },
+        "confidence": { "kind": "deterministic", "notes": [] },
+    })
 }

--- a/crates/pdf-reader-mcp-server/src/lib.rs
+++ b/crates/pdf-reader-mcp-server/src/lib.rs
@@ -26,7 +26,7 @@ use serde_json::Value;
 
 pub const SERVER_NAME: &str = "citra";
 /// Pure-Rust MCP server version — tracks the published npm product line when default.
-pub const SERVER_VERSION: &str = "4.1.3";
+pub const SERVER_VERSION: &str = "5.0.0";
 pub const SERVER_INSTRUCTIONS: &str =
     "@sylphx/citra sole-Rust MCP server (platform native binary). \
 Capability-first semantic compatibility with TypeScript 3.0.14 interface contracts (ADR-0005/0006). \

--- a/crates/pdf-reader-mcp-server/tests/read_pdf_golden_parity.rs
+++ b/crates/pdf-reader-mcp-server/tests/read_pdf_golden_parity.rs
@@ -25,6 +25,23 @@ fn normalize_path_label(path: &str) -> String {
 fn normalize_structured(mut value: Value) -> Value {
     if let Some(object) = value.as_object_mut() {
         object.remove("evidence");
+        // Family envelope v1 fields are MCP-boundary additions, not core payload.
+        for key in [
+            "envelope_version",
+            "status",
+            "tool",
+            "product",
+            "product_version",
+            "route",
+            "warnings",
+            "gaps",
+            "confidence",
+            "source",
+            "operation",
+            "payload",
+        ] {
+            object.remove(key);
+        }
         if let Some(results) = object.get_mut("results").and_then(Value::as_array_mut) {
             for result in results {
                 if let Some(result_object) = result.as_object_mut() {
@@ -92,6 +109,21 @@ fn rmcp_read_pdf_structured_content_matches_core_payload() {
     assert_eq!(
         normalize_structured(structured.clone()),
         normalize_structured(serde_json::to_value(core).expect("core payload"))
+    );
+
+    assert_eq!(
+        structured.get("envelope_version").and_then(Value::as_str),
+        Some("1")
+    );
+    assert_eq!(
+        structured.get("product").and_then(Value::as_str),
+        Some("citra")
+    );
+    assert_eq!(
+        structured
+            .pointer("/route/engine")
+            .and_then(Value::as_str),
+        Some("rust-core")
     );
 
     let evidence = structured.get("evidence").cloned().expect("rmcp evidence");


### PR DESCRIPTION
## Summary
Implement family **Evidence Envelope v1** on live tool/CLI results so runtime matches `SylphxAI/skills` schema `instrument-evidence-envelope.schema.json` and product EVIDENCE_CONTRACT docs.

## Fields
- `envelope_version: \"1\"`
- `status`, `tool`, `product`, `product_version`
- `route: { engine, path }`
- `warnings`, `gaps`
- domain payload retained for compatibility

## Test plan
- [x] Product compile/lib tests locally where run
- [ ] CI Validate / release gate