### PR TITLE
fix: resilient npm readback after citra publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -190,16 +190,35 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="$(jq -r .version package.json)"
-          # npm registry can lag briefly after publish; retry views before failing the job.
-          for i in 1 2 3 4 5 6 7 8 9 10; do
-            if npm view "@sylphx/citra@$VERSION" version               && npm view "@sylphx/citra-linux-x64-gnu@$VERSION" version; then
+          # npm root packuments for brand-new package names can lag after successful publish.
+          # Prefer versioned package documents + longer retries; do not red a job whose
+          # packages already landed (see 5.0.0 publish run that published then failed view).
+          packument_ok() {
+            local name="$1" ver="$2"
+            if npm view "$name@$ver" version >/dev/null 2>&1; then
+              return 0
+            fi
+            local enc
+            enc=$(node -p "encodeURIComponent(process.argv[1])" "$name")
+            local code
+            code=$(curl -sS -o /tmp/npm-packument.json -w '%{http_code}' "https://registry.npmjs.org/$enc/$ver" || true)
+            [ "$code" = "200" ]
+          }
+          ok=0
+          for i in $(seq 1 36); do
+            if packument_ok "@sylphx/citra" "$VERSION" && packument_ok "@sylphx/citra-linux-x64-gnu" "$VERSION"; then
+              ok=1
               break
             fi
-            if [ "$i" -eq 10 ]; then
-              echo "registry readback failed after retries for $VERSION" >&2
-              exit 1
-            fi
-            sleep 6
+            echo "readback wait $i for @sylphx/citra@$VERSION (+ linux-x64-gnu native)"
+            sleep 5
           done
+          if [ "$ok" != "1" ]; then
+            echo "WARN: npm view/packument lag after publish for $VERSION; attempting install proof anyway" >&2
+          else
+            npm view "@sylphx/citra@$VERSION" version bin optionalDependencies || true
+            npm view "@sylphx/citra-linux-x64-gnu@$VERSION" version || true
+          fi
+          # Install proof is the stronger oracle than raw npm view for this job host.
           bun run check:registry-install-proof -- --registry --version="$VERSION"
           # Host-only registry proof in this job; full five-platform pure-Rust initialize remains a dedicated matrix.


### PR DESCRIPTION
## Summary
Publish run for `@sylphx/citra@5.0.0` successfully published main + five natives, then failed **Registry readback** on `npm view` CDN lag for new package names.

## Fix
- Longer retries
- Versioned packument curl fallback
- Continue to install-proof oracle even if view lags (install proof is stronger)

Live registry already proves 5.0.0; this prevents false-red future publishes.