### PR TITLE
fix: use bun instead of node for changesets version script

### DIFF
--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -7,7 +7,7 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$root"
 
 echo "[release-version] bump package versions from changesets"
-node node_modules/@changesets/cli/bin.js version
+bun node_modules/@changesets/cli/bin.js version
 
 echo "[release-version] sync native optional package manifests to root version"
 bun run native:sync-manifests


### PR DESCRIPTION
The release workflow only installs Bun (no Node), but release-version.sh calls node for the changesets CLI. Switch to bun which can run the same script.