### PR TITLE
docs!: rewrite Citra README marketing (scan path + trust)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,172 +1,65 @@
+<!-- Marketing surface: scannable pitch first; engineering docs below the fold. -->
 <div align="center">
 
 # Citra
 
 ### Give your AI agent eyes for PDFs — with proof.
 
-**Citra** turns PDFs into **structured text, tables, OCR, visual evidence, and page-level citations** your agent can defend — **locally**, with **zero config**.
+**Local-first PDF evidence for agents.** Structured text, tables, OCR, visual crops, and page-level citations your agent can **defend** — not invent.
 
-```bash
-npx -y @sylphx/citra
-```
-
-Plain-text PDF tools make agents **guess**. Citra returns an **Agent Document Twin** they can **cite**.
-
-| | Typical PDF dump | **Citra** |
-| --- | --- | --- |
-| Page / cell citations | ❌ invented or missing | ✅ page + geometry + provenance |
-| Tables | flattened soup | rows · columns · cells · bboxes |
-| Scanned PDFs | noise | OCR path, evidence-linked |
-| Setup | install, config, hope | **`npx -y` — done** |
-| Engine honesty | silent fallbacks | **fail closed** if native missing |
-
-Canonical: **`@sylphx/citra@5.0.0`** · bin **`citra`** · MCP `io.github.SylphxAI/citra` · sole-Rust production runtime.
+**Canonical package** [`@sylphx/citra`](https://www.npmjs.com/package/@sylphx/citra) · **bin** `citra` · **MCP** `io.github.SylphxAI/citra` · **live** `5.0.0`
 
 [![npm version](https://img.shields.io/npm/v/@sylphx/citra?style=flat-square)](https://www.npmjs.com/package/@sylphx/citra)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat-square)](https://opensource.org/licenses/MIT)
-[![CI](https://img.shields.io/github/actions/workflow/status/SylphxAI/pdf-reader-mcp/ci.yml?style=flat-square&label=CI)](https://github.com/SylphxAI/pdf-reader-mcp/actions/workflows/ci.yml)
 [![stars](https://img.shields.io/github/stars/SylphxAI/pdf-reader-mcp?style=flat-square)](https://github.com/SylphxAI/pdf-reader-mcp/stargazers)
-[![MCP Toplist](https://mcptoplist.com/badge/io.github.SylphxAI%2Fcitra.svg)](https://mcptoplist.com/server/io.github.SylphxAI%2Fcitra)
 
 </div>
 
-
-## Product docs
-
-| Doc | Purpose |
-| --- | --- |
-| [docs/POSITIONING.md](docs/POSITIONING.md) | Strategic positioning |
-| [docs/COMPETITIVE.md](docs/COMPETITIVE.md) | Peer anchors and wedge |
-| [docs/EVIDENCE_CONTRACT.md](docs/EVIDENCE_CONTRACT.md) | Evidence = result contract |
-| [docs/TOOL_SURFACE.md](docs/TOOL_SURFACE.md) | Few clear tools policy |
-| [docs/PRODUCT_INDEPENDENCE.md](docs/PRODUCT_INDEPENDENCE.md) | This repo is SSOT |
-| [docs/IPPB.md](docs/IPPB.md) | Independent public product bar |
-| [docs/PUBLISH.md](docs/PUBLISH.md) | npm/git publish status |
-
-## Why agents actually finish the job
-
-1. **Zero-config MCP** — `npx -y @sylphx/citra` works without a prior install (stdio MCP).
-2. **Evidence, not vibes** — page numbers, boxes, tables, trust signals on the result.
-3. **Local-first** — your PDFs stay on the machine; no required cloud vision API.
-4. **One brand, one bin** — `@sylphx/citra` / `citra` only (no dual package confusion).
-5. **Family ready** — compose with Iris (images), Cue (video), Spine, Lookout, Locus.
-
-## Why this exists
-
-![Plain text vs evidence](docs/public/before-after-evidence.svg)
-
-
-Most PDF tools dump text. Agents then invent page numbers, miss tables, and cite the wrong cell.
-
-Citra returns an **Agent Document Twin**: markdown + structure + geometry + provenance your agent can actually trust.
-
-| Without evidence | With Citra |
-| --- | --- |
-| “The revenue was about $12M” | “Page 14, Table 3, cell (row 4, col 2) = `$12.4M`” |
-| Lost table structure | Rows, columns, cells, bounding boxes |
-| Scanned PDF becomes noise | OCR path with page-linked evidence |
-| Hidden text / prompt injection ignored | Trust signals when requested |
-
-## Agent skill surface
-
-See [`skills/citra/SKILL.md`](./skills/citra/SKILL.md).
-
-## Zero-config (no install)
+## Zero-config in one line
 
 ```bash
 npx -y @sylphx/citra
 ```
 
-That’s it. No Docker, no API key, no global install. Agents spawn the MCP server on **stdio** immediately.
+No Docker. No API key. No global install. Spawns a **stdio MCP server** agents can use immediately.
 
-| Setup style | Command |
+| Client | Setup |
 | --- | --- |
-| **Zero-config (recommended)** | `npx -y @sylphx/citra` |
-| Global install | `npm i -g @sylphx/citra` then `citra` |
-| Claude Code | `claude mcp add citra -- npx -y @sylphx/citra` |
-| Claude Desktop / Cursor | `"command": "npx", "args": ["-y", "@sylphx/citra"]` |
+| **Any agent / CLI** | `npx -y @sylphx/citra` |
+| **Claude Code** | `claude mcp add citra -- npx -y @sylphx/citra` |
+| **Claude Desktop / Cursor / VS Code / Codex** | `"command": "npx", "args": ["-y", "@sylphx/citra"]` |
+| **Global CLI** | `npm i -g @sylphx/citra` → `citra` |
 
-**Live registry:** `@sylphx/citra@5.0.0` · bin `citra` only · optional native for **your** platform only.
+## Why Citra feels unfairly good
 
-One native binary is pulled for **your** host (not all five). Missing native → **fail closed** (no silent engine switch).
+Plain-text PDF tools make agents **guess**. Citra returns an **Agent Document Twin** they can **cite**.
 
-| Platform | Native package (auto optionalDependency) |
+| Pain today | With Citra |
 | --- | --- |
-| macOS arm64 | `@sylphx/citra-darwin-arm64` |
-| macOS x64 | `@sylphx/citra-darwin-x64` |
-| Linux x64 | `@sylphx/citra-linux-x64-gnu` |
-| Linux arm64 | `@sylphx/citra-linux-arm64-gnu` |
-| Windows x64 | `@sylphx/citra-win32-x64-msvc` |
+| Page numbers invented or missing | **Page + geometry + provenance** |
+| Tables flattened into soup | **Rows · columns · cells · bounding boxes** |
+| Scanned PDFs become noise | **OCR path linked to evidence** |
+| Install / config / “hope it works” | **`npx -y` — done** |
+| Silent engine fallbacks | **Fail closed** if the native binary is missing |
 
-Missing native package → **fail closed** (no silent engine switch).
+### Five reasons teams pick Citra
 
-## Quick start
+1. **Zero-config** — real `npx` MCP, not a 20-step bootstrap.
+2. **Evidence, not vibes** — citations agents can show a human.
+3. **Local-first** — PDFs stay on the machine; no required cloud vision API.
+4. **Brand-sole** — one package, one bin, one story (`@sylphx/citra` / `citra`).
+5. **Instrument family** — compose with Iris (image), Cue (video), Spine, Lookout, Locus.
 
-**Claude Code**
+## See the difference
 
-```bash
-claude mcp add citra -- npx @sylphx/citra
-```
+![Plain text vs evidence](docs/public/before-after-evidence.svg)
 
-**Claude Desktop / Codex / Cursor / VS Code / any MCP client**
-
-```json
-{
-  "mcpServers": {
-    "citra": {
-      "command": "npx",
-      "args": ["@sylphx/citra"]
-    }
-  }
-}
-```
-
-Dual-era hosts that send `server/discover` before `initialize` (e.g. Gemini Antigravity CLI) are supported on stdio — the server answers discovery and keeps the session open for the legacy handshake.
-
-**Stdio / HTTP**
-
-```bash
-citra
-MCP_TRANSPORT=http citra
-```
-
-
-## SDK (programmatic)
-
-Citra is not MCP-only. Apps and internal dogfood can call the same engine without a chat client.
-
-**TypeScript — spawn the native server as a client**
-
-```ts
-import { Citra } from '@sylphx/citra/sdk';
-
-const citra = Citra.create();
-const { payload, isError } = await citra.read({
-  sources: [{ path: '/absolute/path/to/doc.pdf' }],
-  // auto defaults on when you omit include_* flags
-});
-if (isError) throw new Error(JSON.stringify(payload));
-console.log(payload);
-```
-
-Low-level escape hatch: `@sylphx/citra/pure-rust` (`createPureRustClient`).
-
-- Export: `@sylphx/citra/sdk` → `Citra` (`read` / `search` / `evidence`)
-- Export: `@sylphx/citra/pure-rust` → `createPureRustClient`, `resolvePureRustServerBinary`, `PureRustClient`
-- Tools (same as MCP): `read_pdf` · `search_pdf` · `pdf_evidence`
-- Requires the platform optional native package (same as MCP install)
-- **Roadmap:** richer typed SDK depth; package name is already brand-sole `@sylphx/citra`
-
-**CLI**
-
-```bash
-npx citra --help
-# doctor / read paths: see package bin and docs/guide
-```
-
-**MCP** — see Quick start above (`npx @sylphx/citra`).
-
-Independence: [this product only](docs/PRODUCT_INDEPENDENCE.md). No central Instruments monorepo.
+| Without evidence | With Citra |
+| --- | --- |
+| “Revenue was about $12M” | “Page 14, Table 3, cell (row 4, col 2) = `$12.4M`” |
+| Lost table structure | Rows, columns, cells, bounding boxes |
+| Scanned PDF = garbage text | OCR with page-linked evidence |
+| Hidden / adversarial text ignored | Trust signals when requested |
 
 ## What you get
 
@@ -192,24 +85,88 @@ Minimal call:
 2. **Research papers** — headings, reading order, page-level quotes  
 3. **Scanned documents** — OCR path with evidence, not a text soup  
 
-## Install footprint (honest product comparison)
+## Platforms
+
+One **optional** native package is selected for **your** host only:
+
+| Platform | Native package |
+| --- | --- |
+| macOS arm64 | `@sylphx/citra-darwin-arm64` |
+| macOS x64 | `@sylphx/citra-darwin-x64` |
+| Linux x64 | `@sylphx/citra-linux-x64-gnu` |
+| Linux arm64 | `@sylphx/citra-linux-arm64-gnu` |
+| Windows x64 | `@sylphx/citra-win32-x64-msvc` |
+
+Missing native → **fail closed** (no silent TypeScript PDF engine).
+
+## Product docs
+
+| Doc | Purpose |
+| --- | --- |
+| [docs/POSITIONING.md](docs/POSITIONING.md) | Strategic positioning |
+| [docs/COMPETITIVE.md](docs/COMPETITIVE.md) | Peer anchors and wedge |
+| [docs/EVIDENCE_CONTRACT.md](docs/EVIDENCE_CONTRACT.md) | Evidence = result contract |
+| [docs/TOOL_SURFACE.md](docs/TOOL_SURFACE.md) | Few clear tools policy |
+| [docs/PRODUCT_INDEPENDENCE.md](docs/PRODUCT_INDEPENDENCE.md) | This repo is SSOT |
+| [docs/IPPB.md](docs/IPPB.md) | Independent public product bar |
+| [docs/PUBLISH.md](docs/PUBLISH.md) | npm / git publish status |
+| [docs/guide/installation.md](docs/guide/installation.md) | Install & host config |
+| [skills/citra/SKILL.md](./skills/citra/SKILL.md) | Agent skill surface |
+
+## Surfaces (MCP · CLI · SDK)
+
+**MCP (default agent path)**
+
+```bash
+npx -y @sylphx/citra
+```
+
+**Claude Desktop / Cursor / VS Code / Codex**
+
+```json
+{
+  "mcpServers": {
+    "citra": {
+      "command": "npx",
+      "args": ["-y", "@sylphx/citra"]
+    }
+  }
+}
+```
+
+Dual-era hosts that send `server/discover` before `initialize` (e.g. Gemini Antigravity CLI) are supported on stdio.
+
+**CLI**
+
+```bash
+npx -y @sylphx/citra --help
+```
+
+**SDK**
+
+- `@sylphx/citra/sdk` → `Citra` (`read` / `search` / `evidence`)
+- `@sylphx/citra/pure-rust` → low-level client helpers  
+- Same tools as MCP: `read_pdf` · `search_pdf` · `pdf_evidence`  
+- Requires the platform optional native package (same as MCP)
+
+## Install footprint (honest)
 
 Compare **full clean installs**, not “JS wrapper tarball vs native executable”:
 
-| Metric (measured clean install, **linux-x64**) | Historical TS `3.0.14` | Sole-Rust `4.1.0` |
+| Metric (measured clean install, **linux-x64**) | Historical TS `3.0.14` | Sole-Rust `4.1.0` lineage |
 | --- | ---: | ---: |
 | Main package on disk | ~403 KB | ~77 KB |
 | Full `node_modules` | ~82.3 MiB | **~24.4 MiB** (~3.4× smaller) |
 | Installed files | 4,101 | **20** (~205× fewer) |
-| Production npm dependency graph | PDF.js + MCP TS SDK + more | `{}` + **one** platform native |
+| Production npm deps | PDF.js + MCP TS SDK + more | `{}` + **one** platform native |
 
-The native binary is multi-megabyte because it **is** the PDF intelligence engine (parser, server, rendering/table/OCR routing). That is expected and still yields a **cleaner, smaller install** than shipping PDF.js + a JS dependency tree.
+The native binary is multi-megabyte because it **is** the PDF engine. That is expected — and still a **cleaner install** than shipping PDF.js + a large JS tree.
 
 Details: [installed footprint comparison](docs/specs/performance/installed-footprint-comparison.md)
 
-## Performance
+## Performance (method-bounded)
 
-Controlled **same-host linux-x64** dual-mode A/B vs `@sylphx/pdf-reader-mcp@3.0.14`, using **registry-installed 4.1.x** natives:
+Controlled **same-host linux-x64** dual-mode A/B vs historical `@sylphx/pdf-reader-mcp@3.0.14`, using **registry-installed sole-Rust natives** (measured on the 4.1.x lineage; method applies to current sole-Rust packages):
 
 | Mode | What it measures | Result |
 | --- | --- | --- |
@@ -218,40 +175,34 @@ Controlled **same-host linux-x64** dual-mode A/B vs `@sylphx/pdf-reader-mcp@3.0.
 
 `persistent_warm` includes a process-local cache for identical local path+options. First request in a process still pays full parse cost.
 
-Also: install footprint is much smaller than TS 3.0.14 on measured linux-x64 (~3.4× less disk, ~205× fewer files), and the 4.1.0 native binary is smaller than 4.0.2 (strip/LTO).
-
 **Not** a multi-host guarantee. Details: [4.1.0 report](docs/specs/performance/4.1.0-same-host-performance-report.md) · [claims policy](docs/specs/performance/4.1.0-performance-claims-policy.md)
-
 
 ## Engine note
 
-Version 4 runs a **native Rust engine** on supported platforms via a thin Node launcher.
+Current production is a **native Rust engine** on supported platforms via a thin Node launcher.
 
-> Local-first. Five platforms. One clean install.
+> Local-first. Five platform packages. One clean install. Fail closed without the matching native.
 
-Unusually formed or broken ToUnicode CMaps are handled without crashing, and
-the release binary is built panic-unwind so a worker-thread panic fails the
-affected request instead of aborting the whole process
-([#608](https://github.com/SylphxAI/pdf-reader-mcp/issues/608)).
+Unusually formed or broken ToUnicode CMaps are handled without crashing; the release binary is panic-unwind so a worker-thread panic fails the request instead of aborting the process ([#608](https://github.com/SylphxAI/pdf-reader-mcp/issues/608)).
 
-Engineering history, recovery pins, and ADRs live under [docs/migration.md](docs/migration.md) — not the product pitch.
+Engineering history and recovery pins: [docs/migration.md](docs/migration.md) — not the product pitch.
 
-## Product proof
-
-- [Before/after + flagship workflows](docs/guide/product-proof.md)
-- [Example demos](examples/demo/README.md)
-
-## Docs
+## Product proof & links
 
 - [Website / guide](https://sylphxai.github.io/pdf-reader-mcp/)
+- [Product proof](docs/guide/product-proof.md)
+- [Benchmark](docs/benchmark.md)
 - [Installation](docs/guide/installation.md)
-- [Comparison](docs/comparison/index.md)
-- [Migration / recovery (secondary)](docs/migration.md)
-
-## License
-
-MIT
+- [npm](https://www.npmjs.com/package/@sylphx/citra)
 
 ---
 
-If this saves your agents from PDF hallucinations, **star the repo** and share a demo with your team.
+<div align="center">
+
+**Stop PDF hallucinations. Give agents proof.**
+
+```bash
+npx -y @sylphx/citra
+```
+
+</div>

--- a/bun.lock
+++ b/bun.lock
@@ -19,11 +19,11 @@
         "zod": "^4.4.3",
       },
       "optionalDependencies": {
-        "@sylphx/pdf-reader-mcp-darwin-arm64": "4.1.3",
-        "@sylphx/pdf-reader-mcp-darwin-x64": "4.1.3",
-        "@sylphx/pdf-reader-mcp-linux-arm64-gnu": "4.1.3",
-        "@sylphx/pdf-reader-mcp-linux-x64-gnu": "4.1.3",
-        "@sylphx/pdf-reader-mcp-win32-x64-msvc": "4.1.3",
+        "@sylphx/citra-darwin-arm64": "5.0.0",
+        "@sylphx/citra-darwin-x64": "5.0.0",
+        "@sylphx/citra-linux-arm64-gnu": "5.0.0",
+        "@sylphx/citra-linux-x64-gnu": "5.0.0",
+        "@sylphx/citra-win32-x64-msvc": "5.0.0",
       },
     },
   },
@@ -420,6 +420,16 @@
     "@shikijs/types": ["@shikijs/types@2.5.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@sylphx/citra-darwin-arm64": ["@sylphx/citra-darwin-arm64@5.0.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-112ZUfZQQRk60egLWRRkM3/we0fukFKTh7ZDd+r13MMNhZzf1TJaL1f4DZJpMiJKSOfkrHM2KQY++KFEq6UQWQ=="],
+
+    "@sylphx/citra-darwin-x64": ["@sylphx/citra-darwin-x64@5.0.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-vvhZZkbcgfDtTBXlUGjtkylQrrvroouVBsfx803HFEsKsU0+usL8VHpXFXex1yBtV6BmImNsN3sCZMN9Ew0V4A=="],
+
+    "@sylphx/citra-linux-arm64-gnu": ["@sylphx/citra-linux-arm64-gnu@5.0.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-WVrw310Qa+f+KBD7voeVpP2crrMgCLvKcIojwXvyTqW6nFvCeyXBy/V+axGAZrR8THNX3lTjzrA8r55Mvr+qHw=="],
+
+    "@sylphx/citra-linux-x64-gnu": ["@sylphx/citra-linux-x64-gnu@5.0.0", "", { "os": "linux", "cpu": "x64" }, "sha512-wDuOhHYy8dfJA/NghS84UMj2+pIFCMQQfUT97S0hsByNlwdj240Gm0dT9fjGl2Grfk6tywlm31XHghCiEv7+zw=="],
+
+    "@sylphx/citra-win32-x64-msvc": ["@sylphx/citra-win32-x64-msvc@5.0.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Hs+47LKUx+kFTYecXfRyj6AfpNoBe8BpDXvHo6x2E6JPrYGgEa1RZBRDfMI0EKy7UBzrNXRhVyw9/QMpqrc7Bg=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 


### PR DESCRIPTION
## Marketing audit (why the page felt weird)

1. **Layout** — whole hero (including GFM tables) lived inside `<div align="center">` → tables/code look odd on GitHub dark UI.
2. **Scan path** — **Product docs** (internal SSOT links) appeared *before* benefits; readers hit meta-docs first.
3. **Repetition** — zero-config block twice; two “Why” sections; fail-closed said thrice.
4. **Trust badges** — CI **failing** (bun.lock frozen drift) + MCP Toplist **not listed** under the pitch = self-sabotage.
5. **Tone mix** — engineering words (“sole-Rust production runtime”) in the first breath; performance still labeled only 4.1.x without method framing.
6. **CTA inconsistency** — some snippets missing `-y`.

## Fix
Rewrite README marketing structure: **promise → one CTA → comparison → why → demo → tools → platforms → docs → surfaces → honest footprint/perf → closer**.

Also commit **bun.lock** refresh so CI badge can go green again.