### PR TITLE
test: remove runtime source spelling assertions

### DIFF
--- a/test/tsAdapterDeletion.matrix.test.ts
+++ b/test/tsAdapterDeletion.matrix.test.ts
@@ -28,17 +28,6 @@ describe('published sole-Rust production package (no TS production runtime)', ()
     expect(pkg.version).toMatch(/^5\./);
   });
 
-  it('runtime-entry is sole-Rust and rejects force-TS flags', () => {
-    const source = readFileSync(path.join(repoRoot, 'src/runtime-entry.ts'), 'utf8');
-    expect(source).toContain('Sole-Rust');
-    expect(source).toContain('TypeScript production runtime has been removed');
-    expect(source).not.toContain("join(here, 'index.js')");
-    expect(source).not.toContain('// TypeScript fallback path');
-    expect(source).not.toContain('Falls back to the TypeScript');
-    expect(source).not.toContain("process.env['CITRA_RUST_BIN']");
-    expect(source).toContain('nativeVersion !== packageVersion');
-  });
-
   it('parity bridge is deleted', () => {
     expect(
       existsSync(path.join(repoRoot, 'crates/pdf-reader-mcp-server/src/parity_bridge.rs'))


### PR DESCRIPTION
## What changed\n- remove the test that read src/runtime-entry.ts and asserted marker/fallback strings\n- keep package export, parity bridge absence, and capability-matrix artifact contracts; shipped production-path tests remain the behavior oracle\n\n## Verification\n- bun test test/tsAdapterDeletion.matrix.test.ts (3 pass)