### PR TITLE
docs: add changeset for rmcp 3.1.2 MCP conformance fix

### DIFF
--- a/.changeset/rmcp-3-1-2-mcp-conformance.md
+++ b/.changeset/rmcp-3-1-2-mcp-conformance.md
@@ -1,0 +1,5 @@
+---
+"@sylphx/citra": patch
+---
+
+Upgrade rmcp to 3.1.2 and add MCP 2026-07-28 result envelope support (cacheScope, ttlMs, serverInfo _meta) for tools/list and tools/call.


### PR DESCRIPTION
Adds a changeset for the rmcp 3.1.2 upgrade and MCP 2026-07-28 conformance fix from #649.