### PR TITLE
fix: install zig before cargo-zigbuild in citra publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -49,6 +49,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      # cargo-zigbuild needs zig on PATH for portable linux glibc natives
+      - uses: mlugg/setup-zig@v2
+        if: ${{ matrix.platformId == 'linux-x64-gnu' || matrix.platformId == 'linux-arm64-gnu' }}
+        with:
+          version: 0.14.1
       - name: Build release server for ${{ matrix.platformId }}
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
Publish run [31222476833](https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/31222476833) failed on linux-x64/arm64:

`Error: Failed to find zig` after `cargo install cargo-zigbuild`.

#628 correctly used zigbuild for portable GLIBC 2.17 but omitted `mlugg/setup-zig` (present on Iris/Cue multiarch).

## Test plan
- [ ] CI green
- [ ] Merge + re-dispatch Publish npm
- [ ] linux builds pass GLIBC gate
- [ ] `npm view @sylphx/citra version` → 5.0.0