### PR TITLE
docs: family zero-config npx proof (all six Instruments)

### DIFF
--- a/verification/instruments-zero-config-npx-proof-linux-x64.json
+++ b/verification/instruments-zero-config-npx-proof-linux-x64.json
@@ -1,0 +1,79 @@
+{
+  "schemaVersion": 1,
+  "profile": "instruments_zero_config_npx_proof",
+  "reviewedAt": "2026-08-08T02:11:21Z",
+  "host": {
+    "uname": "x86_64",
+    "node": "v22",
+    "method": "npx -y @sylphx/<brand>@version with empty cache; JSON-RPC initialize on stdio"
+  },
+  "results": {
+    "citra": {
+      "package": "@sylphx/citra@5.0.0",
+      "ok": true,
+      "serverInfo": {
+        "name": "citra",
+        "version": "5.0.0"
+      }
+    },
+    "iris": {
+      "package": "@sylphx/iris@0.2.1",
+      "ok": true,
+      "serverInfo": {
+        "name": "iris",
+        "version": "0.2.1"
+      }
+    },
+    "cue": {
+      "package": "@sylphx/cue@0.2.1",
+      "ok": true,
+      "serverInfo": {
+        "name": "cue",
+        "version": "0.2.1"
+      }
+    },
+    "spine": {
+      "package": "@sylphx/spine@0.3.1",
+      "ok": true,
+      "serverInfo": {
+        "name": "spine",
+        "version": "0.3.1"
+      }
+    },
+    "lookout": {
+      "package": "@sylphx/lookout@0.2.1",
+      "ok": true,
+      "serverInfo": {
+        "name": "lookout",
+        "version": "0.2.1"
+      }
+    },
+    "locus": {
+      "package": "@sylphx/locus@0.5.2",
+      "ok": true,
+      "serverInfo": {
+        "name": "locus",
+        "version": "0.5.2"
+      }
+    }
+  },
+  "fixedThisProgram": [
+    "lookout bin path under npm shims + default MCP on bare npx",
+    "iris/cue republish brand-sole serverInfo + portable linux natives",
+    "spine linux-x64 zigbuild glibc 2.17 (was GLIBC_2.39)"
+  ],
+  "zeroConfigCTAs": [
+    "npx -y @sylphx/citra",
+    "npx -y @sylphx/iris",
+    "npx -y @sylphx/cue",
+    "npx -y @sylphx/spine",
+    "npx -y @sylphx/lookout",
+    "npx -y @sylphx/locus --root=/abs/path"
+  ],
+  "outcome": "all_six_instruments_npx_stdio_mcp_initialize_pass_linux_x64",
+  "notes": [
+    "Bare npx starts MCP stdio (no prior install/MCP host config required).",
+    "Locus still needs --root for search usefulness; initialize works zero-config.",
+    "CLI --help on pure MCP servers may error by design (stdio handshake); doctor/CLI where applicable."
+  ]
+}


### PR DESCRIPTION
Linux-x64 evidence: npx zero-config MCP initialize for citra/iris/cue/spine/lookout/locus.