### PR TITLE
docs: remove public ADR cites from PROJECT entry

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -49,7 +49,7 @@ are non-authoritative (oracle/history only).
 
 It does not own hosted customer accounts, billing, storage, tenant policy,
 Gateway routing, product audit, or durable state created after a tool is used.
-Hosted document intelligence must be a separate service with its own ADR/spec
+Hosted document intelligence must be a separate service with its own spec
 and commercial controls.
 
 ## Public Surfaces
@@ -57,7 +57,6 @@ and commercial controls.
 - MCP package and CLI: `package.json` → `dist/runtime-entry.js` (native only)
 - Rust core / server: `crates/pdf-reader-core`, `crates/pdf-reader-mcp-server`
 - Public docs: `README.md`, `docs/`
-- Boundary ADR: `docs/adr/0001-2027-sota-document-intelligence-boundary.md`
 - Tool/spec docs: `docs/specs/`
 - CI: `.github/workflows/ci.yml`
 - Release: Changesets + `.github/workflows/release.yml`
@@ -75,7 +74,7 @@ Windows natives remain on `windows-latest` until a self-hosted Windows pool exis
 Package release is Changesets-driven through the repo release workflow, which
 mints a GitHub App token before creating version PRs or publishing to npm.
 
-Control Plane ADR-0014 retired in-repository GroundAtlas package dogfood.
+A past Control Plane decision retired in-repository GroundAtlas package dogfood.
 Doctrine adapters and Mission Control are retired historical lineage and must
 not be restored as machine truth. Release and adoption claims must be verified
 against source, CI, published registries, and clean consumer installs.


### PR DESCRIPTION
Peel public-facing ADR cites from PROJECT.md entry (Boundaries prose, Public Surfaces index row, Delivery lineage note). ADR files stay in docs/adr history + git history; entry surfaces stay rationale-current per owner standards/docs.md. Docs-only, no runtime change.