### PR TITLE
fix!: honest Citra registry-install host proof matrix

### DIFF
--- a/.github/workflows/registry-install-proof.yml
+++ b/.github/workflows/registry-install-proof.yml
@@ -1,10 +1,9 @@
 name: Registry install proof
 
 # Host-runtime proof for a published @sylphx/citra version.
-# Each job requires a matching native host (PROOF_REQUIRE_PLATFORM_ID).
-# There is currently no owned linux-arm64 or Windows self-hosted pool for
-# runtime proof (see candidate-host-runtime-proof.yml). Do not fake those
-# platforms on x64 linux runners.
+# Required host proofs (must pass): linux-x64-gnu, darwin (actual triple of owned mac runner).
+# Residual host pools (reported, not claimed): linux-arm64-gnu, win32-x64-msvc.
+# Never run an arm64/win proof on an x64 linux runner and claim success.
 
 on:
   workflow_dispatch:
@@ -57,8 +56,6 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${PROOF_VERSION}"
-          # Require whichever darwin triple this owned mac runner actually is.
-          # Rosetta x64 userspace on arm64 is rejected by hostMatchesPlatformId.
           ARCH="$(uname -m)"
           if [ "$ARCH" = "arm64" ]; then
             export PROOF_REQUIRE_PLATFORM_ID=darwin-arm64
@@ -68,25 +65,22 @@ jobs:
           echo "PROOF_REQUIRE_PLATFORM_ID=$PROOF_REQUIRE_PLATFORM_ID"
           bun scripts/check-registry-install-proof.ts --registry --version="$VERSION"
 
-  # Explicit unavailable jobs: keep the matrix visible without false green.
-  proof-linux-arm64-unavailable:
+  residual-hosts:
+    needs: [proof-linux-x64, proof-darwin]
+    if: always()
     runs-on: sylphx-linux-standard
     steps:
-      - name: No owned linux-arm64 runtime host pool
+      - name: Report host-pool residuals (not false green)
         run: |
           set -euo pipefail
-          echo "::error::linux-arm64-gnu host runtime proof is unavailable: no owned arm64 runner pool."
-          echo "Natives may still be published (@sylphx/citra-linux-arm64-gnu) via cross-build."
-          echo "Do not run registry install proof on x64 and claim arm64."
-          exit 1
-
-  proof-windows-unavailable:
-    runs-on: sylphx-linux-standard
-    steps:
-      - name: No owned Windows runtime host pool
-        run: |
-          set -euo pipefail
-          echo "::error::win32-x64-msvc host runtime proof is unavailable: no owned Windows runner pool."
-          echo "Natives may still be published (@sylphx/citra-win32-x64-msvc) via cross-build."
-          echo "Removed [self-hosted, Windows, X64] queue sink that never started."
-          exit 1
+          echo "## Registry install host matrix for @sylphx/citra@${{ inputs.version }}"
+          echo "required linux-x64: ${{ needs.proof-linux-x64.result }}"
+          echo "required darwin: ${{ needs.proof-darwin.result }}"
+          echo "residual linux-arm64-gnu: UNAVAILABLE (no owned arm64 runtime host pool; do not prove on x64)"
+          echo "residual win32-x64-msvc: UNAVAILABLE (no owned Windows runtime host pool)"
+          echo "Packaging natives for residual platforms may still exist on npm; packaging != host runtime."
+          if [ "${{ needs.proof-linux-x64.result }}" != "success" ] || [ "${{ needs.proof-darwin.result }}" != "success" ]; then
+            echo "::error::required host proofs failed"
+            exit 1
+          fi
+          echo "Required host proofs passed. Residual platforms remain open."

--- a/.github/workflows/registry-install-proof.yml
+++ b/.github/workflows/registry-install-proof.yml
@@ -1,5 +1,11 @@
 name: Registry install proof
 
+# Host-runtime proof for a published @sylphx/citra version.
+# Each job requires a matching native host (PROOF_REQUIRE_PLATFORM_ID).
+# There is currently no owned linux-arm64 or Windows self-hosted pool for
+# runtime proof (see candidate-host-runtime-proof.yml). Do not fake those
+# platforms on x64 linux runners.
+
 on:
   workflow_dispatch:
     inputs:
@@ -24,32 +30,14 @@ jobs:
         with:
           node-version: "22"
           registry-url: https://registry.npmjs.org
-      - name: Registry install + pure-Rust initialize proof (linux-x64-gnu)
+      - name: Registry install + pure-Rust initialize (linux-x64-gnu)
         env:
           PROOF_VERSION: ${{ inputs.version }}
+          PROOF_REQUIRE_PLATFORM_ID: linux-x64-gnu
         run: |
           set -euo pipefail
           VERSION="${PROOF_VERSION}"
           test -n "$VERSION"
-          bun scripts/check-registry-install-proof.ts --registry --version="$VERSION"
-
-  proof-linux-arm64:
-    runs-on: sylphx-linux-standard
-    steps:
-      - uses: actions/checkout@v7
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-      - uses: actions/setup-node@v7
-        with:
-          node-version: "22"
-          registry-url: https://registry.npmjs.org
-      - name: Registry install proof (linux-arm64-gnu)
-        env:
-          PROOF_VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          VERSION="${PROOF_VERSION}"
           bun scripts/check-registry-install-proof.ts --registry --version="$VERSION"
 
   proof-darwin:
@@ -63,30 +51,42 @@ jobs:
         with:
           node-version: "22"
           registry-url: https://registry.npmjs.org
-      - name: Registry install proof (darwin host)
+      - name: Registry install + pure-Rust initialize (darwin host triple)
         env:
           PROOF_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           VERSION="${PROOF_VERSION}"
+          # Require whichever darwin triple this owned mac runner actually is.
+          # Rosetta x64 userspace on arm64 is rejected by hostMatchesPlatformId.
+          ARCH="$(uname -m)"
+          if [ "$ARCH" = "arm64" ]; then
+            export PROOF_REQUIRE_PLATFORM_ID=darwin-arm64
+          else
+            export PROOF_REQUIRE_PLATFORM_ID=darwin-x64
+          fi
+          echo "PROOF_REQUIRE_PLATFORM_ID=$PROOF_REQUIRE_PLATFORM_ID"
           bun scripts/check-registry-install-proof.ts --registry --version="$VERSION"
 
-  proof-windows:
-    runs-on: [self-hosted, Windows, X64]
+  # Explicit unavailable jobs: keep the matrix visible without false green.
+  proof-linux-arm64-unavailable:
+    runs-on: sylphx-linux-standard
     steps:
-      - uses: actions/checkout@v7
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-      - uses: actions/setup-node@v7
-        with:
-          node-version: "22"
-          registry-url: https://registry.npmjs.org
-      - name: Registry install proof (win32-x64)
-        shell: bash
-        env:
-          PROOF_VERSION: ${{ inputs.version }}
+      - name: No owned linux-arm64 runtime host pool
         run: |
           set -euo pipefail
-          VERSION="${PROOF_VERSION}"
-          bun scripts/check-registry-install-proof.ts --registry --version="$VERSION"
+          echo "::error::linux-arm64-gnu host runtime proof is unavailable: no owned arm64 runner pool."
+          echo "Natives may still be published (@sylphx/citra-linux-arm64-gnu) via cross-build."
+          echo "Do not run registry install proof on x64 and claim arm64."
+          exit 1
+
+  proof-windows-unavailable:
+    runs-on: sylphx-linux-standard
+    steps:
+      - name: No owned Windows runtime host pool
+        run: |
+          set -euo pipefail
+          echo "::error::win32-x64-msvc host runtime proof is unavailable: no owned Windows runner pool."
+          echo "Natives may still be published (@sylphx/citra-win32-x64-msvc) via cross-build."
+          echo "Removed [self-hosted, Windows, X64] queue sink that never started."
+          exit 1

--- a/docs/specs/pure-rust-capability-matrix.json
+++ b/docs/specs/pure-rust-capability-matrix.json
@@ -121,7 +121,22 @@
       "serverInfoName": "citra",
       "boundary": "linux-x64-gnu host install + MCP initialize/tools.list only; not five-platform matrix"
     },
-    "npmLatestObserved": "5.0.0"
+    "npmLatestObserved": "5.0.0",
+    "registryInstallRuntimeProof": {
+      "status": "partial_linux_x64_and_darwin_x64",
+      "version": "5.0.0",
+      "evidence": "verification/citra-registry-install-runtime-proof-5.0.0-multi-host.json",
+      "workflowRun": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/31230084759",
+      "passedHosts": [
+        "linux-x64-gnu",
+        "darwin-x64"
+      ],
+      "unavailableHosts": [
+        "linux-arm64-gnu",
+        "win32-x64-msvc"
+      ],
+      "goalCompleteAuthorized": false
+    }
   },
   "legend": {
     "FULL": "Production-usable capability for agent tasks in this slice under the capability-first semantic contract (not exact PDF.js JSON equality)",
@@ -511,7 +526,8 @@
       "performanceClaimsAuthorized": true,
       "goalCompleteAuthorized": false,
       "reviewedAt": "2026-08-07T22:16:47Z",
-      "note": "5.0.0 brand-sole re-pin after #630 setup-zig on main c93b30f; registry publish still required."
+      "note": "5.0.0 brand-sole re-pin after #630 setup-zig on main c93b30f; registry publish still required.",
+      "hostRuntimeProofNote": "linux-x64 + darwin-x64 host runtime pass for 5.0.0; arm64/win host pools unavailable"
     },
     "unfreezeAuthorized": true,
     "soleRuntimeAuthorized": true,

--- a/verification/citra-registry-install-runtime-proof-5.0.0-multi-host.json
+++ b/verification/citra-registry-install-runtime-proof-5.0.0-multi-host.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": 1,
+  "profile": "citra_registry_install_runtime_proof_multi_host",
+  "reviewedAt": "2026-08-08T01:06:44Z",
+  "package": "@sylphx/citra",
+  "version": "5.0.0",
+  "workflowRun": "https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/31230084759",
+  "platforms": {
+    "linux-x64-gnu": {
+      "status": "pass",
+      "job": "proof-linux-x64",
+      "optionalPackage": "@sylphx/citra-linux-x64-gnu",
+      "serverInfo": {
+        "name": "citra",
+        "version": "5.0.0"
+      },
+      "runtimeProofValid": true
+    },
+    "darwin-x64": {
+      "status": "pass",
+      "job": "proof-darwin",
+      "optionalPackage": "@sylphx/citra-darwin-x64",
+      "serverInfo": {
+        "name": "citra",
+        "version": "5.0.0"
+      },
+      "runtimeProofValid": true,
+      "rosettaTranslated": false
+    },
+    "linux-arm64-gnu": {
+      "status": "unavailable",
+      "reason": "job previously green on x64 sylphx-linux-standard (false platform); no owned arm64 runtime host pool"
+    },
+    "darwin-arm64": {
+      "status": "not_run_this_dispatch",
+      "reason": "owned mac runner that executed was darwin-x64"
+    },
+    "win32-x64-msvc": {
+      "status": "unavailable",
+      "reason": "no owned Windows self-hosted pool; job queued indefinitely and was cancelled"
+    }
+  },
+  "registryNativesPublished": [
+    "@sylphx/citra-linux-x64-gnu@5.0.0",
+    "@sylphx/citra-linux-arm64-gnu@5.0.0",
+    "@sylphx/citra-darwin-arm64@5.0.0",
+    "@sylphx/citra-darwin-x64@5.0.0",
+    "@sylphx/citra-win32-x64-msvc@5.0.0"
+  ],
+  "transitionalDeprecated": {
+    "@sylphx/pdf-reader-mcp": "Retired install CTA. Use brand-sole @sylphx/citra (bin: citra)."
+  },
+  "outcome": "registry_install_runtime_pass_linux_x64_and_darwin_x64_only",
+  "goalCompleteAuthorized": false,
+  "notes": [
+    "goalComplete remains false until true linux-arm64 + win32 host runtime proofs exist or the admission bar is explicitly narrowed.",
+    "Natives for all five platforms are on npm; that is packaging proof, not host runtime proof.",
+    "Workflow registry-install-proof.yml corrected to fail-closed platform requirements and remove false arm64/windows claims."
+  ]
+}


### PR DESCRIPTION
## Summary
Registry install proof for \`@sylphx/citra@5.0.0\` showed **false green**:
- \`proof-linux-arm64\` ran on **x64** \`sylphx-linux-standard\` and reported \`platformId=linux-x64-gnu\`
- \`proof-windows\` queued forever (\`[self-hosted, Windows, X64]\` pool missing)

## Fix
- Fail-closed \`PROOF_REQUIRE_PLATFORM_ID\` for linux-x64 + darwin host triple
- Explicit unavailable jobs for linux-arm64 / windows (no fake runtime claims)
- Verification artifact for actual pass set: **linux-x64-gnu + darwin-x64**
- \`goalCompleteAuthorized\` stays **false**

## Evidence
- Run: https://github.com/SylphxAI/pdf-reader-mcp/actions/runs/31230084759
- Artifact: \`verification/citra-registry-install-runtime-proof-5.0.0-multi-host.json\`

Natives for all five platforms remain on npm; packaging ≠ host runtime.