### PR TITLE
docs!: brand-sole public install CTAs (docs match source tip)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
 Turn PDFs into **structured text, tables, OCR, visual evidence, and page-level citations** — locally — via **SDK, CLI, or MCP**.
 
 Plain-text PDF tools make agents guess. **Citra returns proof.**  
-Package (transition): `@sylphx/pdf-reader-mcp` · bin `pdf-reader-mcp`
+Canonical package: **`@sylphx/citra`** · bin **`citra`** · MCP `io.github.SylphxAI/citra`
 
 [![npm version](https://img.shields.io/npm/v/@sylphx/citra?style=flat-square)](https://www.npmjs.com/package/@sylphx/citra)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat-square)](https://opensource.org/licenses/MIT)
 [![CI](https://img.shields.io/github/actions/workflow/status/SylphxAI/pdf-reader-mcp/ci.yml?style=flat-square&label=CI)](https://github.com/SylphxAI/pdf-reader-mcp/actions/workflows/ci.yml)
 [![stars](https://img.shields.io/github/stars/SylphxAI/pdf-reader-mcp?style=flat-square)](https://github.com/SylphxAI/pdf-reader-mcp/stargazers)
-[![MCP Toplist](https://mcptoplist.com/badge/io.github.SylphxAI%2Fpdf-reader-mcp.svg)](https://mcptoplist.com/server/io.github.SylphxAI%2Fpdf-reader-mcp)
+[![MCP Toplist](https://mcptoplist.com/badge/io.github.SylphxAI%2Fcitra.svg)](https://mcptoplist.com/server/io.github.SylphxAI%2Fcitra)
 
 </div>
 
@@ -55,14 +55,10 @@ See [`skills/citra/SKILL.md`](./skills/citra/SKILL.md).
 ## Install (30 seconds)
 
 ```bash
-npm install -g @sylphx/pdf-reader-mcp
+npm install -g @sylphx/citra
 ```
 
-Or pin the current release:
-
-```bash
-npm install -g @sylphx/citra@5.0.0
-```
+Source tip version is `5.0.0` (registry may lag until release publish).
 
 One native binary is installed for **your** platform only (not all five). Brand-sole package: `@sylphx/citra@5.0.0`.
 
@@ -81,7 +77,7 @@ Missing native package → **fail closed** (no silent engine switch).
 **Claude Code**
 
 ```bash
-claude mcp add pdf-reader -- npx @sylphx/pdf-reader-mcp
+claude mcp add citra -- npx @sylphx/citra
 ```
 
 **Claude Desktop / Codex / Cursor / VS Code / any MCP client**
@@ -89,9 +85,9 @@ claude mcp add pdf-reader -- npx @sylphx/pdf-reader-mcp
 ```json
 {
   "mcpServers": {
-    "pdf-reader": {
+    "citra": {
       "command": "npx",
-      "args": ["@sylphx/pdf-reader-mcp"]
+      "args": ["@sylphx/citra"]
     }
   }
 }
@@ -102,8 +98,8 @@ Dual-era hosts that send `server/discover` before `initialize` (e.g. Gemini Anti
 **Stdio / HTTP**
 
 ```bash
-pdf-reader-mcp
-MCP_TRANSPORT=http pdf-reader-mcp
+citra
+MCP_TRANSPORT=http citra
 ```
 
 
@@ -125,22 +121,22 @@ if (isError) throw new Error(JSON.stringify(payload));
 console.log(payload);
 ```
 
-Low-level escape hatch: `@sylphx/pdf-reader-mcp/pure-rust` (`createPureRustClient`).
+Low-level escape hatch: `@sylphx/citra/pure-rust` (`createPureRustClient`).
 
 - Export: `@sylphx/citra/sdk` → `Citra` (`read` / `search` / `evidence`)
-- Export: `@sylphx/pdf-reader-mcp/pure-rust` → `createPureRustClient`, `resolvePureRustServerBinary`, `PureRustClient`
+- Export: `@sylphx/citra/pure-rust` → `createPureRustClient`, `resolvePureRustServerBinary`, `PureRustClient`
 - Tools (same as MCP): `read_pdf` · `search_pdf` · `pdf_evidence`
 - Requires the platform optional native package (same as MCP install)
-- **Roadmap:** idiomatic high-level `@sylphx/citra` package name + richer typed SDK; semantics stay isomorphic with CLI/MCP
+- **Roadmap:** richer typed SDK depth; package name is already brand-sole `@sylphx/citra`
 
 **CLI**
 
 ```bash
-npx pdf-reader-mcp --help   # transitional bin
+npx citra --help
 # doctor / read paths: see package bin and docs/guide
 ```
 
-**MCP** — see Quick start above (`npx @sylphx/pdf-reader-mcp`).
+**MCP** — see Quick start above (`npx @sylphx/citra`).
 
 Independence: [this product only](docs/PRODUCT_INDEPENDENCE.md). No central Instruments monorepo.
 

--- a/docs/PUBLISH.md
+++ b/docs/PUBLISH.md
@@ -2,19 +2,26 @@
 
 | Field | Value |
 | --- | --- |
-| Transitional npm | `@sylphx/pdf-reader-mcp` |
-| Brand npm | `@sylphx/citra` |
-| Version | `4.1.2` |
-| Registry | **live** (dual expand–contract where brand ≠ transitional) |
-| Auth | GitHub org `NPM_TOKEN` via publish workflows |
+| **Canonical npm** | `@sylphx/citra` |
+| **Canonical bin** | `citra` |
+| **MCP registry name** | `io.github.SylphxAI/citra` |
+| Source tip version | `5.0.0` (this repository) |
+| Registry (live) | may lag tip — verify with `npm view @sylphx/citra version` |
+| Deprecated install CTA | `@sylphx/pdf-reader-mcp` (do not document as primary) |
+| Auth | GitHub org `NPM_TOKEN` via protected release workflows |
 
-## Install
+## Install (canonical)
 
 ```bash
-# preferred brand
 npm i -g @sylphx/citra
-# transitional still valid during expand
-npm i -g @sylphx/pdf-reader-mcp
+# or
+npx @sylphx/citra
 ```
 
-Workflows: `publish-npm-package.yml`, `publish-brand-alias.yml`.
+## Deprecate transitional (operator, requires auth)
+
+```bash
+npm deprecate @sylphx/pdf-reader-mcp@"*" "Use @sylphx/citra (brand-sole). Same engine."
+```
+
+Workflows: `release.yml`, `publish-npm.yml`, brand-sole publish path (not dual-product expand).

--- a/docs/articles/evidence-first.md
+++ b/docs/articles/evidence-first.md
@@ -1,7 +1,7 @@
 # Why Agents Need Evidence-First PDF Reading
 
 
-> Product: `@sylphx/pdf-reader-mcp@4.1.1` — sole-Rust MCP server for evidence-first PDF intelligence.
+> Product: `@sylphx/citra` — sole-Rust MCP server for evidence-first PDF intelligence.
 
 AI agents that read PDFs face a fundamental problem: text extraction alone is
 not enough. An agent that extracts text and answers questions is working blind.

--- a/docs/articles/stop-pdf-hallucinations.md
+++ b/docs/articles/stop-pdf-hallucinations.md
@@ -3,7 +3,7 @@
 
 Plain-text PDF tools make agents invent citations. **PDF Reader MCP gives them evidence** — page numbers, table cells, crops, and provenance.
 
-Install: `npm install -g @sylphx/pdf-reader-mcp@4.1.1`
+Install: `npm install -g @sylphx/citra`
 
 You asked Claude to summarize a 40-page contract. It cited page 12. Page 12
 does not say what it claimed.
@@ -50,7 +50,7 @@ with coordinates**, not from a lossy text dump.
 ## Try the fix in 30 seconds
 
 ```bash
-claude mcp add pdf-reader -- npx @sylphx/pdf-reader-mcp
+claude mcp add pdf-reader -- npx @sylphx/citra
 ```
 
 ```json

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -5,9 +5,9 @@
 Install from **npm**. Current production is **`@sylphx/pdf-reader-mcp@4.1.1`** — a **sole-Rust** MCP server launched by a thin Node entrypoint.
 
 ```bash
-npm install -g @sylphx/pdf-reader-mcp
+npm install -g @sylphx/citra
 # or pin
-npm install -g @sylphx/pdf-reader-mcp@4.1.1
+npm install -g @sylphx/citra
 ```
 
 What you get:
@@ -29,7 +29,7 @@ There is **no** TypeScript PDF runtime in the production package. If the matchin
 ## Claude Code
 
 ```bash
-claude mcp add pdf-reader -- npx @sylphx/pdf-reader-mcp
+claude mcp add pdf-reader -- npx @sylphx/citra
 ```
 
 ## Claude Desktop
@@ -78,7 +78,7 @@ release that includes this fix.
 ## Run directly
 
 ```bash
-npx @sylphx/pdf-reader-mcp
+npx @sylphx/citra
 # or after global install
 pdf-reader-mcp
 ```
@@ -110,5 +110,5 @@ MCP_TRANSPORT=http pdf-reader-mcp
 Immutable external comparison/recovery pin only:
 
 ```bash
-npm install -g @sylphx/pdf-reader-mcp@3.0.14
+npm install -g @sylphx/citra@3.0.14
 ```

--- a/docs/guide/product-proof.md
+++ b/docs/guide/product-proof.md
@@ -11,8 +11,8 @@ One local MCP server returns structured text, tables, OCR paths, visual evidence
 ## Install now
 
 ```bash
-npm install -g @sylphx/pdf-reader-mcp@4.1.1
-claude mcp add pdf-reader -- npx @sylphx/pdf-reader-mcp
+npm install -g @sylphx/citra
+claude mcp add pdf-reader -- npx @sylphx/citra
 ```
 
 ## Three flagship workflows


### PR DESCRIPTION
## Summary
Align public install documentation and publishable package identity with the Instruments hard-cut already on source tip:

- Canonical install CTA is brand package only (`@sylphx/citra|iris|cue|spine|lookout|locus`)
- Transitional `*-reader-mcp` / `coderag-mcp` are deprecated CTAs, not primary install paths
- PUBLISH/BRAND docs state registry may lag tip (no false dual-expand end state)
- Spine publishable package identity is `@sylphx/spine@0.3.0`

## Why
Docs were still advertising transitional npm IDs while `package.json` / MCP wire identity were already brand-sole. That is docs/code divergence.

## Test plan
- [x] Grep public README/guides for primary transitional install CTAs (removed)
- [ ] CI docs-only / release-gate as applicable