### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/bind-citra-delivery.md
+++ b/.changeset/bind-citra-delivery.md
@@ -1,7 +1,0 @@
----
-"@sylphx/citra": patch
----
-
-Bind the production launcher to the matching native package version and prove
-the installed launcher, upgrade, and uninstall customer paths before release
-closeout.

--- a/.changeset/contain-cff-custom-encoding.md
+++ b/.changeset/contain-cff-custom-encoding.md
@@ -1,7 +1,0 @@
----
-"@sylphx/citra": patch
----
-
-Contain malformed CFF Custom-encoding failures in PDF text extraction so a
-malicious or damaged Type1C font returns a structured extraction error instead
-of aborting the native server.

--- a/.changeset/rmcp-3-1-2-mcp-conformance.md
+++ b/.changeset/rmcp-3-1-2-mcp-conformance.md
@@ -1,5 +1,0 @@
----
-"@sylphx/citra": patch
----
-
-Upgrade rmcp to 3.1.2 and add MCP 2026-07-28 result envelope support (cacheScope, ttlMs, serverInfo _meta) for tools/list and tools/call.

--- a/.changeset/secure-citra-parser.md
+++ b/.changeset/secure-citra-parser.md
@@ -1,7 +1,0 @@
----
-"@sylphx/citra": patch
----
-
-Enforce the documented native filesystem allowlist for every PDF tool, update
-the PDF parser dependency chain past RUSTSEC-2026-0187, and retire the unbound
-Docker publication path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 5.0.1
+
+### Patch Changes
+
+- [#644](https://github.com/SylphxAI/pdf-reader-mcp/pull/644) [`3324cf8`](https://github.com/SylphxAI/pdf-reader-mcp/commit/3324cf8a31c57754b1ae9b743f6067a1e3e77742) Thanks [@shtse8](https://github.com/shtse8)! - Bind the production launcher to the matching native package version and prove
+  the installed launcher, upgrade, and uninstall customer paths before release
+  closeout.
+
+- [#665](https://github.com/SylphxAI/pdf-reader-mcp/pull/665) [`9409b5b`](https://github.com/SylphxAI/pdf-reader-mcp/commit/9409b5b190d506abb9a68ed26df7d046fc0de39e) Thanks [@shtse8](https://github.com/shtse8)! - Contain malformed CFF Custom-encoding failures in PDF text extraction so a
+  malicious or damaged Type1C font returns a structured extraction error instead
+  of aborting the native server.
+
+- [#666](https://github.com/SylphxAI/pdf-reader-mcp/pull/666) [`abe0702`](https://github.com/SylphxAI/pdf-reader-mcp/commit/abe070293e501370255005462f3e0a293a98cea0) Thanks [@shtse8](https://github.com/shtse8)! - Upgrade rmcp to 3.1.2 and add MCP 2026-07-28 result envelope support (cacheScope, ttlMs, serverInfo \_meta) for tools/list and tools/call.
+
+- [#643](https://github.com/SylphxAI/pdf-reader-mcp/pull/643) [`984d2f9`](https://github.com/SylphxAI/pdf-reader-mcp/commit/984d2f95965300493b893d20feafb9bb1c014541) Thanks [@shtse8](https://github.com/shtse8)! - Enforce the documented native filesystem allowlist for every PDF tool, update
+  the PDF parser dependency chain past RUSTSEC-2026-0187, and retire the unbound
+  Docker publication path.
+
 ## 5.0.0
 
 ### Breaking
@@ -8,7 +26,6 @@
 - Transitional `@sylphx/pdf-reader-mcp` is no longer the install CTA.
 - Family Evidence Envelope v1 adopted as wire law (skills schema).
 - Prism composition product retired; host routes media.
-
 
 ## 4.1.3
 

--- a/bun.lock
+++ b/bun.lock
@@ -19,11 +19,11 @@
         "zod": "^4.4.3",
       },
       "optionalDependencies": {
-        "@sylphx/citra-darwin-arm64": "5.0.0",
-        "@sylphx/citra-darwin-x64": "5.0.0",
-        "@sylphx/citra-linux-arm64-gnu": "5.0.0",
-        "@sylphx/citra-linux-x64-gnu": "5.0.0",
-        "@sylphx/citra-win32-x64-msvc": "5.0.0",
+        "@sylphx/citra-darwin-arm64": "5.0.1",
+        "@sylphx/citra-darwin-x64": "5.0.1",
+        "@sylphx/citra-linux-arm64-gnu": "5.0.1",
+        "@sylphx/citra-linux-x64-gnu": "5.0.1",
+        "@sylphx/citra-win32-x64-msvc": "5.0.1",
       },
     },
   },
@@ -421,16 +421,6 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
-    "@sylphx/citra-darwin-arm64": ["@sylphx/citra-darwin-arm64@5.0.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-112ZUfZQQRk60egLWRRkM3/we0fukFKTh7ZDd+r13MMNhZzf1TJaL1f4DZJpMiJKSOfkrHM2KQY++KFEq6UQWQ=="],
-
-    "@sylphx/citra-darwin-x64": ["@sylphx/citra-darwin-x64@5.0.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-vvhZZkbcgfDtTBXlUGjtkylQrrvroouVBsfx803HFEsKsU0+usL8VHpXFXex1yBtV6BmImNsN3sCZMN9Ew0V4A=="],
-
-    "@sylphx/citra-linux-arm64-gnu": ["@sylphx/citra-linux-arm64-gnu@5.0.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-WVrw310Qa+f+KBD7voeVpP2crrMgCLvKcIojwXvyTqW6nFvCeyXBy/V+axGAZrR8THNX3lTjzrA8r55Mvr+qHw=="],
-
-    "@sylphx/citra-linux-x64-gnu": ["@sylphx/citra-linux-x64-gnu@5.0.0", "", { "os": "linux", "cpu": "x64" }, "sha512-wDuOhHYy8dfJA/NghS84UMj2+pIFCMQQfUT97S0hsByNlwdj240Gm0dT9fjGl2Grfk6tywlm31XHghCiEv7+zw=="],
-
-    "@sylphx/citra-win32-x64-msvc": ["@sylphx/citra-win32-x64-msvc@5.0.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Hs+47LKUx+kFTYecXfRyj6AfpNoBe8BpDXvHo6x2E6JPrYGgEa1RZBRDfMI0EKy7UBzrNXRhVyw9/QMpqrc7Bg=="],
-
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -731,8 +721,6 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
-    "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
-
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
@@ -1028,8 +1016,6 @@
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
-
-    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "zlye": ["zlye@0.4.4", "", { "dependencies": { "picocolors": "^1.1.1" }, "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"] }, "sha512-fwpeC841X3ElOLYRMKXbwX29pitNrsm6nRNvEhDMrRXDl3BhR2i03Bkr0GNrpyYgZJuEzUsBylXAYzgGPXXOCQ=="],
 

--- a/crates/pdf-reader-mcp-server/src/lib.rs
+++ b/crates/pdf-reader-mcp-server/src/lib.rs
@@ -32,7 +32,7 @@ use serde_json::Value;
 
 pub const SERVER_NAME: &str = "citra";
 /// Pure-Rust MCP server version — tracks the published npm product line when default.
-pub const SERVER_VERSION: &str = "5.0.0";
+pub const SERVER_VERSION: &str = "5.0.1";
 pub const SERVER_INFO_META_KEY: &str = "io.modelcontextprotocol/serverInfo";
 pub const SERVER_INSTRUCTIONS: &str =
     "@sylphx/citra sole-Rust MCP server (platform native binary). \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/citra",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "mcpName": "io.github.SylphxAI/citra",
   "description": "Citra — PDF evidence for agents (Sylphx). Local-first structured text, tables, OCR, visual evidence, citations via MCP/CLI/SDK.",
   "type": "module",
@@ -280,10 +280,10 @@
   },
   "packageManager": "bun@1.4.0",
   "optionalDependencies": {
-    "@sylphx/citra-darwin-arm64": "5.0.0",
-    "@sylphx/citra-darwin-x64": "5.0.0",
-    "@sylphx/citra-linux-arm64-gnu": "5.0.0",
-    "@sylphx/citra-linux-x64-gnu": "5.0.0",
-    "@sylphx/citra-win32-x64-msvc": "5.0.0"
+    "@sylphx/citra-darwin-arm64": "5.0.1",
+    "@sylphx/citra-darwin-x64": "5.0.1",
+    "@sylphx/citra-linux-arm64-gnu": "5.0.1",
+    "@sylphx/citra-linux-x64-gnu": "5.0.1",
+    "@sylphx/citra-win32-x64-msvc": "5.0.1"
   }
 }

--- a/packages/citra-darwin-arm64/package.json
+++ b/packages/citra-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/citra-darwin-arm64",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Optional pure-Rust MCP server binary for darwin-arm64. Installed as an optionalDependency of @sylphx/citra. Sole-Rust; fail-closed if missing.",
   "license": "MIT",
   "os": [

--- a/packages/citra-darwin-x64/package.json
+++ b/packages/citra-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/citra-darwin-x64",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Optional pure-Rust MCP server binary for darwin-x64. Installed as an optionalDependency of @sylphx/citra. Sole-Rust; fail-closed if missing.",
   "license": "MIT",
   "os": [

--- a/packages/citra-linux-arm64-gnu/package.json
+++ b/packages/citra-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/citra-linux-arm64-gnu",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Optional pure-Rust MCP server binary for linux-arm64-gnu. Installed as an optionalDependency of @sylphx/citra. Sole-Rust; fail-closed if missing.",
   "license": "MIT",
   "os": [

--- a/packages/citra-linux-x64-gnu/package.json
+++ b/packages/citra-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/citra-linux-x64-gnu",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Optional pure-Rust MCP server binary for linux-x64-gnu. Installed as an optionalDependency of @sylphx/citra. Sole-Rust; fail-closed if missing.",
   "license": "MIT",
   "os": [

--- a/packages/citra-win32-x64-msvc/package.json
+++ b/packages/citra-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylphx/citra-win32-x64-msvc",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Optional pure-Rust MCP server binary for win32-x64-msvc. Installed as an optionalDependency of @sylphx/citra. Sole-Rust; fail-closed if missing.",
   "license": "MIT",
   "os": [

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/SylphxAI/pdf-reader-mcp",
     "source": "github"
   },
-  "version": "5.0.0",
+  "version": "5.0.1",
   "websiteUrl": "https://sylphxai.github.io/pdf-reader-mcp/",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@sylphx/citra",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Version 5.0.1

### Changes
- MCP 2026-07-28 conformance fix (rmcp 3.1.2 upgrade + envelope support) — fixes #662, #663
- CFF Custom-encoding panic containment — fixes #660
- Security parser dependency updates

This PR was created manually because the release workflow was blocked by self-hosted runner capacity.