### PR TITLE
docs!: Citra marketing — zero-config npx hero + live 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,25 @@
 
 # Citra
 
-### Give your AI agent eyes for PDFs.
+### Give your AI agent eyes for PDFs — with proof.
 
-**Citra** is a local-first PDF evidence product for agents — fast, citeable, owned entirely in this repository.
+**Citra** turns PDFs into **structured text, tables, OCR, visual evidence, and page-level citations** your agent can defend — **locally**, with **zero config**.
 
-Turn PDFs into **structured text, tables, OCR, visual evidence, and page-level citations** — locally — via **SDK, CLI, or MCP**.
+```bash
+npx -y @sylphx/citra
+```
 
-Plain-text PDF tools make agents guess. **Citra returns proof.**  
-Canonical package: **`@sylphx/citra`** · bin **`citra`** · MCP `io.github.SylphxAI/citra`
+Plain-text PDF tools make agents **guess**. Citra returns an **Agent Document Twin** they can **cite**.
+
+| | Typical PDF dump | **Citra** |
+| --- | --- | --- |
+| Page / cell citations | ❌ invented or missing | ✅ page + geometry + provenance |
+| Tables | flattened soup | rows · columns · cells · bboxes |
+| Scanned PDFs | noise | OCR path, evidence-linked |
+| Setup | install, config, hope | **`npx -y` — done** |
+| Engine honesty | silent fallbacks | **fail closed** if native missing |
+
+Canonical: **`@sylphx/citra@5.0.0`** · bin **`citra`** · MCP `io.github.SylphxAI/citra` · sole-Rust production runtime.
 
 [![npm version](https://img.shields.io/npm/v/@sylphx/citra?style=flat-square)](https://www.npmjs.com/package/@sylphx/citra)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat-square)](https://opensource.org/licenses/MIT)
@@ -32,6 +43,14 @@ Canonical package: **`@sylphx/citra`** · bin **`citra`** · MCP `io.github.Sylp
 | [docs/IPPB.md](docs/IPPB.md) | Independent public product bar |
 | [docs/PUBLISH.md](docs/PUBLISH.md) | npm/git publish status |
 
+## Why agents actually finish the job
+
+1. **Zero-config MCP** — `npx -y @sylphx/citra` works without a prior install (stdio MCP).
+2. **Evidence, not vibes** — page numbers, boxes, tables, trust signals on the result.
+3. **Local-first** — your PDFs stay on the machine; no required cloud vision API.
+4. **One brand, one bin** — `@sylphx/citra` / `citra` only (no dual package confusion).
+5. **Family ready** — compose with Iris (images), Cue (video), Spine, Lookout, Locus.
+
 ## Why this exists
 
 ![Plain text vs evidence](docs/public/before-after-evidence.svg)
@@ -52,15 +71,24 @@ Citra returns an **Agent Document Twin**: markdown + structure + geometry + prov
 
 See [`skills/citra/SKILL.md`](./skills/citra/SKILL.md).
 
-## Install (30 seconds)
+## Zero-config (no install)
 
 ```bash
-npm install -g @sylphx/citra
+npx -y @sylphx/citra
 ```
 
-Source tip version is `5.0.0` (registry may lag until release publish).
+That’s it. No Docker, no API key, no global install. Agents spawn the MCP server on **stdio** immediately.
 
-One native binary is installed for **your** platform only (not all five). Brand-sole package: `@sylphx/citra@5.0.0`.
+| Setup style | Command |
+| --- | --- |
+| **Zero-config (recommended)** | `npx -y @sylphx/citra` |
+| Global install | `npm i -g @sylphx/citra` then `citra` |
+| Claude Code | `claude mcp add citra -- npx -y @sylphx/citra` |
+| Claude Desktop / Cursor | `"command": "npx", "args": ["-y", "@sylphx/citra"]` |
+
+**Live registry:** `@sylphx/citra@5.0.0` · bin `citra` only · optional native for **your** platform only.
+
+One native binary is pulled for **your** host (not all five). Missing native → **fail closed** (no silent engine switch).
 
 | Platform | Native package (auto optionalDependency) |
 | --- | --- |

--- a/docs/COMPETITIVE.md
+++ b/docs/COMPETITIVE.md
@@ -25,3 +25,11 @@ Default path uses local native runtime; no cloud API key required for core read.
 - Becoming a cloud SaaS wrapper as the default path
 - Multi-product monorepo for star aggregation
 - Generative summaries as the sole evidence authority
+
+## Zero-config CTA
+
+```bash
+npx -y @sylphx/citra
+```
+
+Bare invoke starts brand-sole MCP on stdio. Live: `@sylphx/citra@5.0.0`.

--- a/docs/LOCAL_FIRST_FRONTIER.md
+++ b/docs/LOCAL_FIRST_FRONTIER.md
@@ -17,3 +17,11 @@ See product README + EVIDENCE_CONTRACT for surfaces.
 3. Few tools; primary path documented in TOOL_SURFACE.md  
 4. Cloud / LLM only optional and non-authority  
 5. Product SSOT is this repository only (no instruments monorepo)
+
+## Zero-config CTA
+
+```bash
+npx -y @sylphx/citra
+```
+
+Bare invoke starts brand-sole MCP on stdio. Live: `@sylphx/citra@5.0.0`.

--- a/docs/POSITIONING.md
+++ b/docs/POSITIONING.md
@@ -21,3 +21,11 @@
 ## Family
 
 Instrument line (local-first evidence). Not deliberation (Consultant). Prism is retired.
+
+## Zero-config CTA
+
+```bash
+npx -y @sylphx/citra
+```
+
+Bare invoke starts brand-sole MCP on stdio. Live: `@sylphx/citra@5.0.0`.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,5 +1,14 @@
 # Installation
 
+## Zero-config (recommended)
+
+```bash
+npx -y @sylphx/citra
+```
+
+Agents and MCP hosts should prefer **npx** so users never install anything globally. Live package: **`@sylphx/citra@5.0.0`**.
+
+
 ## Published stable
 
 Install from **npm**. Current production is **`@sylphx/citra@5.0.0`** — a **sole-Rust** MCP server launched by a thin Node entrypoint.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,15 +2,15 @@
 layout: home
 
 hero:
-  name: PDF Reader MCP
-  text: Give your AI agent eyes for PDFs.
-  tagline: "Turn PDFs into structured text, tables, OCR, visual evidence, and page-level citations — locally, with one MCP server. Plain-text tools make agents guess. PDF Reader MCP gives them evidence."
+  name: Citra
+  text: Give your AI agent eyes for PDFs — with proof.
+  tagline: "Zero-config local PDF evidence for agents. `npx -y @sylphx/citra` → structured text, tables, OCR, page-level citations. Plain-text tools make agents guess. Citra returns proof."
   image:
     src: /logo.svg
-    alt: PDF Reader MCP Logo
+    alt: Citra Logo
   actions:
     - theme: brand
-      text: Install in 30s
+      text: Zero-config npx
       link: /guide/installation
     - theme: alt
       text: Star on GitHub
@@ -26,6 +26,10 @@ hero:
       link: /benchmark
 
 features:
+  - icon: "🚀"
+    title: Zero-config
+    details: "`npx -y @sylphx/citra` starts a brand-sole MCP server on stdio. No Docker, no API key, no global install."
+
   - icon: "\U0001F441\uFE0F"
     title: Evidence, not text dumps
     details: Page numbers, bounding boxes, table cells, and provenance so agents can cite instead of invent.


### PR DESCRIPTION
Lead with `npx -y @sylphx/citra`, evidence table, VitePress home as Citra, install zero-config first. Registry 5.0.0 is live.