### PR TITLE
docs: citra 5.0.0 linux-x64 host install runtime proof

### DIFF
--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -3,7 +3,7 @@
   "title": "Pure-Rust capability matrix (capability-first semantic admission SSOT)",
   "updated": "2026-07-24",
   "productTruth": {
-    "publishedStable": "@sylphx/citra@5.0.0",
+    "publishedStable": "5.0.0",
     "publishedImplementation": "4.1.2 pure-Rust sole-runtime live (#598); 4.1.3 candidate admits #608 cmap-crash fix + panic-unwind hardening",
     "pureRustStatus": "sole-rust-production-default",
     "optIn": "native optional package required; PDF_READER_MCP_RUST_BIN override allowed; no TS production path",
@@ -112,7 +112,16 @@
       "name": "io.github.SylphxAI/citra",
       "package": "@sylphx/citra",
       "version": "5.0.0"
-    }
+    },
+    "hostInstallRuntimeProofLinuxX64": {
+      "status": "pass",
+      "version": "5.0.0",
+      "package": "@sylphx/citra",
+      "evidence": "verification/citra-host-install-runtime-proof-5.0.0-linux-x64-gnu.json",
+      "serverInfoName": "citra",
+      "boundary": "linux-x64-gnu host install + MCP initialize/tools.list only; not five-platform matrix"
+    },
+    "npmLatestObserved": "5.0.0"
   },
   "legend": {
     "FULL": "Production-usable capability for agent tasks in this slice under the capability-first semantic contract (not exact PDF.js JSON equality)",

--- a/verification/citra-host-install-runtime-proof-5.0.0-linux-x64-gnu.json
+++ b/verification/citra-host-install-runtime-proof-5.0.0-linux-x64-gnu.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": 1,
+  "profile": "citra_host_install_runtime_proof",
+  "reviewedAt": "2026-08-07T23:35:34Z",
+  "package": "@sylphx/citra",
+  "version": "5.0.0",
+  "host": {
+    "platform": "linux-x64-gnu",
+    "install": "npm install @sylphx/citra@5.0.0 --omit=dev",
+    "nativePackage": "@sylphx/citra-linux-x64-gnu@5.0.0",
+    "nativeBinary": "citra-mcp-server",
+    "glibcMaxObserved": "2.17",
+    "glibcGate": "<=2.35"
+  },
+  "mcp": {
+    "initialize": {
+      "serverInfo": {
+        "name": "citra",
+        "version": "5.0.0",
+        "descriptionContains": "sole-Rust MCP server"
+      }
+    },
+    "toolsListIncludes": [
+      "pdf_evidence",
+      "read_pdf"
+    ]
+  },
+  "outcome": "host_install_runtime_pass_linux_x64_gnu",
+  "notes": [
+    "Registry plane already has @sylphx/citra@5.0.0 + five natives.",
+    "Host install resolved optional native and pure-Rust MCP initialize returned brand-sole serverInfo.name=citra.",
+    "Publish workflow readback resilience landed in #632.",
+    "goalCompleteAuthorized may be lifted when five-platform registry install matrix is green; this artifact is host-linux proof only."
+  ],
+  "sourceMainAtRecording": "568a19115630aee8b60b243953bcc7ece958f0c8"
+}


### PR DESCRIPTION
## Summary
Records host-plane evidence for published \`@sylphx/citra@5.0.0\`:
- npm install resolves \`@sylphx/citra-linux-x64-gnu\`
- pure-Rust binary GLIBC max observed 2.17
- MCP initialize \`serverInfo.name=citra\` / \`version=5.0.0\`
- tools/list includes \`read_pdf\`, \`pdf_evidence\`

Does **not** claim five-platform registry install matrix or flip \`goalCompleteAuthorized\`.