### PR TITLE
fix: portable glibc 2.17 linux natives for citra publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -54,13 +54,11 @@ jobs:
         run: |
           set -euo pipefail
           case "${{ matrix.platformId }}" in
-            linux-arm64-gnu)
-              sudo apt-get update -y
-              sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-              export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
-              export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
-              export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
-              cargo build --release -p pdf-reader-mcp-server --target ${{ matrix.target }}
+            linux-x64-gnu|linux-arm64-gnu)
+              # Publish gate requires GLIBC <= 2.35. Host cargo on modern runners
+              # can link newer glibc (e.g. 2.39). Use cargo-zigbuild for portable 2.17.
+              cargo install cargo-zigbuild --version 0.23.0 --locked
+              cargo zigbuild --release -p pdf-reader-mcp-server --target ${{ matrix.target }}.2.17
               ;;
             win32-x64-msvc)
               sudo apt-get update -y


### PR DESCRIPTION
## Summary
- Root-cause: `Publish npm` staged linux-x64 binary requiring **GLIBC_2.39**, refused by hard gate (`<= 2.35`).
- Fix: build `linux-x64-gnu` and `linux-arm64-gnu` with `cargo zigbuild --target <triple>.2.17` (same approach as Iris/Cue multiarch).

## Evidence
- Failed run: https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/31216257194
- Admission for 5.0.0 brand-sole already on main (#627); re-run Publish npm after this lands (may need admission pin refresh to new HEAD if exact-head is strict beyond pin-path).