### PR TITLE
build: pin TypeScript toolchain to Bun 1.4.0

### DIFF
--- a/.github/workflows/candidate-host-runtime-proof.yml
+++ b/.github/workflows/candidate-host-runtime-proof.yml
@@ -61,8 +61,9 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
+      # Node is the npm CLI / customer installer host, not the company TypeScript toolchain.
       - uses: actions/setup-node@v7
         with:
           node-version: '22'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
 
       - name: Install dependencies
         run: |
@@ -146,7 +146,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/deprecate-transitional-npm.yml
+++ b/.github/workflows/deprecate-transitional-npm.yml
@@ -19,6 +19,7 @@ jobs:
     if: ${{ inputs.confirm == 'DEPRECATE_PDF_READER_MCP' }}
     runs-on: sylphx-linux-standard
     steps:
+      # Node is the npm CLI / customer installer host, not the company TypeScript toolchain.
       - uses: actions/setup-node@v7
         with:
           node-version: '22'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.12'
+          bun-version: '1.4.0'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/native-package-scaffold.yml
+++ b/.github/workflows/native-package-scaffold.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
       - id: set
         run: |
           # Product CI: all platforms Sylphx self-hosted only (no GitHub-hosted runners).
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install bun (for optional differential oracle tests)
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.4.0
 
       - name: Enforce crates non-product-channel gate
         run: |

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.12'
+          bun-version: '1.4.0'
 
       - name: Enforce verified-candidate admission
         run: bun scripts/check-verified-candidate-admission.ts --require-exact-head

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -46,7 +46,7 @@ jobs:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -128,9 +128,10 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - name: Setup Node
+        # Node is the npm CLI / customer installer host, not the company TypeScript toolchain.
         uses: actions/setup-node@v7
         with:
           node-version: '22'

--- a/.github/workflows/registry-install-proof.yml
+++ b/.github/workflows/registry-install-proof.yml
@@ -24,7 +24,8 @@ jobs:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.4.0"
+      # Node is the npm CLI / customer installer host, not the company TypeScript toolchain.
       - uses: actions/setup-node@v7
         with:
           node-version: "22"
@@ -53,7 +54,8 @@ jobs:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.4.0"
+      # Node is the npm CLI / customer installer host, not the company TypeScript toolchain.
       - uses: actions/setup-node@v7
         with:
           node-version: "22"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.12'
+          bun-version: '1.4.0'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/rust-parity-differential.yml
+++ b/.github/workflows/rust-parity-differential.yml
@@ -85,6 +85,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.4.0
 
       - name: Install jq
         run: sudo apt-get update -qq && sudo apt-get install -y -qq jq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,7 @@ This project uses [Bun](https://bun.sh/) and [Biome](https://biomejs.dev/).
 
 ### Prerequisites
 
-- Node.js >= 22.13.0
-- Bun >= 1.3.12
+- Bun >= 1.4.0 (`packageManager` `bun@1.4.0`; install frozen from `bun.lock`)
 
 ### Getting Started
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=22.13.0"
+    "bun": ">=1.4.0"
   },
   "repository": {
     "type": "git",
@@ -84,7 +84,7 @@
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
-    "start": "node dist/runtime-entry.js",
+    "start": "bun dist/runtime-entry.js",
     "typecheck": "tsc --noEmit",
     "benchmark": "bun scripts/benchmark-pdf-intelligence.ts",
     "benchmark:quality": "bun scripts/benchmark-pdf-quality.ts",
@@ -278,7 +278,7 @@
     "pngjs": "^7.0.0",
     "zod": "^4.4.3"
   },
-  "packageManager": "bun@1.3.14",
+  "packageManager": "bun@1.4.0",
   "optionalDependencies": {
     "@sylphx/citra-darwin-arm64": "5.0.0",
     "@sylphx/citra-darwin-x64": "5.0.0",


### PR DESCRIPTION
## Identity bind

- **identity:** Citra TypeScript lockfile / `@sylphx/citra` toolchain (`package.json` + `bun.lock` + workflow `bun-version` pins)
- **fate:** `live` (source candidate for the unmet TypeScript toolchain floor)
- **destination revision:** `origin/main` of `SylphxAI/pdf-reader-mcp` (`d41670fbf789c8ac510e35d3ec653be782a23966`)
- **writer:** `SylphxAI/pdf-reader-mcp` (this lockfile only)
- **layer:** `source`
- **write/effect:** Pin this repository's TypeScript lockfile to Bun 1.4.0. `packageManager` `bun@1.4.0`; `engines.bun` `>=1.4.0`; frozen integrity-bearing `bun.lock`; every company-TS `bun-version` exact `1.4.0` never `latest`; Node is not the TypeScript runtime.
- **oracle:** `packageManager` is `bun@1.4.0`; `engines.bun` is `>=1.4.0`; root `engines.node` is not the TS runtime pin; `bun.lock` is install authority (`bun install --frozen-lockfile`); every workflow `bun-version` that installs the company TS toolchain is exact `1.4.0` not `latest`; native/npm publish workflows still function; no product-feature edits.
- **recovery path:** this PR. Independent Worker judges. This Worker does not merge.

## What changed

- Root `package.json`: `packageManager` `bun@1.4.0`; `engines.bun` `>=1.4.0`; removed `engines.node` as the TypeScript runtime pin; `start` is `bun dist/runtime-entry.js`.
- Existing `bun.lock` remains install authority; frozen install on Bun 1.4.0 succeeded with no lock rewrite.
- Workflows: every `oven-sh/setup-bun` `bun-version` is exact `1.4.0`, including `publish-crates.yml` (was `latest`) and `rust-parity-differential.yml` (was unpinned).
- `CONTRIBUTING.md` prerequisites now name Bun 1.4.0 + frozen `bun.lock`, not Node as the TS toolchain.

## What did not change

- Native optional packages keep `engines.node` `>=18` as the *customer installer host* for npm-fetched Rust binaries.
- Published `src/runtime-entry.ts` shebang remains `#!/usr/bin/env node` (npm bin / native launcher path).
- `setup-node` remains on npm publish, registry-install-proof, candidate-host-runtime-proof, and transitional npm-deprecate jobs as npm CLI / customer installer host, **not** the company TypeScript toolchain (commented in-workflow).
- No Rust crate, dest/docs vision, MCP schema, or product-feature edits.

## Triggered floors

```text
Outcome: Citra TypeScript lockfile and CI toolchain are Bun 1.4.0
Applicable clause: standards/PRINCIPLES.md — 2. Correctness
Trigger: every write/effect
Product mapping: SylphxAI/pdf-reader-mcp package.json + bun.lock + .github/workflows bun-version pins
Oracle: bun --version is 1.4.0; bun install --frozen-lockfile succeeds; packageManager is bun@1.4.0; engines.bun is >=1.4.0; no workflow bun-version is latest or <1.4.0
Gap or exception: none
```

```text
Outcome: Company TypeScript toolchain is Bun 1.4 exact pin
Applicable clause: standards/stack.md — TypeScript toolchain
Trigger: this repository uses TypeScript/JavaScript (package.json, bun.lock, setup-bun jobs)
Product mapping: packageManager, engines.bun, bun.lock, workflow bun-version
Oracle: packageManager bun@1.4.0; engines.bun >=1.4.0; engines.node is not the TS runtime; bun.lock is the only install authority; every setup-bun bun-version is exact 1.4.0 not latest; changed TS paths run on Bun (start script)
Gap or exception: none for this lockfile. npm/Node remains customer installer host and npm-publish CLI only.
```

```text
Outcome: Clean environment resolves exact Bun 1.4.0 + frozen bun.lock
Applicable clause: standards/dx.md — Reproducibility and feedback
Trigger: TypeScript/JavaScript environment identity for this product
Product mapping: CONTRIBUTING.md prerequisites; packageManager; bun.lock; CI bun-version
Oracle: bun --version 1.4.0; bun install --frozen-lockfile; CONTRIBUTING does not present Node as the TS toolchain
Gap or exception: none
```

Official pin (company law `standards/stack.md`): exact current 1.4.x is **1.4.0** (npm dist-tag `latest`; GitHub `oven-sh/bun` release `bun-v1.4.0` published 2026-08-20).

Independent Worker must judge this SHA before land. This Worker does not merge.
