### PR TITLE
docs!: brand-sole Citra install CTAs + deprecate transitional workflow

### DIFF
--- a/.github/workflows/deprecate-transitional-npm.yml
+++ b/.github/workflows/deprecate-transitional-npm.yml
@@ -1,0 +1,44 @@
+name: Deprecate transitional npm id
+
+# Clean break: mark @sylphx/pdf-reader-mcp as retired install CTA.
+# Does not unpublish; brand-sole @sylphx/citra remains latest/production.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: Type DEPRECATE_PDF_READER_MCP
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  deprecate:
+    if: ${{ inputs.confirm == 'DEPRECATE_PDF_READER_MCP' }}
+    runs-on: sylphx-linux-standard
+    steps:
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          always-auth: true
+      - name: npm deprecate transitional package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          TOKEN="${NODE_AUTH_TOKEN:-$NPM_TOKEN}"
+          test -n "$TOKEN"
+          printf '//registry.npmjs.org/:_authToken=%s\nalways-auth=true\n' "$TOKEN" > "$HOME/.npmrc"
+          export NPM_CONFIG_USERCONFIG="$HOME/.npmrc"
+          npm whoami
+          MSG='Retired install CTA. Use brand-sole @sylphx/citra (bin: citra). Historical pin only: @sylphx/pdf-reader-mcp@3.0.14.'
+          # Deprecate all versions still serving as accidental installs
+          npm deprecate "@sylphx/pdf-reader-mcp" "$MSG"
+          echo "=== sample ==="
+          npm view @sylphx/pdf-reader-mcp version deprecated dist-tags || true
+          echo "=== brand remains ==="
+          npm view @sylphx/citra version bin dist-tags

--- a/.github/workflows/publish-brand-alias.yml
+++ b/.github/workflows/publish-brand-alias.yml
@@ -1,8 +1,8 @@
 name: Publish brand package
 
 # Clean break: @sylphx/citra is the canonical package built from this repo.
-# Transitional @sylphx/citra must not be dual-published as a second product.
-# Optional: deprecate transitional via workflow_dispatch with DEPRECATE_TRANSITIONAL=true.
+# Transitional @sylphx/pdf-reader-mcp must not be dual-published as a second product.
+# Prefer deprecate-transitional-npm.yml for @sylphx/pdf-reader-mcp retirement.
 
 on:
   workflow_dispatch:
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       deprecate_transitional:
-        description: 'Also npm deprecate @sylphx/citra (true/false)'
+        description: 'Also npm deprecate @sylphx/pdf-reader-mcp (true/false)'
         required: false
         default: 'false'
         type: string
@@ -48,4 +48,4 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
-          npm deprecate "@sylphx/citra@*" "Use @sylphx/citra (brand-sole). Same engine family." || true
+          npm deprecate "@sylphx/pdf-reader-mcp@*" "Use @sylphx/citra (brand-sole Citra). This transitional package id is retired as install CTA." || true

--- a/.github/workflows/registry-install-proof.yml
+++ b/.github/workflows/registry-install-proof.yml
@@ -7,7 +7,7 @@ on:
         description: Published npm version to prove
         required: true
         type: string
-        default: "4.1.2"
+        default: "5.0.0"
 
 permissions:
   contents: read

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -2,7 +2,7 @@
 
 ## Published stable
 
-Install from **npm**. Current production is **`@sylphx/pdf-reader-mcp@4.1.1`** — a **sole-Rust** MCP server launched by a thin Node entrypoint.
+Install from **npm**. Current production is **`@sylphx/citra@5.0.0`** — a **sole-Rust** MCP server launched by a thin Node entrypoint.
 
 ```bash
 npm install -g @sylphx/citra
@@ -29,7 +29,7 @@ There is **no** TypeScript PDF runtime in the production package. If the matchin
 ## Claude Code
 
 ```bash
-claude mcp add pdf-reader -- npx @sylphx/citra
+claude mcp add citra -- npx @sylphx/citra
 ```
 
 ## Claude Desktop
@@ -39,9 +39,9 @@ Add to `claude_desktop_config.json`:
 ```json
 {
   "mcpServers": {
-    "pdf-reader": {
+    "citra": {
       "command": "npx",
-      "args": ["@sylphx/pdf-reader-mcp"]
+      "args": ["@sylphx/citra"]
     }
   }
 }
@@ -58,9 +58,9 @@ Add to `claude_desktop_config.json`:
 ```json
 {
   "mcpServers": {
-    "pdf-reader": {
+    "citra": {
       "command": "npx",
-      "args": ["@sylphx/pdf-reader-mcp"]
+      "args": ["@sylphx/citra"]
     }
   }
 }
@@ -80,24 +80,24 @@ release that includes this fix.
 ```bash
 npx @sylphx/citra
 # or after global install
-pdf-reader-mcp
+citra
 ```
 
 HTTP transport:
 
 ```bash
-MCP_TRANSPORT=http pdf-reader-mcp
+MCP_TRANSPORT=http citra
 ```
 
 ## Platforms
 
 | Platform | Native package |
 | --- | --- |
-| macOS arm64 | `@sylphx/pdf-reader-mcp-darwin-arm64` |
-| macOS x64 | `@sylphx/pdf-reader-mcp-darwin-x64` |
-| Linux x64 | `@sylphx/pdf-reader-mcp-linux-x64-gnu` |
-| Linux arm64 | `@sylphx/pdf-reader-mcp-linux-arm64-gnu` |
-| Windows x64 | `@sylphx/pdf-reader-mcp-win32-x64-msvc` |
+| macOS arm64 | `@sylphx/citra-darwin-arm64` |
+| macOS x64 | `@sylphx/citra-darwin-x64` |
+| Linux x64 | `@sylphx/citra-linux-x64-gnu` |
+| Linux arm64 | `@sylphx/citra-linux-arm64-gnu` |
+| Windows x64 | `@sylphx/citra-win32-x64-msvc` |
 
 ## Next
 
@@ -107,8 +107,10 @@ MCP_TRANSPORT=http pdf-reader-mcp
 
 ## Historical TypeScript baseline (not production)
 
-Immutable external comparison/recovery pin only:
+Immutable external comparison/recovery pin only (transitional package id; **not** install CTA):
 
 ```bash
-npm install -g @sylphx/citra@3.0.14
+npm install -g @sylphx/pdf-reader-mcp@3.0.14
 ```
+
+Production install CTA remains **`@sylphx/citra@5.0.0`** only.


### PR DESCRIPTION
## Summary
Clean-break docs/ops for brand-sole Citra:
- Install guide CTAs → \`@sylphx/citra\` / bin \`citra\` / \`@sylphx/citra-*\` natives
- Registry install proof default \`5.0.0\` (dispatched)
- Deprecate workflow for transitional \`@sylphx/pdf-reader-mcp\`
- Fix mistaken deprecate target that would have hit \`@sylphx/citra\`

## After merge
\`\`\`bash
gh workflow run 'Deprecate transitional npm id' -f confirm=DEPRECATE_PDF_READER_MCP
\`\`\`